### PR TITLE
perf(client): lazy load pages and trim graph bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@
 - **Coverage for memory services and routes** — Added regression tests across schemas, project-key derivation, recall, writeback, backfill, origin creation, decision logic, and HTTP route behavior.
 - **Real HTTP + MCP smoke coverage** — Verified the full writeback/recall loop through a real Fastify process and MCP stdio server with a mock embedding backend.
 
+### Client Performance
+
+- **Route-level lazy loading** — Switched the main client routes to lazy-loaded page bundles with a shared suspense fallback so the initial app payload is smaller.
+- **Relation graph canvas split** — Moved the force-graph implementation into a lazily loaded `RelationGraphCanvas` component so the graph runtime is only loaded when the graph page is opened.
+- **Lighter markdown code blocks** — Replaced `react-syntax-highlighter` with native `<pre><code>` rendering and removed the related client dependencies from the bundle.
+
 ## [0.4.0] - 2026-04-10
 
 ### New Data Sources

--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,6 @@
     "react-i18next": "^17.0.2",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.2",
-    "react-syntax-highlighter": "^16.1.1",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2"
@@ -33,7 +32,6 @@
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,16 +1,19 @@
+import { Suspense, lazy, type ReactNode } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import { ThemeProvider } from '@/providers/ThemeProvider.tsx';
 import '@/i18n';
 import { Layout } from '@/components/Layout.tsx';
-import { Dashboard } from '@/pages/Dashboard.tsx';
-import { Conversations } from '@/pages/Conversations.tsx';
-import { ConversationDetail } from '@/pages/ConversationDetail.tsx';
-import { Notes } from '@/pages/Notes.tsx';
-import { NoteDetail } from '@/pages/NoteDetail.tsx';
-import { SearchPage } from '@/pages/SearchPage.tsx';
-import { SettingsPage } from '@/pages/SettingsPage.tsx';
-import { RelationGraph } from '@/pages/RelationGraph.tsx';
+
+const DashboardPage = lazy(() => import('@/pages/Dashboard.tsx').then((module) => ({ default: module.Dashboard })));
+const ConversationsPage = lazy(() => import('@/pages/Conversations.tsx').then((module) => ({ default: module.Conversations })));
+const ConversationDetailPage = lazy(() => import('@/pages/ConversationDetail.tsx').then((module) => ({ default: module.ConversationDetail })));
+const NotesPage = lazy(() => import('@/pages/Notes.tsx').then((module) => ({ default: module.Notes })));
+const NoteDetailPage = lazy(() => import('@/pages/NoteDetail.tsx').then((module) => ({ default: module.NoteDetail })));
+const SearchPage = lazy(() => import('@/pages/SearchPage.tsx').then((module) => ({ default: module.SearchPage })));
+const RelationGraphPage = lazy(() => import('@/pages/RelationGraph.tsx').then((module) => ({ default: module.RelationGraph })));
+const SettingsPage = lazy(() => import('@/pages/SettingsPage.tsx').then((module) => ({ default: module.SettingsPage })));
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -21,6 +24,15 @@ const queryClient = new QueryClient({
   },
 });
 
