### PR TITLE
[codex] Fix search/query robustness and transactional write paths

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/server/src/index.js"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.64",

--- a/server/package.json
+++ b/server/package.json
@@ -34,7 +34,7 @@
   ],
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc",
+    "build": "tsc && node scripts/copy-seed-data.mjs",
     "start": "node dist/server/src/index.js"
   },
   "dependencies": {

--- a/server/scripts/copy-seed-data.mjs
+++ b/server/scripts/copy-seed-data.mjs
@@ -1,0 +1,12 @@
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const sourcePath = resolve(import.meta.dirname, '../src/data/seed-notes.json');
+const targetPath = resolve(import.meta.dirname, '../dist/server/src/data/seed-notes.json');
+
+if (!existsSync(sourcePath)) {
+  process.exit(0);
+}
+
+mkdirSync(dirname(targetPath), { recursive: true });
+copyFileSync(sourcePath, targetPath);

--- a/server/src/db/transaction.test.ts
+++ b/server/src/db/transaction.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import initSqlJs from 'sql.js';
+import { withTransaction } from './transaction.js';
+
+async function createDatabase() {
+  const SQL = await initSqlJs({
+    locateFile: (file) =>
+      fileURLToPath(
+        new URL(`../../../node_modules/sql.js/dist/${file}`, import.meta.url),
+      ),
+  });
+
+  const db = new SQL.Database();
+  db.run('CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL)');
+  return db;
+}
+
+function getValues(db: Awaited<ReturnType<typeof createDatabase>>): string[] {
+  const result = db.exec('SELECT value FROM items ORDER BY id');
+  if (!result.length) {
+    return [];
+  }
+  return result[0].values.map((row) => String(row[0]));
+}
+
+test('withTransaction commits all changes on success', async () => {
+  const db = await createDatabase();
+
+  withTransaction(db, () => {
+    db.run('INSERT INTO items (value) VALUES (?)', ['first']);
+    db.run('INSERT INTO items (value) VALUES (?)', ['second']);
+  });
+
+  assert.deepEqual(getValues(db), ['first', 'second']);
+});
+
+test('withTransaction rolls back all changes on error', async () => {
+  const db = await createDatabase();
+
+  assert.throws(() => {
+    withTransaction(db, () => {
+      db.run('INSERT INTO items (value) VALUES (?)', ['first']);
+      throw new Error('boom');
+    });
+  }, /boom/);
+
+  assert.deepEqual(getValues(db), []);
+});
+
+test('nested rollback preserves outer transaction work', async () => {
+  const db = await createDatabase();
+
+  withTransaction(db, () => {
+    db.run('INSERT INTO items (value) VALUES (?)', ['outer-before']);
+
+    assert.throws(() => {
+      withTransaction(db, () => {
+        db.run('INSERT INTO items (value) VALUES (?)', ['inner-fail']);
+        throw new Error('inner boom');
+      });
+    }, /inner boom/);
+
+    db.run('INSERT INTO items (value) VALUES (?)', ['outer-after']);
+  });
+
+  assert.deepEqual(getValues(db), ['outer-before', 'outer-after']);
+});
+
+test('nested rollback can be followed by a second nested success', async () => {
+  const db = await createDatabase();
+
+  withTransaction(db, () => {
+    assert.throws(() => {
+      withTransaction(db, () => {
+        db.run('INSERT INTO items (value) VALUES (?)', ['inner-fail']);
+        throw new Error('inner boom');
+      });
+    }, /inner boom/);
+
+    withTransaction(db, () => {
+      db.run('INSERT INTO items (value) VALUES (?)', ['inner-success']);
+    });
+  });
+
+  assert.deepEqual(getValues(db), ['inner-success']);
+});

--- a/server/src/db/transaction.ts
+++ b/server/src/db/transaction.ts
@@ -1,0 +1,52 @@
+import type { Database } from 'sql.js';
+
+const depthMap = new WeakMap<Database, number>();
+
+function setDepth(db: Database, depth: number): void {
+  if (depth === 0) {
+    depthMap.delete(db);
+    return;
+  }
+
+  depthMap.set(db, depth);
+}
+
+export function withTransaction<T>(db: Database, fn: () => T): T {
+  const depth = depthMap.get(db) ?? 0;
+  const isNested = depth > 0;
+  const savepointName = `sp_${depth}`;
+
+  if (isNested) {
+    db.run(`SAVEPOINT ${savepointName}`);
+  } else {
+    db.run('BEGIN');
+  }
+
+  setDepth(db, depth + 1);
+
+  try {
+    const result = fn();
+
+    if (isNested) {
+      db.run(`RELEASE ${savepointName}`);
+    } else {
+      db.run('COMMIT');
+    }
+
+    setDepth(db, depth);
+    return result;
+  } catch (error) {
+    try {
+      if (isNested) {
+        db.run(`ROLLBACK TO ${savepointName}`);
+        db.run(`RELEASE ${savepointName}`);
+      } else {
+        db.run('ROLLBACK');
+      }
+    } finally {
+      setDepth(db, depth);
+    }
+
+    throw error;
+  }
+}

--- a/server/src/queue/tracker.test.ts
+++ b/server/src/queue/tracker.test.ts
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { TaskTracker } from './tracker.js';
+
+test('isTaskActive is true only for queued and processing tasks', () => {
+  const tracker = new TaskTracker();
+  const queuedId = 'queued-task';
+  const processingId = 'processing-task';
+  const completedId = 'completed-task';
+  const failedId = 'failed-task';
+
+  tracker.add(queuedId, 'Queued task');
+  assert.equal(tracker.isTaskActive(queuedId), true);
+
+  tracker.add(processingId, 'Processing task');
+  tracker.start(processingId);
+  assert.equal(tracker.isTaskActive(processingId), true);
+
+  tracker.add(completedId, 'Completed task');
+  tracker.complete(completedId);
+  assert.equal(tracker.isTaskActive(completedId), false);
+
+  tracker.add(failedId, 'Failed task');
+  tracker.fail(failedId, 'boom');
+  assert.equal(tracker.isTaskActive(failedId), false);
+  assert.equal(tracker.isTaskActive('missing-task'), false);
+});

--- a/server/src/queue/tracker.ts
+++ b/server/src/queue/tracker.ts
@@ -16,7 +16,7 @@ export interface TaskSnapshot {
   tasks: TaskEntry[];
 }
 
-class TaskTracker {
+export class TaskTracker {
   private tasks = new Map<string, TaskEntry>();
   private resetTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -91,6 +91,11 @@ class TaskTracker {
     return [...this.tasks.values()].some(
       (t) => t.status === 'queued' || t.status === 'processing',
     );
+  }
+
+  isTaskActive(id: string): boolean {
+    const task = this.tasks.get(id);
+    return task?.status === 'queued' || task?.status === 'processing';
   }
 
   private scheduleResetIfIdle() {

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -2,7 +2,9 @@ import { generateText, embed } from "ai";
 import type { FastifyInstance } from "fastify";
 import { appConfig, updateConfig } from "../config.js";
 import { getDatabase, saveDatabase } from "../db/index.js";
+import { withTransaction } from "../db/transaction.js";
 import { taskTracker } from "../queue/index.js";
+import { clearEmbeddingIndex } from "../services/embedding.js";
 import { getLanguageModel } from "../services/llm.js";
 import { getProvider, listProviders } from "../services/providers.js";
 
@@ -89,15 +91,12 @@ export async function configRoutes(app: FastifyInstance) {
 
 			if (changed) {
 				const db = getDatabase();
-				db.run("DELETE FROM embeddings");
+				withTransaction(db, () => {
+					db.run("DELETE FROM embeddings");
+					db.run("UPDATE notes SET embedding_status = 'pending'");
+				});
 				saveDatabase();
-				// Clear vectra index
-				const { resolve } = await import("node:path");
-				const { rmSync, existsSync } = await import("node:fs");
-				const indexPath = resolve(appConfig.dataDir, "vectra-index");
-				if (existsSync(indexPath)) {
-					rmSync(indexPath, { recursive: true, force: true });
-				}
+				clearEmbeddingIndex();
 				console.log(
 					"[Config] Cleared embeddings and vectra index due to model change",
 				);

--- a/server/src/routes/notes.ts
+++ b/server/src/routes/notes.ts
@@ -253,26 +253,39 @@ export async function noteRoutes(app: FastifyInstance) {
     try {
       const results = await semanticSearch(q, Math.min(Number(limit), 50), expand === 'true');
 
-      // Enrich results with tags from DB
+      // Enrich results with tags from DB (batch query)
       const db = getDatabase();
-      const enriched = results.map((r) => {
+      const noteIds = results.map((result) => result.noteId);
+      const tagMap = new Map<number, string[]>();
+
+      if (noteIds.length > 0) {
+        const placeholders = noteIds.map(() => '?').join(',');
         const tagResult = db.exec(
-          `SELECT GROUP_CONCAT(t.name) as tags_csv
+          `SELECT nt.note_id, GROUP_CONCAT(t.name) as tags_csv
            FROM note_tags nt JOIN tags t ON t.id = nt.tag_id
-           WHERE nt.note_id = ?`,
-          [r.noteId],
+           WHERE nt.note_id IN (${placeholders})
+           GROUP BY nt.note_id`,
+          noteIds,
         );
-        const tagsCsv = tagResult[0]?.values[0]?.[0] as string | null;
-        return {
-          note_id: r.noteId,
-          conversation_id: r.conversationId,
-          title: r.title,
-          project_name: r.projectName,
-          score: Math.round(r.score * 1000) / 1000,
-          tags: tagsCsv ? tagsCsv.split(',') : [],
-          via_relation: r.viaRelation || null,
-        };
-      });
+
+        if (tagResult.length > 0) {
+          for (const row of tagResult[0].values) {
+            const noteId = Number(row[0]);
+            const tagsCsv = row[1] as string | null;
+            tagMap.set(noteId, tagsCsv ? tagsCsv.split(',') : []);
+          }
+        }
+      }
+
+      const enriched = results.map((result) => ({
+        note_id: result.noteId,
+        conversation_id: result.conversationId,
+        title: result.title,
+        project_name: result.projectName,
+        score: Math.round(result.score * 1000) / 1000,
+        tags: tagMap.get(result.noteId) ?? [],
+        via_relation: result.viaRelation || null,
+      }));
 
       return { success: true, data: enriched };
     } catch (err) {
@@ -300,7 +313,7 @@ export async function noteRoutes(app: FastifyInstance) {
     const db = getDatabase();
     const result = db.exec(
       `SELECT n.id FROM notes n
-       WHERE n.embedding_status IN ('pending', 'failed')`,
+       WHERE n.embedding_status IN ('pending', 'failed', 'syncing')`,
     );
     if (!result.length || !result[0].values.length) {
       return { success: true, data: { queued: 0 } };

--- a/server/src/routes/notes.ts
+++ b/server/src/routes/notes.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { getDatabase } from '../db/index.js';
 import { resultToObjects } from '../db/utils.js';
 import { triggerSummarize, getUnsummarizedIds } from '../services/summarize.js';
-import { enqueueWithRetry, getQueueStatus, cancelQueue } from '../queue/index.js';
+import { enqueueWithRetry, getQueueStatus, cancelQueue, taskTracker } from '../queue/index.js';
 import { generateEmbeddings, semanticSearch } from '../services/embedding.js';
 
 function hydrateNote(row: Record<string, unknown>): Record<string, unknown> {
@@ -320,12 +320,15 @@ export async function noteRoutes(app: FastifyInstance) {
     }
 
     const noteIds = result[0].values.map((r) => Number(r[0]));
-    for (const noteId of noteIds) {
-      enqueueWithRetry(`embed-${noteId}`, `Embedding #${noteId}`, () => generateEmbeddings(noteId)).catch((err) => {
+    const queueableIds = noteIds.filter((noteId) => !taskTracker.isTaskActive(`embed-${noteId}`));
+
+    for (const noteId of queueableIds) {
+      const taskId = `embed-${noteId}`;
+      enqueueWithRetry(taskId, `Embedding #${noteId}`, () => generateEmbeddings(noteId)).catch((err) => {
         console.error(`[Embedding] Error for note ${noteId}:`, err instanceof Error ? err.message : err);
       });
     }
 
-    return { success: true, data: { queued: noteIds.length, queue: getQueueStatus() } };
+    return { success: true, data: { queued: queueableIds.length, queue: getQueueStatus() } };
   });
 }

--- a/server/src/services/embedding.test.ts
+++ b/server/src/services/embedding.test.ts
@@ -1,0 +1,148 @@
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { LocalIndex } from 'vectra';
+import {
+  committedVectraIdsForNote,
+  currentVectraIdsCommitted,
+  materializeDirectSearchHits,
+} from './embedding.js';
+
+function createTempDir() {
+  return mkdtempSync(join(tmpdir(), 'chatcrystal-embedding-'));
+}
+
+test('committed vectra ids come from persisted index state, not staged updates', async () => {
+  const dir = createTempDir();
+  const index = new LocalIndex(join(dir, 'vectra-index'));
+
+  try {
+    await index.createIndex();
+
+    const committed = await index.insertItem({
+      vector: [1, 0, 0],
+      metadata: { noteId: 7, chunkIndex: 0, conversationId: 'conv-a', title: 'A', projectName: 'P' },
+    });
+
+    await index.beginUpdate();
+    const staged = await index.insertItem({
+      vector: [0, 1, 0],
+      metadata: { noteId: 7, chunkIndex: 1, conversationId: 'conv-a', title: 'A', projectName: 'P' },
+    });
+    await index.cancelUpdate();
+
+    const committedIds = await committedVectraIdsForNote(index, 7);
+
+    assert.deepEqual(committedIds, [committed.id]);
+    assert.equal(committedIds.includes(staged.id), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('currentVectraIdsCommitted distinguishes staged-only ids from committed ids', async () => {
+  const dir = createTempDir();
+  const index = new LocalIndex(join(dir, 'vectra-index'));
+
+  try {
+    await index.createIndex();
+
+    const committed = await index.insertItem({
+      vector: [1, 0, 0],
+      metadata: { noteId: 9, chunkIndex: 0, conversationId: 'conv-b', title: 'B', projectName: 'P' },
+    });
+
+    await index.beginUpdate();
+    const staged = await index.insertItem({
+      vector: [0, 1, 0],
+      metadata: { noteId: 9, chunkIndex: 1, conversationId: 'conv-b', title: 'B', projectName: 'P' },
+    });
+
+    assert.equal(await currentVectraIdsCommitted(index, [committed.id]), true);
+    assert.equal(await currentVectraIdsCommitted(index, [staged.id]), false);
+
+    await index.cancelUpdate();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('currentVectraIdsCommitted returns true only when every id is committed', async () => {
+  const dir = createTempDir();
+  const index = new LocalIndex(join(dir, 'vectra-index'));
+
+  try {
+    await index.createIndex();
+
+    const first = await index.insertItem({
+      vector: [1, 0, 0],
+      metadata: { noteId: 11, chunkIndex: 0, conversationId: 'conv-d', title: 'D', projectName: 'P' },
+    });
+    const second = await index.insertItem({
+      vector: [0, 1, 0],
+      metadata: { noteId: 11, chunkIndex: 1, conversationId: 'conv-d', title: 'D', projectName: 'P' },
+    });
+
+    assert.equal(await currentVectraIdsCommitted(index, [first.id, second.id]), true);
+    assert.equal(await currentVectraIdsCommitted(index, [first.id, 'missing-id']), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('semantic-search direct-hit materialization validates SQLite-backed chunks before deduping', async () => {
+  const db = {
+    exec(sql: string, params: unknown[]) {
+      if (sql.includes('FROM embeddings e')) {
+        if (params[1] === 0) {
+          return [{ values: [] }];
+        }
+        return [{ values: [['valid chunk text']] }];
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    },
+  };
+
+  const results = [
+    {
+      item: {
+        metadata: {
+          noteId: 21,
+          chunkIndex: 0,
+          conversationId: 'conv-c',
+          title: 'Title',
+          projectName: 'Project',
+        },
+      },
+      score: 0.99,
+    },
+    {
+      item: {
+        metadata: {
+          noteId: 21,
+          chunkIndex: 1,
+          conversationId: 'conv-c',
+          title: 'Title',
+          projectName: 'Project',
+        },
+      },
+      score: 0.75,
+    },
+  ];
+
+  const directResults = await materializeDirectSearchHits(db as never, results as never);
+
+  assert.deepEqual(directResults, [
+    {
+      noteId: 21,
+      conversationId: 'conv-c',
+      title: 'Title',
+      projectName: 'Project',
+      score: 0.75,
+      chunkText: 'valid chunk text',
+      viaRelation: undefined,
+    },
+  ]);
+});

--- a/server/src/services/embedding.test.ts
+++ b/server/src/services/embedding.test.ts
@@ -7,6 +7,7 @@ import { LocalIndex } from 'vectra';
 import {
   committedVectraIdsForNote,
   currentVectraIdsCommitted,
+  maybeFinalizeCommittedSyncingNote,
   materializeDirectSearchHits,
 } from './embedding.js';
 
@@ -87,6 +88,51 @@ test('currentVectraIdsCommitted returns true only when every id is committed', a
 
     assert.equal(await currentVectraIdsCommitted(index, [first.id, second.id]), true);
     assert.equal(await currentVectraIdsCommitted(index, [first.id, 'missing-id']), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('syncing note with committed ids can finalize without re-embedding', async () => {
+  const dir = createTempDir();
+  const index = new LocalIndex(join(dir, 'vectra-index'));
+  let updatedNoteId: number | null = null;
+  let saveCount = 0;
+
+  try {
+    await index.createIndex();
+
+    const first = await index.insertItem({
+      vector: [1, 0, 0],
+      metadata: { noteId: 15, chunkIndex: 0, conversationId: 'conv-e', title: 'E', projectName: 'P' },
+    });
+    const second = await index.insertItem({
+      vector: [0, 1, 0],
+      metadata: { noteId: 15, chunkIndex: 1, conversationId: 'conv-e', title: 'E', projectName: 'P' },
+    });
+
+    const finalized = await maybeFinalizeCommittedSyncingNote(
+      {
+        run(sql: string, params?: unknown[]) {
+          if (sql === "UPDATE notes SET embedding_status = 'done' WHERE id = ?") {
+            updatedNoteId = Number(params?.[0]);
+            return;
+          }
+          throw new Error(`Unexpected SQL: ${sql}`);
+        },
+      } as never,
+      index,
+      15,
+      'syncing',
+      [first.id, second.id],
+      () => {
+        saveCount += 1;
+      },
+    );
+
+    assert.equal(finalized, true);
+    assert.equal(updatedNoteId, 15);
+    assert.equal(saveCount, 1);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/server/src/services/embedding.ts
+++ b/server/src/services/embedding.ts
@@ -84,6 +84,83 @@ type NoteChunkMeta = Record<string, string | number> & {
   projectName: string;
 };
 
+type SemanticSearchHit = {
+  item: {
+    metadata: NoteChunkMeta;
+  };
+  score: number;
+};
+
+type DirectSearchHit = {
+  noteId: number;
+  conversationId: string;
+  title: string;
+  projectName: string;
+  score: number;
+  chunkText: string;
+  viaRelation?: string;
+};
+
+type DatabaseLike = ReturnType<typeof getDatabase>;
+
+export async function committedVectraIdsForNote(index: LocalIndex, noteId: number): Promise<string[]> {
+  const items = await index.listItemsByMetadata({ noteId });
+  return items.map((item) => item.id);
+}
+
+export async function currentVectraIdsCommitted(index: LocalIndex, vectraIds: string[]): Promise<boolean> {
+  if (vectraIds.length === 0) {
+    return false;
+  }
+
+  for (const vectraId of vectraIds) {
+    if (!(await index.getItem(vectraId))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export async function materializeDirectSearchHits(
+  db: Pick<DatabaseLike, 'exec'>,
+  results: SemanticSearchHit[],
+): Promise<DirectSearchHit[]> {
+  const materialized: DirectSearchHit[] = [];
+
+  for (const result of results) {
+    const chunkResult = db.exec(
+      `SELECT e.chunk_text
+       FROM embeddings e
+       JOIN notes n ON n.id = e.note_id
+       WHERE e.note_id = ? AND e.chunk_index = ? AND n.embedding_status = 'done'`,
+      [result.item.metadata.noteId, result.item.metadata.chunkIndex],
+    );
+    if (!chunkResult.length || !chunkResult[0].values.length) {
+      continue;
+    }
+
+    materialized.push({
+      noteId: result.item.metadata.noteId,
+      conversationId: result.item.metadata.conversationId,
+      title: result.item.metadata.title,
+      projectName: result.item.metadata.projectName,
+      score: result.score,
+      chunkText: String(chunkResult[0].values[0][0]),
+      viaRelation: undefined,
+    });
+  }
+
+  const seen = new Map<number, DirectSearchHit>();
+  for (const result of materialized) {
+    if (!seen.has(result.noteId) || seen.get(result.noteId)!.score < result.score) {
+      seen.set(result.noteId, result);
+    }
+  }
+
+  return Array.from(seen.values());
+}
+
 /**
  * Generate embeddings for a note and store in vectra index + DB.
  */
@@ -161,12 +238,25 @@ export async function generateEmbeddings(noteId: number): Promise<number> {
     'SELECT vectra_id FROM embeddings WHERE note_id = ?',
     [noteId],
   );
-  const index = await getIndex();
-  const oldVectraIds = existingResult.length > 0
+  const currentDbVectraIds = existingResult.length > 0
     ? existingResult[0].values
       .map((row) => row[0] as string | null)
       .filter((vectraId): vectraId is string => Boolean(vectraId))
     : [];
+  const noteStatusResult = db.exec(
+    'SELECT embedding_status FROM notes WHERE id = ?',
+    [noteId],
+  );
+  const noteStatus = String(noteStatusResult[0]?.values[0]?.[0] ?? 'pending');
+  const index = await getIndex();
+
+  if (noteStatus === 'syncing' && await currentVectraIdsCommitted(index, currentDbVectraIds)) {
+    db.run("UPDATE notes SET embedding_status = 'done' WHERE id = ?", [noteId]);
+    saveDatabase();
+    return chunks.length;
+  }
+
+  const oldVectraIds = await committedVectraIdsForNote(index, noteId);
 
   let updateOpen = false;
   let dbSwapped = false;
@@ -260,37 +350,8 @@ export async function semanticSearch(
   const results = await index.queryItems<NoteChunkMeta>(embedding, query, topK);
 
   // Deduplicate by noteId, keeping highest score
-  const seen = new Map<number, (typeof results)[0]>();
-  for (const r of results) {
-    const noteId = r.item.metadata.noteId;
-    if (!seen.has(noteId) || seen.get(noteId)!.score < r.score) {
-      seen.set(noteId, r);
-    }
-  }
-
   const db = getDatabase();
-  const directResults = Array.from(seen.values()).flatMap((result) => {
-    const chunkResult = db.exec(
-      `SELECT e.chunk_text
-       FROM embeddings e
-       JOIN notes n ON n.id = e.note_id
-       WHERE e.note_id = ? AND e.chunk_index = ? AND n.embedding_status = 'done'`,
-      [result.item.metadata.noteId, result.item.metadata.chunkIndex],
-    );
-    if (!chunkResult.length || !chunkResult[0].values.length) {
-      return [];
-    }
-
-    return [{
-      noteId: result.item.metadata.noteId,
-      conversationId: result.item.metadata.conversationId,
-      title: result.item.metadata.title,
-      projectName: result.item.metadata.projectName,
-      score: result.score,
-      chunkText: String(chunkResult[0].values[0][0]),
-      viaRelation: undefined as string | undefined,
-    }];
-  });
+  const directResults = await materializeDirectSearchHits(db, results);
 
   if (!expandRelations || directResults.length === 0) {
     return directResults;

--- a/server/src/services/embedding.ts
+++ b/server/src/services/embedding.ts
@@ -1,7 +1,9 @@
 import { embed } from 'ai';
 import { LocalIndex } from 'vectra';
+import { existsSync, rmSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { getDatabase, saveDatabase } from '../db/index.js';
+import { withTransaction } from '../db/transaction.js';
 import { resultToObjects } from '../db/utils.js';
 import { appConfig } from '../config.js';
 import { getProvider } from './providers.js';
@@ -34,6 +36,13 @@ async function getIndex(): Promise<LocalIndex> {
     await _index.createIndex();
   }
   return _index;
+}
+
+export function clearEmbeddingIndex(): void {
+  _index = null;
+  if (existsSync(INDEX_PATH)) {
+    rmSync(INDEX_PATH, { recursive: true, force: true });
+  }
 }
 
 // =============================================
@@ -132,52 +141,102 @@ export async function generateEmbeddings(noteId: number): Promise<number> {
   // Chunk the text
   const chunks = chunkText(fullText);
 
-  // Delete existing embeddings for this note
+  const embeddings = chunks.map((chunkText, chunkIndex) => ({
+    chunkIndex,
+    chunkText,
+  }));
+
+  const model = getEmbeddingModel();
+  const vectors: { chunkIndex: number; chunkText: string; vector: number[] }[] = [];
+  for (const chunk of embeddings) {
+    const { embedding } = await embed({ model, value: chunk.chunkText });
+    vectors.push({
+      chunkIndex: chunk.chunkIndex,
+      chunkText: chunk.chunkText,
+      vector: embedding,
+    });
+  }
+
   const existingResult = db.exec(
     'SELECT vectra_id FROM embeddings WHERE note_id = ?',
     [noteId],
   );
-  if (existingResult.length > 0) {
-    const index = await getIndex();
-    for (const row of existingResult[0].values) {
-      const vectraId = row[0] as string;
-      if (vectraId) {
-        try { await index.deleteItem(vectraId); } catch { /* ignore */ }
+  const index = await getIndex();
+  const oldVectraIds = existingResult.length > 0
+    ? existingResult[0].values
+      .map((row) => row[0] as string | null)
+      .filter((vectraId): vectraId is string => Boolean(vectraId))
+    : [];
+
+  let updateOpen = false;
+  let dbSwapped = false;
+
+  try {
+    await index.beginUpdate();
+    updateOpen = true;
+
+    const newItems: { chunkIndex: number; chunkText: string; vectraId: string }[] = [];
+    for (const chunk of vectors) {
+      const item = await index.insertItem({
+        vector: chunk.vector,
+        metadata: {
+          noteId: id,
+          chunkIndex: chunk.chunkIndex,
+          conversationId,
+          title,
+          projectName,
+        } as NoteChunkMeta,
+      });
+
+      newItems.push({
+        chunkIndex: chunk.chunkIndex,
+        chunkText: chunk.chunkText,
+        vectraId: item.id,
+      });
+    }
+
+    withTransaction(db, () => {
+      db.run('DELETE FROM embeddings WHERE note_id = ?', [noteId]);
+
+      for (const item of newItems) {
+        db.run(
+          `INSERT INTO embeddings (note_id, chunk_index, chunk_text, vectra_id)
+           VALUES (?, ?, ?, ?)`,
+          [noteId, item.chunkIndex, item.chunkText, item.vectraId],
+        );
+      }
+
+      db.run("UPDATE notes SET embedding_status = 'syncing' WHERE id = ?", [noteId]);
+    });
+    dbSwapped = true;
+    saveDatabase();
+
+    for (const vectraId of oldVectraIds) {
+      await index.deleteItem(vectraId);
+    }
+
+    await index.endUpdate();
+    updateOpen = false;
+
+    db.run("UPDATE notes SET embedding_status = 'done' WHERE id = ?", [noteId]);
+    saveDatabase();
+    return chunks.length;
+  } catch (error) {
+    if (updateOpen) {
+      try {
+        index.cancelUpdate();
+      } catch {
+        // Ignore cancel failures and prefer surfacing the original error.
       }
     }
-    db.run('DELETE FROM embeddings WHERE note_id = ?', [noteId]);
+
+    if (dbSwapped) {
+      db.run("UPDATE notes SET embedding_status = 'failed' WHERE id = ?", [noteId]);
+      saveDatabase();
+    }
+
+    throw error;
   }
-
-  const index = await getIndex();
-  const model = getEmbeddingModel();
-
-  // Generate embeddings and insert
-  for (let i = 0; i < chunks.length; i++) {
-    const { embedding } = await embed({ model, value: chunks[i] });
-
-    const item = await index.insertItem({
-      vector: embedding,
-      metadata: {
-        noteId: id,
-        chunkIndex: i,
-        conversationId,
-        title,
-        projectName,
-      } as NoteChunkMeta,
-    });
-
-    db.run(
-      `INSERT INTO embeddings (note_id, chunk_index, chunk_text, vectra_id)
-       VALUES (?, ?, ?, ?)`,
-      [noteId, i, chunks[i], item.id],
-    );
-  }
-
-  // Mark embedding as done
-  db.run("UPDATE notes SET embedding_status = 'done' WHERE id = ?", [noteId]);
-
-  saveDatabase();
-  return chunks.length;
 }
 
 /**
@@ -210,22 +269,27 @@ export async function semanticSearch(
   }
 
   const db = getDatabase();
-  const directResults = Array.from(seen.values()).map((r) => {
+  const directResults = Array.from(seen.values()).flatMap((result) => {
     const chunkResult = db.exec(
-      'SELECT chunk_text FROM embeddings WHERE note_id = ? AND chunk_index = ?',
-      [r.item.metadata.noteId, r.item.metadata.chunkIndex],
+      `SELECT e.chunk_text
+       FROM embeddings e
+       JOIN notes n ON n.id = e.note_id
+       WHERE e.note_id = ? AND e.chunk_index = ? AND n.embedding_status = 'done'`,
+      [result.item.metadata.noteId, result.item.metadata.chunkIndex],
     );
-    const chunkText = (chunkResult[0]?.values[0]?.[0] as string) || '';
+    if (!chunkResult.length || !chunkResult[0].values.length) {
+      return [];
+    }
 
-    return {
-      noteId: r.item.metadata.noteId,
-      conversationId: r.item.metadata.conversationId,
-      title: r.item.metadata.title,
-      projectName: r.item.metadata.projectName,
-      score: r.score,
-      chunkText,
+    return [{
+      noteId: result.item.metadata.noteId,
+      conversationId: result.item.metadata.conversationId,
+      title: result.item.metadata.title,
+      projectName: result.item.metadata.projectName,
+      score: result.score,
+      chunkText: String(chunkResult[0].values[0][0]),
       viaRelation: undefined as string | undefined,
-    };
+    }];
   });
 
   if (!expandRelations || directResults.length === 0) {
@@ -254,7 +318,7 @@ export async function semanticSearch(
       const noteInfo = db.exec(
         `SELECT n.id, n.conversation_id, n.title, c.project_name
          FROM notes n JOIN conversations c ON c.id = n.conversation_id
-         WHERE n.id = ?`,
+         WHERE n.id = ? AND n.embedding_status = 'done'`,
         [linkedId],
       );
       if (!noteInfo.length || !noteInfo[0].values.length) continue;

--- a/server/src/services/embedding.ts
+++ b/server/src/services/embedding.ts
@@ -102,6 +102,7 @@ type DirectSearchHit = {
 };
 
 type DatabaseLike = ReturnType<typeof getDatabase>;
+type DatabaseRunner = Pick<DatabaseLike, 'run'>;
 
 export async function committedVectraIdsForNote(index: LocalIndex, noteId: number): Promise<string[]> {
   const items = await index.listItemsByMetadata({ noteId });
@@ -119,6 +120,27 @@ export async function currentVectraIdsCommitted(index: LocalIndex, vectraIds: st
     }
   }
 
+  return true;
+}
+
+export async function maybeFinalizeCommittedSyncingNote(
+  db: DatabaseRunner,
+  index: LocalIndex,
+  noteId: number,
+  noteStatus: string,
+  currentDbVectraIds: string[],
+  save: () => void = saveDatabase,
+): Promise<boolean> {
+  if (noteStatus !== 'syncing') {
+    return false;
+  }
+
+  if (!(await currentVectraIdsCommitted(index, currentDbVectraIds))) {
+    return false;
+  }
+
+  db.run("UPDATE notes SET embedding_status = 'done' WHERE id = ?", [noteId]);
+  save();
   return true;
 }
 
@@ -223,17 +245,6 @@ export async function generateEmbeddings(noteId: number): Promise<number> {
     chunkText,
   }));
 
-  const model = getEmbeddingModel();
-  const vectors: { chunkIndex: number; chunkText: string; vector: number[] }[] = [];
-  for (const chunk of embeddings) {
-    const { embedding } = await embed({ model, value: chunk.chunkText });
-    vectors.push({
-      chunkIndex: chunk.chunkIndex,
-      chunkText: chunk.chunkText,
-      vector: embedding,
-    });
-  }
-
   const existingResult = db.exec(
     'SELECT vectra_id FROM embeddings WHERE note_id = ?',
     [noteId],
@@ -250,10 +261,19 @@ export async function generateEmbeddings(noteId: number): Promise<number> {
   const noteStatus = String(noteStatusResult[0]?.values[0]?.[0] ?? 'pending');
   const index = await getIndex();
 
-  if (noteStatus === 'syncing' && await currentVectraIdsCommitted(index, currentDbVectraIds)) {
-    db.run("UPDATE notes SET embedding_status = 'done' WHERE id = ?", [noteId]);
-    saveDatabase();
+  if (await maybeFinalizeCommittedSyncingNote(db, index, noteId, noteStatus, currentDbVectraIds)) {
     return chunks.length;
+  }
+
+  const model = getEmbeddingModel();
+  const vectors: { chunkIndex: number; chunkText: string; vector: number[] }[] = [];
+  for (const chunk of embeddings) {
+    const { embedding } = await embed({ model, value: chunk.chunkText });
+    vectors.push({
+      chunkIndex: chunk.chunkIndex,
+      chunkText: chunk.chunkText,
+      vector: embedding,
+    });
   }
 
   const oldVectraIds = await committedVectraIdsForNote(index, noteId);

--- a/server/src/services/import.ts
+++ b/server/src/services/import.ts
@@ -1,6 +1,7 @@
 import type { ConversationMeta, ParsedConversation } from "@chatcrystal/shared";
 import { appConfig } from "../config.js";
 import { getDatabase, saveDatabase } from "../db/index.js";
+import { withTransaction } from "../db/transaction.js";
 import { getAdapter, getAllAdapters } from "../parser/index.js";
 
 export interface ImportProgress {
@@ -68,8 +69,6 @@ export async function importAll(
 					progress.skipped++;
 					continue;
 				}
-				// File changed — delete old data and re-import
-				db.run(`DELETE FROM conversations WHERE id = ?`, [meta.id]);
 			}
 
 			// Parse the conversation
@@ -87,19 +86,21 @@ export async function importAll(
 				continue;
 			}
 
-			// Insert conversation
-			insertConversation(db, parsed, meta);
+			withTransaction(db, () => {
+				if (existing.length > 0 && existing[0].values.length > 0) {
+					db.run(`DELETE FROM conversations WHERE id = ?`, [meta.id]);
+				}
 
-			// Insert messages
-			insertMessages(db, parsed);
+				insertConversation(db, parsed, meta);
+				insertMessages(db, parsed);
+
+				db.run(
+					`INSERT INTO import_log (file_path, status, message) VALUES (?, 'success', ?)`,
+					[meta.filePath, `Imported ${parsed.messages.length} messages`],
+				);
+			});
 
 			progress.imported++;
-
-			// Log import
-			db.run(
-				`INSERT INTO import_log (file_path, status, message) VALUES (?, 'success', ?)`,
-				[meta.filePath, `Imported ${parsed.messages.length} messages`],
-			);
 		} catch (err) {
 			progress.errors++;
 			const errorMsg = err instanceof Error ? err.message : "Unknown error";

--- a/server/src/services/relations.ts
+++ b/server/src/services/relations.ts
@@ -1,6 +1,7 @@
 import { generateObject } from 'ai';
 import { z } from 'zod';
 import { getDatabase, saveDatabase } from '../db/index.js';
+import { withTransaction } from '../db/transaction.js';
 import { resultToObjects } from '../db/utils.js';
 import { getLanguageModel } from './llm.js';
 import { semanticSearch } from './embedding.js';
@@ -157,38 +158,48 @@ ${candidateList}`;
   // Filter and persist
   const validRelations: NoteRelation[] = [];
   const candidateIdSet = new Set(candidates.map((c) => c.id));
+  const filteredRelations = rawRelations
+    .filter(
+      (rel) => candidateIdSet.has(rel.target_note_id) && rel.confidence >= MIN_CONFIDENCE,
+    )
+    .slice(0, MAX_RELATIONS);
 
-  for (const rel of rawRelations) {
-    if (!candidateIdSet.has(rel.target_note_id)) continue;
-    if (rel.confidence < MIN_CONFIDENCE) continue;
-    if (validRelations.length >= MAX_RELATIONS) break;
+  if (filteredRelations.length > 0) {
+    withTransaction(db, () => {
+      for (const relation of filteredRelations) {
+        db.run(
+          `INSERT OR IGNORE INTO note_relations
+            (source_note_id, target_note_id, relation_type, confidence, description, created_by)
+           VALUES (?, ?, ?, ?, ?, 'llm')`,
+          [
+            noteId,
+            relation.target_note_id,
+            relation.relation_type,
+            Math.round(relation.confidence * 100) / 100,
+            relation.description,
+          ],
+        );
 
-    // Insert into DB
-    try {
-      db.run(
-        `INSERT OR IGNORE INTO note_relations
-          (source_note_id, target_note_id, relation_type, confidence, description, created_by)
-         VALUES (?, ?, ?, ?, ?, 'llm')`,
-        [noteId, rel.target_note_id, rel.relation_type, Math.round(rel.confidence * 100) / 100, rel.description],
-      );
+        if (db.getRowsModified() === 0) {
+          continue;
+        }
 
-      validRelations.push({
-        id: 0,
-        source_note_id: noteId,
-        target_note_id: rel.target_note_id,
-        relation_type: rel.relation_type,
-        confidence: rel.confidence,
-        description: rel.description,
-        created_by: 'llm',
-        created_at: new Date().toISOString(),
-      });
-    } catch {
-      // UNIQUE constraint violation — relation already exists, skip
+        validRelations.push({
+          id: 0,
+          source_note_id: noteId,
+          target_note_id: relation.target_note_id,
+          relation_type: relation.relation_type,
+          confidence: relation.confidence,
+          description: relation.description,
+          created_by: 'llm',
+          created_at: new Date().toISOString(),
+        });
+      }
+    });
+
+    if (validRelations.length > 0) {
+      saveDatabase();
     }
-  }
-
-  if (validRelations.length > 0) {
-    saveDatabase();
   }
 
   console.log(`[Relations] Discovered ${validRelations.length} relations for note ${noteId}`);
@@ -229,35 +240,36 @@ export function createRelation(
   }
 
   const db = getDatabase();
+  const relation = withTransaction(db, () => {
+    const check = db.exec(
+      'SELECT COUNT(*) FROM notes WHERE id IN (?, ?)',
+      [sourceNoteId, targetNoteId],
+    );
+    if (Number(check[0]?.values[0]?.[0]) < 2) {
+      throw new Error('One or both notes not found');
+    }
 
-  // Verify both notes exist
-  const check = db.exec(
-    'SELECT COUNT(*) FROM notes WHERE id IN (?, ?)',
-    [sourceNoteId, targetNoteId],
-  );
-  if (Number(check[0]?.values[0]?.[0]) < 2) {
-    throw new Error('One or both notes not found');
-  }
+    db.run(
+      `INSERT INTO note_relations
+        (source_note_id, target_note_id, relation_type, confidence, description, created_by)
+       VALUES (?, ?, ?, 1.0, ?, 'manual')`,
+      [sourceNoteId, targetNoteId, relationType, description || null],
+    );
 
-  db.run(
-    `INSERT INTO note_relations
-      (source_note_id, target_note_id, relation_type, confidence, description, created_by)
-     VALUES (?, ?, ?, 1.0, ?, 'manual')`,
-    [sourceNoteId, targetNoteId, relationType, description || null],
-  );
+    const result = db.exec(
+      `SELECT r.*, sn.title as source_title, tn.title as target_title
+       FROM note_relations r
+       JOIN notes sn ON sn.id = r.source_note_id
+       JOIN notes tn ON tn.id = r.target_note_id
+       WHERE r.source_note_id = ? AND r.target_note_id = ? AND r.relation_type = ?`,
+      [sourceNoteId, targetNoteId, relationType],
+    );
+
+    return resultToObjects(result)[0] as unknown as NoteRelation;
+  });
 
   saveDatabase();
-
-  // Fetch the inserted relation
-  const result = db.exec(
-    `SELECT r.*, sn.title as source_title, tn.title as target_title
-     FROM note_relations r
-     JOIN notes sn ON sn.id = r.source_note_id
-     JOIN notes tn ON tn.id = r.target_note_id
-     WHERE r.source_note_id = ? AND r.target_note_id = ? AND r.relation_type = ?`,
-    [sourceNoteId, targetNoteId, relationType],
-  );
-  return resultToObjects(result)[0] as unknown as NoteRelation;
+  return relation;
 }
 
 /**

--- a/server/src/services/seed.ts
+++ b/server/src/services/seed.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { getDatabase, saveDatabase } from '../db/index.js';
+import { withTransaction } from '../db/transaction.js';
 
 interface SeedConversation {
   id: string;
@@ -49,91 +50,93 @@ export function seedDemoData(): void {
   try {
     const seedPath = join(import.meta.dirname, '../data/seed-notes.json');
     const seedData: SeedData = JSON.parse(readFileSync(seedPath, 'utf-8'));
-    db.run('BEGIN');
-
-    // Insert conversations
-    const convStmt = db.prepare(
-      `INSERT OR IGNORE INTO conversations (
-        id, slug, source, project_dir, project_name, cwd, git_branch,
-        message_count, first_message_at, last_message_at,
-        file_path, file_size, file_mtime, status
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    );
-    for (const conv of seedData.conversations) {
-      convStmt.run([
-        conv.id,
-        conv.slug,
-        conv.source,
-        conv.project_dir,
-        conv.project_name,
-        conv.cwd,
-        conv.git_branch,
-        conv.message_count,
-        conv.first_message_at,
-        conv.last_message_at,
-        conv.file_path,
-        conv.file_size,
-        conv.file_mtime,
-        conv.status,
-      ]);
-    }
-    convStmt.free();
-
-    // Insert tags (all unique tags used across notes)
-    const tagStmt = db.prepare(
-      `INSERT OR IGNORE INTO tags (name) VALUES (?)`,
-    );
-    for (const tag of seedData.tags) {
-      tagStmt.run([tag]);
-    }
-    tagStmt.free();
-
-    // Insert notes and note_tags
-    const noteStmt = db.prepare(
-      `INSERT INTO notes (
-        conversation_id, title, summary, key_conclusions, code_snippets
-      ) VALUES (?, ?, ?, ?, ?)`,
-    );
-    for (const note of seedData.notes) {
-      noteStmt.run([
-        note.conversation_id,
-        note.title,
-        note.summary,
-        note.key_conclusions,
-        note.code_snippets,
-      ]);
-
-      // Retrieve the AUTOINCREMENT-assigned ID
-      const noteIdResult = db.exec(
-        `SELECT id FROM notes WHERE conversation_id = ?`,
-        [note.conversation_id],
+    withTransaction(db, () => {
+      const convStmt = db.prepare(
+        `INSERT OR IGNORE INTO conversations (
+          id, slug, source, project_dir, project_name, cwd, git_branch,
+          message_count, first_message_at, last_message_at,
+          file_path, file_size, file_mtime, status
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       );
-      const noteId = noteIdResult[0]?.values[0]?.[0];
+      try {
+        for (const conv of seedData.conversations) {
+          convStmt.run([
+            conv.id,
+            conv.slug,
+            conv.source,
+            conv.project_dir,
+            conv.project_name,
+            conv.cwd,
+            conv.git_branch,
+            conv.message_count,
+            conv.first_message_at,
+            conv.last_message_at,
+            conv.file_path,
+            conv.file_size,
+            conv.file_mtime,
+            conv.status,
+          ]);
+        }
+      } finally {
+        convStmt.free();
+      }
 
-      // Link tags to this note
-      if (noteId != null) {
-        for (const tagName of note.tags) {
-          const tagResult = db.exec(
-            `SELECT id FROM tags WHERE name = ?`,
-            [tagName],
+      const tagStmt = db.prepare(`INSERT OR IGNORE INTO tags (name) VALUES (?)`);
+      try {
+        for (const tag of seedData.tags) {
+          tagStmt.run([tag]);
+        }
+      } finally {
+        tagStmt.free();
+      }
+
+      const noteStmt = db.prepare(
+        `INSERT INTO notes (
+          conversation_id, title, summary, key_conclusions, code_snippets
+        ) VALUES (?, ?, ?, ?, ?)`,
+      );
+      try {
+        for (const note of seedData.notes) {
+          noteStmt.run([
+            note.conversation_id,
+            note.title,
+            note.summary,
+            note.key_conclusions,
+            note.code_snippets,
+          ]);
+
+          const noteIdResult = db.exec(
+            `SELECT id FROM notes WHERE conversation_id = ?`,
+            [note.conversation_id],
           );
-          const tagId = tagResult[0]?.values[0]?.[0];
-          if (tagId != null) {
-            db.run(
-              `INSERT OR IGNORE INTO note_tags (note_id, tag_id) VALUES (?, ?)`,
-              [noteId, tagId],
+          const noteId = noteIdResult[0]?.values[0]?.[0];
+
+          if (noteId == null) {
+            continue;
+          }
+
+          for (const tagName of note.tags) {
+            const tagResult = db.exec(
+              `SELECT id FROM tags WHERE name = ?`,
+              [tagName],
             );
+            const tagId = tagResult[0]?.values[0]?.[0];
+            if (tagId != null) {
+              db.run(
+                `INSERT OR IGNORE INTO note_tags (note_id, tag_id) VALUES (?, ?)`,
+                [noteId, tagId],
+              );
+            }
           }
         }
+      } finally {
+        noteStmt.free();
       }
-    }
-    noteStmt.free();
+    });
 
-    db.run('COMMIT');
     saveDatabase();
     console.log('[Seed] Demo data inserted successfully.');
   } catch (err) {
-    try { db.run('ROLLBACK'); } catch { /* ignore if no transaction active */ }
     console.error('[Seed] Failed to load demo data:', err);
   }
 }

--- a/server/src/services/summarize.ts
+++ b/server/src/services/summarize.ts
@@ -1,6 +1,7 @@
 import { generateObject } from 'ai';
 import { z } from 'zod';
 import { getDatabase, saveDatabase } from '../db/index.js';
+import { withTransaction } from '../db/transaction.js';
 import { getLanguageModel } from './llm.js';
 import { prepareTranscript } from './transcript.js';
 import { generateEmbeddings } from './embedding.js';
@@ -92,40 +93,41 @@ async function summarizeConversation(conversationId: string): Promise<SummarizeR
 function saveNote(conversationId: string, result: SummarizeResult): number {
   const db = getDatabase();
 
-  db.run(
-    `INSERT OR REPLACE INTO notes
-      (conversation_id, title, summary, key_conclusions, code_snippets, raw_llm_response, is_edited)
-     VALUES (?, ?, ?, ?, ?, ?, 0)`,
-    [
-      conversationId,
-      result.title,
-      result.summary,
-      JSON.stringify(result.key_conclusions),
-      JSON.stringify(result.code_snippets),
-      result.raw_response,
-    ],
-  );
+  const noteId = withTransaction(db, () => {
+    db.run(
+      `INSERT OR REPLACE INTO notes
+        (conversation_id, title, summary, key_conclusions, code_snippets, raw_llm_response, is_edited)
+       VALUES (?, ?, ?, ?, ?, ?, 0)`,
+      [
+        conversationId,
+        result.title,
+        result.summary,
+        JSON.stringify(result.key_conclusions),
+        JSON.stringify(result.code_snippets),
+        result.raw_response,
+      ],
+    );
 
-  // Get note ID
-  const noteResult = db.exec(
-    'SELECT id FROM notes WHERE conversation_id = ?',
-    [conversationId],
-  );
-  const noteId = Number(noteResult[0]?.values[0]?.[0]);
+    const noteResult = db.exec(
+      'SELECT id FROM notes WHERE conversation_id = ?',
+      [conversationId],
+    );
+    const nextNoteId = Number(noteResult[0]?.values[0]?.[0]);
 
-  // Upsert tags
-  for (const tagName of result.tags) {
-    db.run('INSERT OR IGNORE INTO tags (name) VALUES (?)', [tagName]);
-    const tagResult = db.exec('SELECT id FROM tags WHERE name = ?', [tagName]);
-    const tagId = Number(tagResult[0]?.values[0]?.[0]);
-    db.run('INSERT OR IGNORE INTO note_tags (note_id, tag_id) VALUES (?, ?)', [noteId, tagId]);
-  }
+    for (const tagName of result.tags) {
+      db.run('INSERT OR IGNORE INTO tags (name) VALUES (?)', [tagName]);
+      const tagResult = db.exec('SELECT id FROM tags WHERE name = ?', [tagName]);
+      const tagId = Number(tagResult[0]?.values[0]?.[0]);
+      db.run('INSERT OR IGNORE INTO note_tags (note_id, tag_id) VALUES (?, ?)', [nextNoteId, tagId]);
+    }
 
-  // Update conversation status
-  db.run(
-    `UPDATE conversations SET status = 'summarized', updated_at = datetime('now') WHERE id = ?`,
-    [conversationId],
-  );
+    db.run(
+      `UPDATE conversations SET status = 'summarized', updated_at = datetime('now') WHERE id = ?`,
+      [conversationId],
+    );
+
+    return nextNoteId;
+  });
 
   saveDatabase();
   return noteId;


### PR DESCRIPTION
## What changed

This PR fixes the search N+1 tag lookup, adds a tested SQLite transaction helper, and applies it across the multi-step write paths that were previously unprotected.

It also hardens the embedding pipeline so SQLite and Vectra no longer rely on a false assumption of cross-store atomicity. Notes only become searchable again after the Vectra update finishes and `embedding_status` returns to `done`.

Follow-up commits on top of that work also fix two older packaging/runtime issues discovered during verification:

- `npm run start -w server` now points at the real built entry.
- `seed-notes.json` is now copied into the built server output so first-run seed works from compiled artifacts.

## Why

The codebase had two classes of problems:

1. `/api/search` fetched tags with one query per result.
2. Several write flows performed multiple SQLite mutations without a transaction boundary, so partial state was possible on failure.

There was also a higher-risk issue in embeddings: SQLite and Vectra writes were interleaved as if they could commit atomically. They cannot. This PR changes that flow to a staged, repairable sync model.

While verifying the fixes, two older packaging/runtime defects surfaced. Those are now included as isolated follow-up commits on the same branch.

## User / developer impact

- Search avoids the per-result tag query overhead.
- Summarize/import/relation/seed paths now roll back cleanly on SQLite errors.
- Embedding rebuild failures now degrade to hidden-and-repairable instead of visible half-synced state.
- Batch embedding rebuild now also picks up `syncing` notes.
- Model-switch resets note embedding status back to `pending`.
- `npm run start -w server` works against the actual compiled entry.
- Built server artifacts can seed demo data on first run.

## Root cause

- Missing transaction abstraction for synchronous multi-step SQLite write paths.
- Incorrect nested transaction handling around SQLite savepoints.
- Cross-store write path treated SQLite and Vectra as if they shared one transaction model.
- Historical mismatch between `server` build output layout and the `start` script path.
- Seed JSON was introduced as a runtime dependency without a corresponding build copy step.

## Validation

- `node --import tsx --test server/src/db/transaction.test.ts`
- `npx tsc --noEmit --project server/tsconfig.json`
- `npm run build`
- Manual smoke against built server entry:
  - `GET /api/search?q=test&limit=5` -> 200
  - `POST /api/embeddings/batch` -> 200
- `npm run start -w server` reaches `/api/status` successfully after the entry-path fix.
- Fresh built server on empty DB seeds demo notes successfully after the asset-copy fix.