+function RouteSuspense({ children }: { children: ReactNode }) {
+  const { t } = useTranslation();
+  return (
+    <Suspense fallback={<div className="p-6 text-muted">{t('status.loading')}</div>}>
+      {children}
+    </Suspense>
+  );
+}
+
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
@@ -28,14 +40,14 @@ export default function App() {
         <BrowserRouter>
           <Routes>
             <Route element={<Layout />}>
-              <Route path="/" element={<Dashboard />} />
-              <Route path="/conversations" element={<Conversations />} />
-              <Route path="/conversations/:id" element={<ConversationDetail />} />
-              <Route path="/notes" element={<Notes />} />
-              <Route path="/notes/:id" element={<NoteDetail />} />
-              <Route path="/search" element={<SearchPage />} />
-              <Route path="/graph" element={<RelationGraph />} />
-              <Route path="/settings" element={<SettingsPage />} />
+              <Route path="/" element={<RouteSuspense><DashboardPage /></RouteSuspense>} />
+              <Route path="/conversations" element={<RouteSuspense><ConversationsPage /></RouteSuspense>} />
+              <Route path="/conversations/:id" element={<RouteSuspense><ConversationDetailPage /></RouteSuspense>} />
+              <Route path="/notes" element={<RouteSuspense><NotesPage /></RouteSuspense>} />
+              <Route path="/notes/:id" element={<RouteSuspense><NoteDetailPage /></RouteSuspense>} />
+              <Route path="/search" element={<RouteSuspense><SearchPage /></RouteSuspense>} />
+              <Route path="/graph" element={<RouteSuspense><RelationGraphPage /></RouteSuspense>} />
+              <Route path="/settings" element={<RouteSuspense><SettingsPage /></RouteSuspense>} />
             </Route>
           </Routes>
         </BrowserRouter>

--- a/client/src/components/MarkdownRenderer.tsx
+++ b/client/src/components/MarkdownRenderer.tsx
@@ -1,43 +1,6 @@
 import { memo } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
-
-// Register only languages commonly seen in AI coding conversations
-import typescript from 'react-syntax-highlighter/dist/esm/languages/prism/typescript';
-import javascript from 'react-syntax-highlighter/dist/esm/languages/prism/javascript';
-import tsx from 'react-syntax-highlighter/dist/esm/languages/prism/tsx';
-import jsx from 'react-syntax-highlighter/dist/esm/languages/prism/jsx';
-import python from 'react-syntax-highlighter/dist/esm/languages/prism/python';
-import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash';
-import json from 'react-syntax-highlighter/dist/esm/languages/prism/json';
-import css from 'react-syntax-highlighter/dist/esm/languages/prism/css';
-import sql from 'react-syntax-highlighter/dist/esm/languages/prism/sql';
-import yaml from 'react-syntax-highlighter/dist/esm/languages/prism/yaml';
-import markdown from 'react-syntax-highlighter/dist/esm/languages/prism/markdown';
-import rust from 'react-syntax-highlighter/dist/esm/languages/prism/rust';
-import go from 'react-syntax-highlighter/dist/esm/languages/prism/go';
-import java from 'react-syntax-highlighter/dist/esm/languages/prism/java';
-import csharp from 'react-syntax-highlighter/dist/esm/languages/prism/csharp';
-
-SyntaxHighlighter.registerLanguage('typescript', typescript);
-SyntaxHighlighter.registerLanguage('javascript', javascript);
-SyntaxHighlighter.registerLanguage('tsx', tsx);
-SyntaxHighlighter.registerLanguage('jsx', jsx);
-SyntaxHighlighter.registerLanguage('python', python);
-SyntaxHighlighter.registerLanguage('bash', bash);
-SyntaxHighlighter.registerLanguage('shell', bash);
-SyntaxHighlighter.registerLanguage('json', json);
-SyntaxHighlighter.registerLanguage('css', css);
-SyntaxHighlighter.registerLanguage('sql', sql);
-SyntaxHighlighter.registerLanguage('yaml', yaml);
-SyntaxHighlighter.registerLanguage('markdown', markdown);
-SyntaxHighlighter.registerLanguage('rust', rust);
-SyntaxHighlighter.registerLanguage('go', go);
-SyntaxHighlighter.registerLanguage('java', java);
-SyntaxHighlighter.registerLanguage('csharp', csharp);
-SyntaxHighlighter.registerLanguage('cs', csharp);
 
 interface MarkdownRendererProps {
   content: string;
@@ -67,19 +30,9 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
               <div className="cc-code-header">
                 <span className="cc-code-lang">{match[1]}</span>
               </div>
-              <SyntaxHighlighter
-                style={vscDarkPlus}
-                language={match[1]}
-                PreTag="div"
-                customStyle={{
-                  margin: 0,
-                  borderRadius: '0 0 6px 6px',
-                  background: 'var(--code-bg)',
-                  fontSize: '13px',
-                }}
-              >
-                {String(children).replace(/\n$/, '')}
-              </SyntaxHighlighter>
+              <pre className="cc-code-body">
+                <code {...props}>{String(children).replace(/\n$/, '')}</code>
+              </pre>
             </div>
           );
         },

--- a/client/src/components/RelationGraphCanvas.tsx
+++ b/client/src/components/RelationGraphCanvas.tsx
@@ -1,0 +1,66 @@
+import type { MutableRefObject } from 'react';
+import ForceGraph2D, { type ForceGraphMethods } from 'react-force-graph-2d';
+
+export interface GraphNode {
+  id: number;
+  title: string;
+  project_name: string;
+  tags: string[];
+  color: string;
+  val: number;
+  x?: number;
+  y?: number;
+}
+
+export interface GraphLink {
+  source: number;
+  target: number;
+  type: string;
+  confidence: number;
+  color: string;
+}
+
+interface RelationGraphCanvasProps {
+  graphRef: MutableRefObject<ForceGraphMethods<any, any> | undefined>;
+  graphData: {
+    nodes: GraphNode[];
+    links: GraphLink[];
+  };
+  paintNode: (node: GraphNode, ctx: CanvasRenderingContext2D, globalScale: number) => void;
+  paintLink: (link: GraphLink, ctx: CanvasRenderingContext2D, globalScale: number) => void;
+  onNodeHover: (node: GraphNode | null) => void;
+  onNodeClick: (node: GraphNode) => void;
+}
+
+export function RelationGraphCanvas({
+  graphRef,
+  graphData,
+  paintNode,
+  paintLink,
+  onNodeHover,
+  onNodeClick,
+}: RelationGraphCanvasProps) {
+  return (
+    <ForceGraph2D
+      ref={graphRef}
+      graphData={graphData}
+      nodeCanvasObject={paintNode}
+      linkCanvasObject={paintLink}
+      nodePointerAreaPaint={(node, color, ctx) => {
+        const radius = Math.sqrt(node.val) * 3 + 3;
+        ctx.beginPath();
+        ctx.arc(node.x!, node.y!, radius, 0, Math.PI * 2);
+        ctx.fillStyle = color;
+        ctx.fill();
+      }}
+      onNodeHover={(node) => onNodeHover(node as GraphNode | null)}
+      onNodeClick={(node) => onNodeClick(node as GraphNode)}
+      nodeLabel={() => ''}
+      cooldownTicks={100}
+      warmupTicks={50}
+      d3AlphaDecay={0.02}
+      d3VelocityDecay={0.3}
+      backgroundColor="transparent"
+    />
+  );
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -94,6 +94,21 @@
   padding: 4px 12px;
 }
 
+.cc-code-body {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  background: var(--code-bg);
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.6;
+  overflow-x: auto;
+}
+
+.cc-code-body code {
+  display: block;
+  white-space: pre;
+}
+
 .cc-code-lang {
   font-family: var(--font-mono);
   font-size: 11px;

--- a/client/src/pages/RelationGraph.tsx
+++ b/client/src/pages/RelationGraph.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { Suspense, lazy, useCallback, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Loader2, ZoomIn, ZoomOut, Maximize } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
-import ForceGraph2D, { type ForceGraphMethods } from 'react-force-graph-2d';
 import { api } from '@/lib/api.ts';
+import type { GraphLink, GraphNode } from '@/components/RelationGraphCanvas.tsx';
+import type { ForceGraphMethods } from 'react-force-graph-2d';
 
 // =============================================
 // Constants
@@ -37,28 +38,11 @@ const PROJECT_COLORS = [
   '#06b6d4', '#eab308', '#ec4899', '#14b8a6', '#8b5cf6',
 ];
 
-// =============================================
-// Types for ForceGraph
-// =============================================
-
-interface GraphNode {
-  id: number;
-  title: string;
-  project_name: string;
-  tags: string[];
-  color: string;
-  val: number;
-  x?: number;
-  y?: number;
-}
-
-interface GraphLink {
-  source: number;
-  target: number;
-  type: string;
-  confidence: number;
-  color: string;
-}
+const RelationGraphCanvas = lazy(() =>
+  import('@/components/RelationGraphCanvas.tsx').then((module) => ({
+    default: module.RelationGraphCanvas,
+  })),
+);
 
 // =============================================
 // Component
@@ -259,27 +243,23 @@ export function RelationGraph() {
 
       {/* Graph */}
       <div className="flex-1 relative overflow-hidden">
-        <ForceGraph2D
-          ref={graphRef}
-          graphData={graphData}
-          nodeCanvasObject={paintNode}
-          linkCanvasObject={paintLink}
-          nodePointerAreaPaint={(node, color, ctx) => {
-            const radius = Math.sqrt(node.val) * 3 + 3;
-            ctx.beginPath();
-            ctx.arc(node.x!, node.y!, radius, 0, Math.PI * 2);
-            ctx.fillStyle = color;
-            ctx.fill();
-          }}
-          onNodeHover={(node) => setHoveredNode(node as GraphNode | null)}
-          onNodeClick={(node) => navigate(`/notes/${node.id}`)}
-          nodeLabel={() => ''} // We handle labels in paintNode
-          cooldownTicks={100}
-          warmupTicks={50}
-          d3AlphaDecay={0.02}
-          d3VelocityDecay={0.3}
-          backgroundColor="transparent"
-        />
+        <Suspense
+          fallback={
+            <div className="flex h-full items-center justify-center text-muted">
+              <Loader2 size={18} className="animate-spin mr-2" />
+              {isZh ? '加载图谱中...' : 'Loading graph...'}
+            </div>
+          }
+        >
+          <RelationGraphCanvas
+            graphRef={graphRef as never}
+            graphData={graphData}
+            paintNode={paintNode}
+            paintLink={paintLink}
+            onNodeHover={setHoveredNode}
+            onNodeClick={(node) => navigate(`/notes/${node.id}`)}
+          />
+        </Suspense>
 
         {/* Tooltip */}
         {hoveredNode && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
         "react-i18next": "^17.0.2",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.2",
-        "react-syntax-highlighter": "^16.1.1",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2"
@@ -50,7 +49,6 @@
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "@types/react-syntax-highlighter": "^15.5.13",
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -3182,12 +3180,6 @@
         "xmlbuilder": ">=11.0.1"
       }
     },
-    "node_modules/@types/prismjs": {
-      "version": "1.26.6",
-      "resolved": "https://registry.npmmirror.com/@types/prismjs/-/prismjs-1.26.6.tgz",
-      "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmmirror.com/@types/react/-/react-19.2.14.tgz",
@@ -3205,16 +3197,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
-      }
-    },
-    "node_modules/@types/react-syntax-highlighter": {
-      "version": "15.5.13",
-      "resolved": "https://registry.npmmirror.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz",
-      "integrity": "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*"
       }
     },
     "node_modules/@types/responselike": {
@@ -7058,19 +7040,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fault": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmmirror.com/fault/-/fault-1.0.4.tgz",
-      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
-      "license": "MIT",
-      "dependencies": {
-        "format": "^0.2.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -7321,14 +7290,6 @@
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
       "license": "MIT"
-    },
-    "node_modules/format": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmmirror.com/format/-/format-0.2.2.tgz",
-      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
-      "engines": {
-        "node": ">=0.4.x"
-      }
     },
     "node_modules/formdata-node": {
       "version": "4.4.1",
@@ -7705,19 +7666,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hast-util-parse-selector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmmirror.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
-      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmmirror.com/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -7758,23 +7706,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hastscript": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmmirror.com/hastscript/-/hastscript-9.0.1.tgz",
-      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^4.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmmirror.com/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -7791,21 +7722,6 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
-    },
-    "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmmirror.com/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/highlightjs-vue": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
-      "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
-      "license": "CC0-1.0"
     },
     "node_modules/hono": {
       "version": "4.12.12",
@@ -9174,20 +9090,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/lowlight": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmmirror.com/lowlight/-/lowlight-1.20.0.tgz",
-      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
-      "license": "MIT",
-      "dependencies": {
-        "fault": "^1.0.0",
-        "highlight.js": "~10.7.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -11198,15 +11100,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prismjs": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmmirror.com/prismjs/-/prismjs-1.30.0.tgz",
-      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/proc-log": {
       "version": "5.0.0",
       "resolved": "https://registry.npmmirror.com/proc-log/-/proc-log-5.0.0.tgz",
@@ -11586,26 +11479,6 @@
         "react-dom": ">=18"
       }
     },
-    "node_modules/react-syntax-highlighter": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmmirror.com/react-syntax-highlighter/-/react-syntax-highlighter-16.1.1.tgz",
-      "integrity": "sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "highlight.js": "^10.4.1",
-        "highlightjs-vue": "^1.0.0",
-        "lowlight": "^1.17.0",
-        "prismjs": "^1.30.0",
-        "refractor": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 16.20.2"
-      },
-      "peerDependencies": {
-        "react": ">= 0.14.0"
-      }
-    },
     "node_modules/read-binary-file-arch": {
       "version": "1.0.6",
       "resolved": "https://registry.npmmirror.com/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
@@ -11654,22 +11527,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
-      }
-    },
-    "node_modules/refractor": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmmirror.com/refractor/-/refractor-5.0.0.tgz",
-      "integrity": "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/prismjs": "^1.0.0",
-        "hastscript": "^9.0.0",
-        "parse-entities": "^4.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/remark-gfm": {


### PR DESCRIPTION
## Summary

This PR improves the client-side loading path and trims bundle weight for the graph and markdown experiences.

- lazy-load the main route pages behind a shared suspense fallback
- split the force-graph runtime into a lazy `RelationGraphCanvas` component
- replace `react-syntax-highlighter` with native `<pre><code>` rendering
- remove the related client dependencies from `client/package.json` and `package-lock.json`
- update `CHANGELOG.md` so these client changes are included in the planned `0.4.6` release notes

## Validation

- `npm run build -w client`

## Release Note

This change is intended to ship as part of `0.4.6`.