### PR TITLE
[codex] Enforce structured memory writeback quality gate

### DIFF
--- a/server/src/cli/client.ts
+++ b/server/src/cli/client.ts
@@ -6,6 +6,8 @@ import type {
   DeleteNoteReviewResponse,
   RecallForTaskRequest,
   RecallForTaskResponse,
+  ValidateTaskMemoryRequest,
+  ValidateTaskMemoryResponse,
   WriteTaskMemoryRequest,
   WriteTaskMemoryResponse,
 } from '@chatcrystal/shared';
@@ -350,6 +352,14 @@ export class CrystalClient {
 
   async recallForTask(body: RecallForTaskRequest) {
     return this.request<RecallForTaskResponse>('POST', '/api/memory/recall', body);
+  }
+
+  async validateTaskMemory(body: ValidateTaskMemoryRequest) {
+    return this.request<ValidateTaskMemoryResponse>(
+      'POST',
+      '/api/memory/validate',
+      body,
+    );
   }
 
   async writeTaskMemory(body: WriteTaskMemoryRequest) {

--- a/server/src/cli/mcp/server.ts
+++ b/server/src/cli/mcp/server.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { CrystalClient } from '../client.js';
 import {
   RecallForTaskRequestShape,
+  ValidateTaskMemoryRequestShape,
   WriteTaskMemoryRequestShape,
 } from '../../services/memory/schemas.js';
 
@@ -107,8 +108,23 @@ export async function startMcpServer(baseUrl: string) {
   );
 
   server.tool(
+    'validate_task_memory',
+    'Preflight a task memory candidate without side effects. Use this before write_task_memory when available. Returns materialized ChatCrystal note fields, acceptance, reason, and warnings.',
+    ValidateTaskMemoryRequestShape,
+    async (input) => {
+      const data = await client.validateTaskMemory(input);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(data, null, 2),
+        }],
+      };
+    },
+  );
+
+  server.tool(
     'write_task_memory',
-    'Persist a task memory with idempotent auto-writeback semantics.',
+    'Persist a task memory only when it can become a high-quality ChatCrystal note: specific title, concrete summary, meaningful key conclusions, and a durable reusable lesson such as a pitfall, fix, decision, pattern, or symptom-to-resolution mapping. Do not write one-time environment checks, version/status reports, ordinary progress logs, or vague robustness claims. Weak auto writebacks are skipped by core validation and recorded only as receipts.',
     WriteTaskMemoryRequestShape,
     async (input) => {
       const data = await client.writeTaskMemory(input);

--- a/server/src/routes/memory.ts
+++ b/server/src/routes/memory.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { ZodError } from 'zod';
+import { validateTaskMemory } from '../services/memory/preflight.js';
 import { recallForTask } from '../services/memory/recall.js';
 import { writeTaskMemory } from '../services/memory/writeback.js';
 
@@ -16,6 +17,22 @@ export async function memoryRoutes(app: FastifyInstance) {
           error instanceof Error
             ? error.message
             : 'Invalid recall request',
+      };
+    }
+  });
+
+  app.post('/api/memory/validate', async (req, reply) => {
+    try {
+      const data = validateTaskMemory(req.body);
+      return { success: true, data };
+    } catch (error) {
+      reply.status(error instanceof ZodError ? 400 : 500);
+      return {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Invalid memory validation request',
       };
     }
   });

--- a/server/src/services/embedding.test.ts
+++ b/server/src/services/embedding.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import test from 'node:test';
 import { LocalIndex } from 'vectra';
 import {
+  buildNoteEmbeddingText,
   committedVectraIdsForNote,
   currentVectraIdsCommitted,
   deleteVectraItemsForNote,
@@ -16,6 +17,88 @@ import {
 function createTempDir() {
   return mkdtempSync(join(tmpdir(), 'chatcrystal-embedding-'));
 }
+
+test('buildNoteEmbeddingText includes structured agent writeback memory signals', () => {
+  const text = buildNoteEmbeddingText({
+    title: 'Server readiness race causes ECONNREFUSED',
+    summary: 'Requests must wait for server readiness before client calls.',
+    keyConclusionsJson: JSON.stringify([
+      'Await readiness before issuing HTTP requests.',
+      'Visible key conclusions stay searchable.',
+    ]),
+    codeSnippetsJson: JSON.stringify([
+      { description: 'Readiness helper wraps Fastify startup.' },
+      { code: 'console.log("ignored because no description")' },
+    ]),
+    tagsText: 'readiness testing',
+    sourceType: 'agent-writeback',
+    rawPayloadJson: JSON.stringify({
+      root_cause: 'Client calls raced server startup.',
+      resolution: 'Block request setup until server readiness resolves.',
+      pitfalls: ['Do not fire API requests before Fastify ready.'],
+      reusable_patterns: ['Share a readiness helper across HTTP tests.'],
+      decisions: ['Keep readiness helper in test utilities.'],
+    }),
+    errorSignaturesJson: JSON.stringify(['ECONNREFUSED 127.0.0.1:3721']),
+    filesTouchedJson: JSON.stringify(['server/src/test/readiness.ts']),
+  });
+
+  assert.match(text, /Server readiness race causes ECONNREFUSED/);
+  assert.match(text, /Requests must wait for server readiness/);
+  assert.match(text, /Await readiness before issuing HTTP requests/);
+  assert.match(text, /Visible key conclusions stay searchable/);
+  assert.match(text, /readiness testing/);
+  assert.match(text, /Readiness helper wraps Fastify startup/);
+  assert.match(text, /Root cause: Client calls raced server startup\./);
+  assert.match(text, /Resolution: Block request setup until server readiness resolves\./);
+  assert.match(text, /Pitfall: Do not fire API requests before Fastify ready\./);
+  assert.match(text, /Pattern: Share a readiness helper across HTTP tests\./);
+  assert.match(text, /Decision: Keep readiness helper in test utilities\./);
+  assert.match(text, /Error signature: ECONNREFUSED 127\.0\.0\.1:3721/);
+  assert.match(text, /File: server\/src\/test\/readiness\.ts/);
+});
+
+test('buildNoteEmbeddingText ignores malformed JSON defensively', () => {
+  assert.doesNotThrow(() => {
+    buildNoteEmbeddingText({
+      title: 'Malformed memory payload',
+      summary: 'Embedding text still includes stable fields.',
+      keyConclusionsJson: '{not-json',
+      codeSnippetsJson: 'also-not-json',
+      tagsText: null,
+      sourceType: 'agent-writeback',
+      rawPayloadJson: '{"root_cause"',
+      errorSignaturesJson: '[broken',
+      filesTouchedJson: '{broken',
+    });
+  });
+});
+
+test('buildNoteEmbeddingText skips raw memory payload details for imported conversations', () => {
+  const text = buildNoteEmbeddingText({
+    title: 'Imported conversation note',
+    summary: 'Imported summaries still embed visible note fields.',
+    keyConclusionsJson: JSON.stringify(['Visible imported conclusion.']),
+    codeSnippetsJson: '[]',
+    tagsText: null,
+    sourceType: 'imported-conversation',
+    rawPayloadJson: JSON.stringify({
+      root_cause: 'SHOULD_NOT_EMBED_ROOT_CAUSE',
+      reusable_patterns: ['SHOULD_NOT_EMBED_PATTERN'],
+      decisions: ['SHOULD_NOT_EMBED_DECISION'],
+    }),
+    errorSignaturesJson: JSON.stringify(['SHOULD_NOT_EMBED_SIGNATURE']),
+    filesTouchedJson: JSON.stringify(['SHOULD_NOT_EMBED_FILE']),
+  });
+
+  assert.match(text, /Imported conversation note/);
+  assert.match(text, /Visible imported conclusion/);
+  assert.equal(text.includes('SHOULD_NOT_EMBED_ROOT_CAUSE'), false);
+  assert.equal(text.includes('SHOULD_NOT_EMBED_PATTERN'), false);
+  assert.equal(text.includes('SHOULD_NOT_EMBED_DECISION'), false);
+  assert.equal(text.includes('SHOULD_NOT_EMBED_SIGNATURE'), false);
+  assert.equal(text.includes('SHOULD_NOT_EMBED_FILE'), false);
+});
 
 test('committed vectra ids come from persisted index state, not staged updates', async () => {
   const dir = createTempDir();

--- a/server/src/services/embedding.test.ts
+++ b/server/src/services/embedding.test.ts
@@ -28,7 +28,7 @@ test('buildNoteEmbeddingText includes structured agent writeback memory signals'
     ]),
     codeSnippetsJson: JSON.stringify([
       { description: 'Readiness helper wraps Fastify startup.' },
-      { code: 'console.log("ignored because no description")' },
+      { code: 'console.log("code-only body remains searchable")' },
     ]),
     tagsText: 'readiness testing',
     sourceType: 'agent-writeback',
@@ -56,6 +56,35 @@ test('buildNoteEmbeddingText includes structured agent writeback memory signals'
   assert.match(text, /Decision: Keep readiness helper in test utilities\./);
   assert.match(text, /Error signature: ECONNREFUSED 127\.0\.0\.1:3721/);
   assert.match(text, /File: server\/src\/test\/readiness\.ts/);
+});
+
+test('buildNoteEmbeddingText includes bounded code snippet bodies for memory notes', () => {
+  const longBody = 'x'.repeat(1005);
+  const text = buildNoteEmbeddingText({
+    title: 'Readiness helper memory',
+    summary: 'Code evidence should match the validation preview.',
+    keyConclusionsJson: '[]',
+    codeSnippetsJson: JSON.stringify([
+      {
+        language: 'ts',
+        code: "await fastify.ready();\nawait client.get('/api/status');",
+      },
+      {
+        code: longBody,
+      },
+    ]),
+    tagsText: null,
+    sourceType: 'agent-writeback',
+    rawPayloadJson: '{}',
+    errorSignaturesJson: '[]',
+    filesTouchedJson: '[]',
+  });
+
+  assert.match(
+    text,
+    /Code snippet \(ts\): await fastify\.ready\(\); await client\.get\('\/api\/status'\);/,
+  );
+  assert.match(text, new RegExp(`Code snippet \\(text\\): ${'x'.repeat(1000)}(?!x)`));
 });
 
 test('buildNoteEmbeddingText ignores malformed JSON defensively', () => {

--- a/server/src/services/embedding.ts
+++ b/server/src/services/embedding.ts
@@ -59,6 +59,121 @@ function chunkText(text: string): string[] {
   return chunks;
 }
 
+export type BuildNoteEmbeddingTextInput = {
+  title: string;
+  summary: string;
+  keyConclusionsJson: string;
+  codeSnippetsJson: string;
+  tagsText: string | null;
+  sourceType: string | null;
+  rawPayloadJson: string | null;
+  errorSignaturesJson: string | null;
+  filesTouchedJson: string | null;
+};
+
+function safeParseJson(value: string | null): unknown {
+  if (!value) return undefined;
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function cleanEmbeddingText(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function stringArrayFromJson(value: string | null): string[] {
+  const parsed = safeParseJson(value);
+  if (!Array.isArray(parsed)) return [];
+
+  return parsed
+    .map(cleanEmbeddingText)
+    .filter((item): item is string => Boolean(item));
+}
+
+function appendText(target: string[], value: unknown) {
+  const text = cleanEmbeddingText(value);
+  if (text) target.push(text);
+}
+
+function appendLabeledText(target: string[], label: string, value: unknown) {
+  const text = cleanEmbeddingText(value);
+  if (text) target.push(`${label}: ${text}`);
+}
+
+function appendLabeledArray(target: string[], label: string, value: unknown) {
+  if (!Array.isArray(value)) return;
+
+  for (const item of value) {
+    appendLabeledText(target, label, item);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isMemoryNoteSource(sourceType: string | null): boolean {
+  return sourceType === 'agent-writeback' || sourceType === 'manual-note';
+}
+
+function dedupeExact(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    result.push(value);
+  }
+
+  return result;
+}
+
+export function buildNoteEmbeddingText(input: BuildNoteEmbeddingTextInput): string {
+  const parts: string[] = [];
+
+  appendText(parts, input.title);
+  appendText(parts, input.summary);
+
+  for (const conclusion of stringArrayFromJson(input.keyConclusionsJson)) {
+    appendText(parts, conclusion);
+  }
+
+  appendText(parts, input.tagsText);
+
+  const codeSnippets = safeParseJson(input.codeSnippetsJson);
+  if (Array.isArray(codeSnippets)) {
+    for (const snippet of codeSnippets) {
+      if (isRecord(snippet)) {
+        appendText(parts, snippet.description);
+      }
+    }
+  }
+
+  if (isMemoryNoteSource(input.sourceType)) {
+    const rawPayload = safeParseJson(input.rawPayloadJson);
+    if (isRecord(rawPayload)) {
+      appendLabeledText(parts, 'Root cause', rawPayload.root_cause);
+      appendLabeledText(parts, 'Resolution', rawPayload.resolution);
+      appendLabeledArray(parts, 'Pitfall', rawPayload.pitfalls);
+      appendLabeledArray(parts, 'Pattern', rawPayload.reusable_patterns);
+      appendLabeledArray(parts, 'Decision', rawPayload.decisions);
+    }
+
+    appendLabeledArray(parts, 'Error signature', safeParseJson(input.errorSignaturesJson));
+    appendLabeledArray(parts, 'File', safeParseJson(input.filesTouchedJson));
+  }
+
+  return dedupeExact(parts).join('\n\n');
+}
+
 // =============================================
 // Public API
 // =============================================
@@ -194,7 +309,8 @@ export async function generateEmbeddings(noteId: number): Promise<number> {
 
   // Get note data
   const noteResult = db.exec(
-    `SELECT n.id, n.conversation_id, n.title, n.summary, n.key_conclusions, n.code_snippets, c.project_name
+    `SELECT n.id, n.conversation_id, n.title, n.summary, n.key_conclusions, n.code_snippets, c.project_name,
+            n.source_type, n.raw_llm_response, n.error_signatures, n.files_touched
      FROM notes n JOIN conversations c ON c.id = n.conversation_id
      WHERE n.id = ?`,
     [noteId],
@@ -203,42 +319,50 @@ export async function generateEmbeddings(noteId: number): Promise<number> {
     throw new Error('Note not found');
   }
 
-  const [id, conversationId, title, summary, keyConclusions, codeSnippets, projectName] = noteResult[0].values[0] as [
-    number, string, string, string, string, string, string,
+  const [
+    id,
+    conversationId,
+    title,
+    summary,
+    keyConclusions,
+    codeSnippets,
+    projectName,
+    sourceType,
+    rawPayload,
+    errorSignatures,
+    filesTouched,
+  ] = noteResult[0].values[0] as [
+    number,
+    string,
+    string,
+    string,
+    string | null,
+    string | null,
+    string,
+    string | null,
+    string | null,
+    string | null,
+    string | null,
   ];
 
-  // Build text to embed: title + summary + conclusions
-  let fullText = `${title}\n\n${summary}`;
-  try {
-    const conclusions = JSON.parse(keyConclusions || '[]') as string[];
-    if (conclusions.length > 0) {
-      fullText += '\n\n' + conclusions.join('\n');
-    }
-  } catch {
-    // ignore parse errors
-  }
-
-  // Append tags for keyword matching
   const tagsResult = db.exec(
     `SELECT GROUP_CONCAT(t.name, ' ') FROM note_tags nt
      JOIN tags t ON t.id = nt.tag_id WHERE nt.note_id = ?`,
     [noteId],
   );
   const tagsText = tagsResult[0]?.values[0]?.[0] as string | null;
-  if (tagsText) {
-    fullText += '\n\n' + tagsText;
-  }
 
-  // Append code snippet descriptions
-  try {
-    const snippets = JSON.parse(codeSnippets || '[]') as { description?: string }[];
-    const descriptions = snippets.map((s) => s.description).filter(Boolean);
-    if (descriptions.length > 0) {
-      fullText += '\n\n' + descriptions.join('\n');
-    }
-  } catch {
-    // ignore parse errors
-  }
+  const fullText = buildNoteEmbeddingText({
+    title,
+    summary,
+    keyConclusionsJson: keyConclusions ?? '[]',
+    codeSnippetsJson: codeSnippets ?? '[]',
+    tagsText,
+    sourceType,
+    rawPayloadJson: rawPayload,
+    errorSignaturesJson: errorSignatures,
+    filesTouchedJson: filesTouched,
+  });
 
   // Chunk the text
   const chunks = chunkText(fullText);

--- a/server/src/services/embedding.ts
+++ b/server/src/services/embedding.ts
@@ -37,6 +37,7 @@ function getEmbeddingModel() {
 // =============================================
 
 const CHUNK_SIZE = 500; // characters per chunk
+const MAX_EMBEDDED_CODE_SNIPPET_CHARS = 1000;
 
 function chunkText(text: string): string[] {
   if (text.length <= CHUNK_SIZE) return [text];
@@ -88,6 +89,13 @@ function cleanEmbeddingText(value: unknown): string | undefined {
   return trimmed || undefined;
 }
 
+function cleanCodeEvidenceText(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+
+  const trimmed = value.replace(/\s+/g, ' ').trim();
+  return trimmed || undefined;
+}
+
 function stringArrayFromJson(value: string | null): string[] {
   const parsed = safeParseJson(value);
   if (!Array.isArray(parsed)) return [];
@@ -113,6 +121,16 @@ function appendLabeledArray(target: string[], label: string, value: unknown) {
   for (const item of value) {
     appendLabeledText(target, label, item);
   }
+}
+
+function appendCodeSnippetEvidence(target: string[], snippet: unknown) {
+  if (!isRecord(snippet)) return;
+
+  const code = cleanCodeEvidenceText(snippet.code);
+  if (!code) return;
+
+  const language = cleanCodeEvidenceText(snippet.language) ?? 'text';
+  target.push(`Code snippet (${language}): ${code.slice(0, MAX_EMBEDDED_CODE_SNIPPET_CHARS)}`);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -158,6 +176,12 @@ export function buildNoteEmbeddingText(input: BuildNoteEmbeddingTextInput): stri
   }
 
   if (isMemoryNoteSource(input.sourceType)) {
+    if (Array.isArray(codeSnippets)) {
+      for (const snippet of codeSnippets) {
+        appendCodeSnippetEvidence(parts, snippet);
+      }
+    }
+
     const rawPayload = safeParseJson(input.rawPayloadJson);
     if (isRecord(rawPayload)) {
       appendLabeledText(parts, 'Root cause', rawPayload.root_cause);

--- a/server/src/services/memory/materialize.test.ts
+++ b/server/src/services/memory/materialize.test.ts
@@ -83,3 +83,33 @@ test('materializeTaskMemory does not invent missing claims', () => {
   assert.equal(note.embedding_text.includes('Root cause:'), false);
   assert.equal(note.embedding_text.includes('Resolution:'), false);
 });
+
+test('materializeTaskMemory includes bounded code snippet evidence in embeddings', () => {
+  const request = parsed({
+    mode: 'auto',
+    source_run_key: 'run-code-evidence',
+    task: { goal: 'Document retry config', task_kind: 'implement', source_agent: 'codex' },
+    memory: {
+      summary: 'Retry configuration should be searchable by API name and env key.',
+      outcome_type: 'pattern',
+      code_snippets: [
+        {
+          language: 'ts',
+          description: 'Retry policy uses CRYSTAL_MAX_RETRIES.',
+          code: `const retries = Number(process.env.CRYSTAL_MAX_RETRIES);
+export function configureRetry() {
+  return { retries };
+}
+${'x'.repeat(1200)}TRUNCATED_SENTINEL`,
+        },
+      ],
+    },
+  });
+
+  const note = materializeTaskMemory(request);
+
+  assert.match(note.embedding_text, /Code: Retry policy uses CRYSTAL_MAX_RETRIES\./);
+  assert.match(note.embedding_text, /Code snippet \(ts\): const retries = Number\(process\.env\.CRYSTAL_MAX_RETRIES\);/);
+  assert.match(note.embedding_text, /configureRetry/);
+  assert.equal(note.embedding_text.includes('TRUNCATED_SENTINEL'), false);
+});

--- a/server/src/services/memory/materialize.test.ts
+++ b/server/src/services/memory/materialize.test.ts
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { materializeTaskMemory } from './materialize.js';
+import { parseWriteTaskMemoryRequest } from './schemas.js';
+
+function parsed(input: unknown) {
+  return parseWriteTaskMemoryRequest(input);
+}
+
+test('materializeTaskMemory passes through high-quality visible note fields', () => {
+  const request = parsed({
+    mode: 'auto',
+    source_run_key: 'run-pass-through',
+    task: { goal: 'Fix server readiness race', task_kind: 'debug', source_agent: 'codex' },
+    memory: {
+      title: 'Server readiness race causes ECONNREFUSED',
+      summary: 'Requests must wait for server readiness before client calls.',
+      outcome_type: 'fix',
+      key_conclusions: ['Await readiness before issuing HTTP requests.'],
+      root_cause: 'Client calls raced server startup.',
+      resolution: 'Block request setup until readiness resolves.',
+      tags: ['testing', 'readiness'],
+    },
+  });
+
+  const note = materializeTaskMemory(request);
+
+  assert.equal(note.title, 'Server readiness race causes ECONNREFUSED');
+  assert.equal(note.summary, 'Requests must wait for server readiness before client calls.');
+  assert.deepEqual(note.key_conclusions, [
+    'Await readiness before issuing HTTP requests.',
+    'Root cause: Client calls raced server startup.',
+    'Resolution: Block request setup until readiness resolves.',
+  ]);
+  assert.deepEqual(note.tags, ['readiness', 'testing']);
+  assert.equal(note.raw_payload, request.memory);
+});
+
+test('materializeTaskMemory lifts reusable structured fields into visible conclusions', () => {
+  const request = parsed({
+    mode: 'auto',
+    source_run_key: 'run-pattern',
+    task: { goal: 'Add note deletion E2E', task_kind: 'implement', source_agent: 'codex' },
+    memory: {
+      summary: 'Deletion flows must verify SQL rows and vector index state together.',
+      outcome_type: 'pattern',
+      reusable_patterns: ['When deleting notes, assert SQL cleanup and Vectra cleanup in the same E2E run.'],
+      decisions: ['Keep Vectra cleanup idempotent because SQLite and vector commits can diverge.'],
+      error_signatures: ['foreign_key_check reports orphan rows'],
+      files_touched: ['server/src/routes/notes.ts'],
+      tags: ['Deletion', ' Vectra ', 'deletion'],
+    },
+  });
+
+  const note = materializeTaskMemory(request);
+
+  assert.deepEqual(note.key_conclusions, [
+    'Pattern: When deleting notes, assert SQL cleanup and Vectra cleanup in the same E2E run.',
+    'Decision: Keep Vectra cleanup idempotent because SQLite and vector commits can diverge.',
+    'Error signature: foreign_key_check reports orphan rows',
+  ]);
+  assert.match(note.embedding_text, /Vectra cleanup/);
+  assert.match(note.embedding_text, /server\/src\/routes\/notes\.ts/);
+  assert.deepEqual(note.tags, ['deletion', 'vectra']);
+});
+
+test('materializeTaskMemory does not invent missing claims', () => {
+  const request = parsed({
+    mode: 'auto',
+    source_run_key: 'run-weak',
+    task: { goal: 'Check package version', task_kind: 'investigate', source_agent: 'codex' },
+    memory: {
+      summary: 'Checked package version and local dist output.',
+      outcome_type: 'pattern',
+      reusable_patterns: [],
+    },
+  });
+
+  const note = materializeTaskMemory(request);
+
+  assert.equal(note.title, 'Check package version');
+  assert.deepEqual(note.key_conclusions, []);
+  assert.equal(note.embedding_text.includes('Root cause:'), false);
+  assert.equal(note.embedding_text.includes('Resolution:'), false);
+});

--- a/server/src/services/memory/materialize.ts
+++ b/server/src/services/memory/materialize.ts
@@ -6,6 +6,8 @@ import type { parseWriteTaskMemoryRequest } from './schemas.js';
 
 type ParsedWriteTaskMemoryRequest = ReturnType<typeof parseWriteTaskMemoryRequest>;
 
+const MAX_EMBEDDED_CODE_SNIPPET_CHARS = 1000;
+
 function cleanText(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   const trimmed = value.replace(/\s+/g, ' ').trim();
@@ -41,11 +43,20 @@ function appendLabeled(target: string[], label: string, values: unknown) {
   }
 }
 
+function materializeCodeSnippetEvidence(
+  snippet: NonNullable<WriteTaskMemoryPayload['code_snippets']>[number],
+): string | undefined {
+  const code = cleanText(snippet.code);
+  if (!code) return undefined;
+  const language = cleanText(snippet.language) ?? 'text';
+  return `Code snippet (${language}): ${code.slice(0, MAX_EMBEDDED_CODE_SNIPPET_CHARS)}`;
+}
+
 export function materializeTaskMemory(
   request: ParsedWriteTaskMemoryRequest,
   payload: WriteTaskMemoryPayload = request.memory,
 ): MaterializedTaskMemoryNote {
-  const title = cleanText(payload.title) ?? request.task.goal.trim();
+  const title = cleanText(payload.title) ?? cleanText(request.task.goal) ?? request.task.goal.trim();
   const summary = cleanText(payload.summary) ?? '';
   const keyConclusions: string[] = [
     ...cleanStringArray(payload.key_conclusions),
@@ -63,6 +74,9 @@ export function materializeTaskMemory(
   const codeDescriptions = (payload.code_snippets ?? [])
     .map((snippet) => cleanText(snippet.description))
     .filter((value): value is string => Boolean(value));
+  const codeEvidence = (payload.code_snippets ?? [])
+    .map(materializeCodeSnippetEvidence)
+    .filter((value): value is string => Boolean(value));
   const filesTouched = cleanStringArray(payload.files_touched);
   const tags = normalizeTags(payload.tags);
 
@@ -71,6 +85,7 @@ export function materializeTaskMemory(
     summary,
     ...dedupe(keyConclusions),
     ...codeDescriptions.map((description) => `Code: ${description}`),
+    ...codeEvidence,
     ...filesTouched.map((file) => `File: ${file}`),
     ...tags.map((tag) => `Tag: ${tag}`),
   ]

--- a/server/src/services/memory/materialize.ts
+++ b/server/src/services/memory/materialize.ts
@@ -1,0 +1,88 @@
+import type {
+  MaterializedTaskMemoryNote,
+  WriteTaskMemoryPayload,
+} from '@chatcrystal/shared';
+import type { parseWriteTaskMemoryRequest } from './schemas.js';
+
+type ParsedWriteTaskMemoryRequest = ReturnType<typeof parseWriteTaskMemoryRequest>;
+
+function cleanText(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.replace(/\s+/g, ' ').trim();
+  return trimmed || undefined;
+}
+
+function cleanStringArray(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  return values
+    .map(cleanText)
+    .filter((value): value is string => Boolean(value));
+}
+
+function dedupe(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const key = value.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(value);
+  }
+  return result;
+}
+
+function normalizeTags(tags: unknown): string[] {
+  return [...new Set(cleanStringArray(tags).map((tag) => tag.toLowerCase()))].sort();
+}
+
+function appendLabeled(target: string[], label: string, values: unknown) {
+  for (const value of cleanStringArray(values)) {
+    target.push(`${label}: ${value}`);
+  }
+}
+
+export function materializeTaskMemory(
+  request: ParsedWriteTaskMemoryRequest,
+  payload: WriteTaskMemoryPayload = request.memory,
+): MaterializedTaskMemoryNote {
+  const title = cleanText(payload.title) ?? request.task.goal.trim();
+  const summary = cleanText(payload.summary) ?? '';
+  const keyConclusions: string[] = [
+    ...cleanStringArray(payload.key_conclusions),
+  ];
+
+  const rootCause = cleanText(payload.root_cause);
+  const resolution = cleanText(payload.resolution);
+  if (rootCause) keyConclusions.push(`Root cause: ${rootCause}`);
+  if (resolution) keyConclusions.push(`Resolution: ${resolution}`);
+  appendLabeled(keyConclusions, 'Pitfall', payload.pitfalls);
+  appendLabeled(keyConclusions, 'Pattern', payload.reusable_patterns);
+  appendLabeled(keyConclusions, 'Decision', payload.decisions);
+  appendLabeled(keyConclusions, 'Error signature', payload.error_signatures);
+
+  const codeDescriptions = (payload.code_snippets ?? [])
+    .map((snippet) => cleanText(snippet.description))
+    .filter((value): value is string => Boolean(value));
+  const filesTouched = cleanStringArray(payload.files_touched);
+  const tags = normalizeTags(payload.tags);
+
+  const embeddingText = [
+    title,
+    summary,
+    ...dedupe(keyConclusions),
+    ...codeDescriptions.map((description) => `Code: ${description}`),
+    ...filesTouched.map((file) => `File: ${file}`),
+    ...tags.map((tag) => `Tag: ${tag}`),
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+
+  return {
+    title,
+    summary,
+    key_conclusions: dedupe(keyConclusions),
+    embedding_text: embeddingText,
+    tags,
+    raw_payload: payload,
+  };
+}

--- a/server/src/services/memory/preflight.test.ts
+++ b/server/src/services/memory/preflight.test.ts
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateTaskMemory } from './preflight.js';
+
+test('validateTaskMemory accepts strong candidates and returns visible conclusions', () => {
+  const result = validateTaskMemory({
+    mode: 'auto',
+    source_run_key: 'run-strong-preflight',
+    task: {
+      goal: 'Fix server readiness race',
+      task_kind: 'debug',
+      source_agent: 'codex',
+    },
+    memory: {
+      title: 'Server readiness race returns ECONNREFUSED',
+      summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client calls hit ECONNREFUSED because they ran before the local server was ready.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+      tags: ['readiness', 'testing'],
+    },
+  });
+
+  assert.equal(result.mode, 'auto');
+  assert.equal(result.accepted, true);
+  assert.equal(result.decision, 'accepted');
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+  assert.deepEqual(result.materialized_note.key_conclusions, [
+    'Root cause: Client calls hit ECONNREFUSED because they ran before the local server was ready.',
+    'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+  ]);
+  assert.equal(
+    result.materialized_note.raw_payload.summary,
+    'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+  );
+});
+
+test('validateTaskMemory skips weak auto candidates with note quality warnings', () => {
+  const result = validateTaskMemory({
+    mode: 'auto',
+    source_run_key: 'run-weak-quality-preflight',
+    task: {
+      goal: 'Fix server readiness validation',
+      task_kind: 'debug',
+      source_agent: 'codex',
+    },
+    memory: {
+      title: 'Server readiness validation prevents ECONNREFUSED',
+      summary: 'Validate server readiness to prevent future failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Validate server readiness to prevent future failures.',
+    },
+  });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.decision, 'skipped');
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+  assert.match(result.materialized_note.embedding_text, /ECONNREFUSED/);
+});
+
+test('validateTaskMemory returns structured validation failures before note quality', () => {
+  let qualityCalls = 0;
+
+  const result = validateTaskMemory(
+    {
+      mode: 'auto',
+      source_run_key: 'run-low-signal-preflight',
+      task: {
+        goal: 'Fix flaky test',
+        task_kind: 'debug',
+        source_agent: 'codex',
+      },
+      memory: {
+        summary: 'The flaky integration test should be captured as a reusable fix candidate.',
+        outcome_type: 'fix',
+      },
+    },
+    {
+      validateMaterializedNoteQuality: () => {
+        qualityCalls++;
+        throw new Error('note quality should not run');
+      },
+    },
+  );
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.decision, 'skipped');
+  assert.equal(result.reason, 'low-signal');
+  assert.ok(result.warnings.includes('root_cause_or_resolution'));
+  assert.equal(qualityCalls, 0);
+  assert.deepEqual(result.materialized_note.key_conclusions, []);
+});

--- a/server/src/services/memory/preflight.ts
+++ b/server/src/services/memory/preflight.ts
@@ -1,0 +1,65 @@
+import type {
+  MaterializedTaskMemoryNote,
+  ValidateTaskMemoryResponse,
+} from '@chatcrystal/shared';
+import type { ExperienceGateDecision } from '../experience/schemas.js';
+import { validateStructuredMemoryCandidate } from '../experience/gate.js';
+import { materializeTaskMemory } from './materialize.js';
+import { validateMaterializedNoteQuality } from './quality.js';
+import { parseValidateTaskMemoryRequest } from './schemas.js';
+
+type ParsedValidateTaskMemoryRequest = ReturnType<
+  typeof parseValidateTaskMemoryRequest
+>;
+type StructuredMemoryCandidate = ParsedValidateTaskMemoryRequest['memory'];
+type StructuredMemoryGateDecision =
+  Pick<ExperienceGateDecision, 'reasons' | 'missing_signals'> | null;
+type StructuredMemoryValidator = (
+  memory: StructuredMemoryCandidate,
+) => StructuredMemoryGateDecision;
+type NoteQualityValidator = (
+  note: MaterializedTaskMemoryNote,
+  options: { mode: ParsedValidateTaskMemoryRequest['mode'] },
+) => {
+  accepted: boolean;
+  reason: string;
+  warnings: string[];
+};
+
+export function validateTaskMemory(
+  input: unknown,
+  deps: {
+    validateStructuredMemoryCandidate?: StructuredMemoryValidator;
+    validateMaterializedNoteQuality?: NoteQualityValidator;
+  } = {},
+): ValidateTaskMemoryResponse {
+  const request = parseValidateTaskMemoryRequest(input);
+  const materialized = materializeTaskMemory(request);
+  const validateMemory =
+    deps.validateStructuredMemoryCandidate ?? validateStructuredMemoryCandidate;
+  const structuredDecision = validateMemory(request.memory);
+
+  if (structuredDecision) {
+    return {
+      mode: request.mode,
+      accepted: false,
+      decision: 'skipped',
+      reason: structuredDecision.reasons[0] ?? 'low-signal',
+      warnings: structuredDecision.missing_signals,
+      materialized_note: materialized,
+    };
+  }
+
+  const qualityValidator =
+    deps.validateMaterializedNoteQuality ?? validateMaterializedNoteQuality;
+  const qualityDecision = qualityValidator(materialized, { mode: request.mode });
+
+  return {
+    mode: request.mode,
+    accepted: qualityDecision.accepted,
+    decision: qualityDecision.accepted ? 'accepted' : 'skipped',
+    reason: qualityDecision.reason,
+    warnings: qualityDecision.warnings,
+    materialized_note: materialized,
+  };
+}

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -2240,6 +2240,49 @@ test('validateMaterializedNoteQuality rejects generic import dedupe reliability 
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality accepts SQLite WAL sidecar source adapter fixes', () => {
+  const summary = 'Copy Cursor state.vscdb with its -wal and -shm sidecars before sql.js opens it so composer metadata rows are not missing.';
+  const root_cause = 'Cursor kept recent composer metadata in state.vscdb-wal, so reading only state.vscdb with sql.js returned stale or missing chat rows.';
+  const resolution = 'Copy state.vscdb, state.vscdb-wal, and state.vscdb-shm into a temporary directory before opening the database so sql.js sees the committed WAL pages.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Cursor workspaceStorage WAL hides composer rows',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects generic database file reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Database file reliability fix',
+    summary: 'Copy database files for reliability.',
+    key_conclusions: [
+      'Root cause: Database files were unreliable.',
+      'Resolution: Copy database files for reliability.',
+    ],
+    tags: ['sqlite'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Copy database files for reliability.',
+      root_cause: 'Database files were unreliable.',
+      resolution: 'Copy database files for reliability.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality accepts React Query cache invalidation fixes', () => {
   const summary = 'Invalidate React Query notes and tags cache after deleting a note so the sidebar does not show stale tag filters.';
   const root_cause = 'The note delete mutation removed the SQL row but did not invalidate the React Query tags cache, so the sidebar kept stale filter chips.';

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -296,6 +296,57 @@ test('validateMaterializedNoteQuality accepts concrete DATA_DIR Electron config 
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality rejects generic object-only mechanisms', () => {
+  const addResult = validateMaterializedNoteQuality(note({
+    title: 'Generic API config addition',
+    summary: 'Add API config because it should work.',
+    key_conclusions: ['Decision: Add API config because it should work.'],
+    raw_payload: {
+      summary: 'Add API config because it should work.',
+      outcome_type: 'decision',
+      decisions: ['Add API config because it should work.'],
+    },
+  }), { mode: 'auto' });
+  const cacheResult = validateMaterializedNoteQuality(note({
+    title: 'Generic server config cache pattern',
+    summary: 'Cache server config because it should work.',
+    key_conclusions: ['Pattern: Cache server config because it should work.'],
+    raw_payload: {
+      summary: 'Cache server config because it should work.',
+      outcome_type: 'pattern',
+      reusable_patterns: ['Cache server config because it should work.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(addResult.accepted, false);
+  assert.equal(addResult.reason, 'low-note-quality');
+  assert.ok(addResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(cacheResult.accepted, false);
+  assert.equal(cacheResult.reason, 'low-note-quality');
+  assert.ok(cacheResult.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic object-only root cause and resolution', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Generic API config fix',
+    summary: 'Add API config so the server works.',
+    key_conclusions: [
+      'Root cause: API config was wrong.',
+      'Resolution: Add API config so the server works.',
+    ],
+    raw_payload: {
+      summary: 'Add API config so the server works.',
+      outcome_type: 'fix',
+      root_cause: 'API config was wrong.',
+      resolution: 'Add API config so the server works.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects generic readiness root cause and resolution', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Server readiness generic fix',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -443,6 +443,49 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
       resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
     },
   }), { mode: 'auto' });
+  const chineseHandledResult = validateMaterializedNoteQuality(note({
+    title: 'API 注册顺序导致 /api/notes HTTP 404',
+    summary: '问题处理完，/api/notes 不再返回 HTTP 404。',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+    ],
+    tags: ['api-route'],
+    raw_payload: {
+      summary: '问题处理完，/api/notes 不再返回 HTTP 404。',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
+  const chineseFixedStableResult = validateMaterializedNoteQuality(note({
+    title: 'API 注册顺序导致 /api/notes HTTP 404',
+    summary: '这次把 /api/notes HTTP 404 修复好了，接口更稳定。',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+    ],
+    raw_payload: {
+      summary: '这次把 /api/notes HTTP 404 修复好了，接口更稳定。',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
+  const chineseRecoveredResult = validateMaterializedNoteQuality(note({
+    title: 'API 注册顺序导致 /api/notes HTTP 404',
+    summary: '/api/notes HTTP 404 已经处理，回归正常。',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+    ],
+    raw_payload: {
+      summary: '/api/notes HTTP 404 已经处理，回归正常。',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(summaryResult.accepted, false);
   assert.equal(summaryResult.reason, 'low-note-quality');
@@ -498,6 +541,37 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
   assert.equal(chineseBuildPassedResult.accepted, false);
   assert.equal(chineseBuildPassedResult.reason, 'low-note-quality');
   assert.ok(chineseBuildPassedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(chineseHandledResult.accepted, false);
+  assert.equal(chineseHandledResult.reason, 'low-note-quality');
+  assert.ok(chineseHandledResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(chineseFixedStableResult.accepted, false);
+  assert.equal(chineseFixedStableResult.reason, 'low-note-quality');
+  assert.ok(chineseFixedStableResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(chineseRecoveredResult.accepted, false);
+  assert.equal(chineseRecoveredResult.reason, 'low-note-quality');
+  assert.ok(chineseRecoveredResult.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality accepts Chinese summaries with concrete route mechanisms', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'API 注册顺序导致 /api/notes HTTP 404',
+    summary: '在 request setup 前注册 /api/notes 路由，避免 API requests 返回 HTTP 404。',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+    ],
+    tags: ['api-route'],
+    raw_payload: {
+      summary: '在 request setup 前注册 /api/notes 路由，避免 API requests 返回 HTTP 404。',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
 });
 
 test('validateMaterializedNoteQuality rejects low-quality extra key conclusions', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -4301,6 +4301,38 @@ test('validateMaterializedNoteQuality rejects broad status check shells with con
   }
 });
 
+test('validateMaterializedNoteQuality rejects no-separator status prefix shells with concrete fix payloads', () => {
+  const root_cause = 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.';
+  const resolution = 'Ensure activeRequestId matches before setResults so stale /api/search responses cannot overwrite current results.';
+  const prefixes = [
+    'Status check',
+    'Progress',
+    'Search progress',
+    'Verification note',
+    'Search completion check',
+    'Result check',
+  ];
+
+  for (const prefix of prefixes) {
+    const text = `${prefix} activeRequestId gates stale /api/search responses before setResults so older responses cannot overwrite current results.`;
+    const result = validateMaterializedNoteQuality(note({
+      title: text,
+      summary: text,
+      key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+      raw_payload: {
+        outcome_type: 'fix',
+        summary: text,
+        root_cause,
+        resolution,
+      },
+    }), { mode: 'auto' });
+
+    assert.equal(result.accepted, false, text);
+    assert.equal(result.reason, 'low-note-quality', text);
+    assert.ok(result.warnings.includes('durable_reusable_lesson'), text);
+  }
+});
+
 test('validateMaterializedNoteQuality rejects broad test and diagnostic shells with concrete fix payloads', () => {
   const root_cause = 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.';
   const resolution = 'Gate setResults with activeRequestId so stale responses cannot overwrite current results.';

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -2853,7 +2853,7 @@ test('validateMaterializedNoteQuality rejects generic import sanitization reliab
 
 test('validateMaterializedNoteQuality accepts cross-platform DATA_DIR path normalization fixes', () => {
   const summary = 'Normalize C:/Users fixture paths with path.win32 before comparing DATA_DIR output because POSIX path parsing prepends the repo path on Ubuntu runners.';
-  const root_cause = 'Ubuntu runner prepended the repository path to C:/Users/Rayner/.chatcrystal/data because Node POSIX path parsing treated the Windows DATA_DIR fixture as relative.';
+  const root_cause = 'Ubuntu runner prepended the repository path to C:/Users/FixtureUser/.chatcrystal/data because Node POSIX path parsing treated the Windows DATA_DIR fixture as relative.';
   const resolution = 'Normalize Windows DATA_DIR fixture expectations with path.win32 before comparing resolveDataDirForTest output on POSIX runners.';
   const result = validateMaterializedNoteQuality(note({
     title: 'Ubuntu treats Windows DATA_DIR fixture paths as relative',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -2978,6 +2978,27 @@ test('validateMaterializedNoteQuality accepts stale async search response fixes'
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts request-id gated stale response fixes', () => {
+  const summary = 'Gate React search result updates by the active /api/search request id so older responses cannot overwrite current results.';
+  const root_cause = 'Older /api/search responses could arrive after a newer query and overwrite current results.';
+  const resolution = 'Gate result updates by the active /api/search request id and ignore responses that are not from the latest query.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request sequence prevents stale results',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality accepts route initialization HTTP failures', () => {
   const summary = 'POST /api/import returned HTTP 500 because the route handled requests before sql.js finished initialization; wait for db initialization before accepting import requests.';
   const root_cause = 'POST /api/import returned HTTP 500 because the route handled requests before sql.js finished initialization.';
@@ -3018,6 +3039,28 @@ test('validateMaterializedNoteQuality accepts MCP stdio JSON-RPC transport fixes
   assert.equal(result.accepted, true);
   assert.equal(result.reason, 'note-quality-ok');
   assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects recorded fix completion patterns', () => {
+  const summary = 'Recorded that /api/import returned HTTP 500 before sql.js initialization and is now fixed.';
+  const result = validateMaterializedNoteQuality(note({
+    title: '/api/import HTTP 500 fix completed',
+    summary,
+    key_conclusions: [
+      `Pattern: ${summary}`,
+    ],
+    raw_payload: {
+      outcome_type: 'pattern',
+      summary,
+      reusable_patterns: [
+        summary,
+      ],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality accepts stale Vectra index cleanup fixes', () => {
@@ -3140,6 +3183,28 @@ test('validateMaterializedNoteQuality rejects generic frontend cancel reliabilit
       summary: 'Cancel requests to improve frontend reliability.',
       root_cause: 'Frontend requests were unreliable.',
       resolution: 'Cancel requests to improve frontend reliability.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic request-id gating reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request gating reliability fix',
+    summary: 'Gate requests by request id to improve search reliability.',
+    key_conclusions: [
+      'Root cause: Search requests were unreliable.',
+      'Resolution: Gate requests by request id to improve search reliability.',
+    ],
+    tags: ['search', 'frontend'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Gate requests by request id to improve search reliability.',
+      root_cause: 'Search requests were unreliable.',
+      resolution: 'Gate requests by request id to improve search reliability.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3425,6 +3425,27 @@ test('validateMaterializedNoteQuality accepts natural import transaction atomici
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts transaction-scoped advisory lock fixes', () => {
+  const summary = 'Use transaction-scoped pg_advisory_xact_lock so rollback releases the lock; session locks can survive failed jobs and block queue workers.';
+  const root_cause = 'Session-scoped pg_advisory_lock survived failed job rollbacks, so stale locks blocked queue workers after retries.';
+  const resolution = 'Use pg_advisory_xact_lock inside the job transaction so rollback releases the lock before the next retry.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Postgres advisory locks block queue workers after rollback',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality accepts indexed lookup timeout fixes', () => {
   const summary = 'Add idx_messages_conversation_id on messages.conversation_id because note detail lookups scanned the full messages table and timed out on large imports.';
   const root_cause = 'Note detail lookups filtered messages by conversation_id without an index, so large imports caused full table scans and request timeouts.';
@@ -4594,6 +4615,39 @@ test('validateMaterializedNoteQuality rejects shows and is result shells with co
   }
 });
 
+test('validateMaterializedNoteQuality rejects check and acceptance shows result shells', () => {
+  const root_cause = 'Older /api/search responses overwrote current results because setResults did not check activeRequestId before updating results.';
+  const resolution = 'Gate setResults on activeRequestId before applying /api/search responses so stale responses cannot overwrite current results.';
+  const shells = [
+    [
+      'Check shows activeRequestId gates stale /api/search responses',
+      'Check shows activeRequestId gates stale /api/search responses before setResults so older responses cannot overwrite current results.',
+    ],
+    [
+      'Acceptance shows activeRequestId gates stale /api/search responses',
+      'Acceptance shows activeRequestId gates stale /api/search responses before setResults so older responses cannot overwrite current results.',
+    ],
+  ];
+
+  for (const [title, summary] of shells) {
+    const result = validateMaterializedNoteQuality(note({
+      title,
+      summary,
+      key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+      raw_payload: {
+        outcome_type: 'fix',
+        summary,
+        root_cause,
+        resolution,
+      },
+    }), { mode: 'auto' });
+
+    assert.equal(result.accepted, false, title);
+    assert.equal(result.reason, 'low-note-quality', title);
+    assert.ok(result.warnings.includes('durable_reusable_lesson'), title);
+  }
+});
+
 test('validateMaterializedNoteQuality rejects English work record structured items', () => {
   const summary = 'Work record - use active request id gate for /api/search result updates, avoiding stale responses that overwrite current results.';
   const result = validateMaterializedNoteQuality(note({
@@ -5014,6 +5068,27 @@ test('validateMaterializedNoteQuality rejects generic transaction reliability fi
       summary: 'Use transactions for database reliability.',
       root_cause: 'Database writes were unreliable.',
       resolution: 'Use transactions for database reliability.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic lock reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Queue lock reliability fix',
+    summary: 'Use transaction locks to improve queue reliability.',
+    key_conclusions: [
+      'Root cause: Queue locks were unreliable.',
+      'Resolution: Use transaction locks to improve queue reliability.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Use transaction locks to improve queue reliability.',
+      root_cause: 'Queue locks were unreliable.',
+      resolution: 'Use transaction locks to improve queue reliability.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -126,6 +126,26 @@ test('validateMaterializedNoteQuality rejects package version status comparisons
   );
 });
 
+test('validateMaterializedNoteQuality rejects package version status comparisons with divergence wording', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Package version status comparison',
+    summary: 'Compare current package version before generated dist output because generated dist output diverged during local status checks.',
+    key_conclusions: ['Decision: Compare current package version before generated dist output because generated dist output diverged during local status checks.'],
+    raw_payload: {
+      summary: 'Compare current package version before generated dist output because generated dist output diverged during local status checks.',
+      outcome_type: 'decision',
+      decisions: ['Compare current package version before generated dist output because generated dist output diverged during local status checks.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(
+    result.warnings.includes('one_off_status') ||
+    result.warnings.includes('durable_reusable_lesson'),
+  );
+});
+
 test('validateMaterializedNoteQuality accepts reusable package version fixes', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Normalize package version parsing before dist comparison',
@@ -505,6 +525,27 @@ test('validateMaterializedNoteQuality accepts natural NODE_ENV HTTP import order
       outcome_type: 'fix',
       root_cause: 'Production API requests returned HTTP 500 because NODE_ENV config was imported after request setup.',
       resolution: 'Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts NODE_ENV import resolutions', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Production API config import ordering caused HTTP 500',
+    summary: 'Import NODE_ENV config before request setup to prevent HTTP 500 in production API requests.',
+    key_conclusions: [
+      'Root cause: Production API requests returned HTTP 500 because NODE_ENV config was imported after request setup.',
+      'Resolution: Import NODE_ENV config before request setup to prevent HTTP 500 in production API requests.',
+    ],
+    raw_payload: {
+      summary: 'Import NODE_ENV config before request setup to prevent HTTP 500 in production API requests.',
+      outcome_type: 'fix',
+      root_cause: 'Production API requests returned HTTP 500 because NODE_ENV config was imported after request setup.',
+      resolution: 'Import NODE_ENV config before request setup to prevent HTTP 500 in production API requests.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1894,6 +1894,48 @@ test('validateMaterializedNoteQuality rejects generic import sanitization reliab
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality accepts fixture provenance privacy governance fixes', () => {
+  const summary = 'Wrap experience-gate calibration samples in a dataset object with provenance and privacy assertions so fixture corpora cannot silently include raw user paths or secrets.';
+  const root_cause = 'Anonymous JSON sample arrays hid whether the experience-gate calibration corpus came from synthetic data, so future updates could commit raw local paths, private IPs, or secret-like tokens without review context.';
+  const resolution = 'Store samples under a fixture object with provenance, contains_real_user_data=false, sanitization rules, and tests that reject user paths, private IPs, credentials, and private-key text before committing calibration changes.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Calibration fixtures need synthetic provenance metadata',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects generic fixture privacy reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Fixture privacy reliability fix',
+    summary: 'Add privacy checks to fixtures so data is safer and reliable.',
+    key_conclusions: [
+      'Root cause: Fixture data was unreliable.',
+      'Resolution: Add privacy checks to fixtures so data is safer and reliable.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Add privacy checks to fixtures so data is safer and reliable.',
+      root_cause: 'Fixture data was unreliable.',
+      resolution: 'Add privacy checks to fixtures so data is safer and reliable.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality accepts concrete negative parser pitfalls', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Codex parser partial events throw TypeError',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -347,6 +347,36 @@ test('validateMaterializedNoteQuality rejects generic object-only root cause and
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects concrete identifiers with vague work rationales', () => {
+  const dataDirResult = validateMaterializedNoteQuality(note({
+    title: 'API config DATA_DIR decision',
+    summary: 'Set API config to DATA_DIR so API config should work.',
+    key_conclusions: ['Decision: Set API config to DATA_DIR so API config should work.'],
+    raw_payload: {
+      summary: 'Set API config to DATA_DIR so API config should work.',
+      outcome_type: 'decision',
+      decisions: ['Set API config to DATA_DIR so API config should work.'],
+    },
+  }), { mode: 'auto' });
+  const portResult = validateMaterializedNoteQuality(note({
+    title: 'PORT config correctness decision',
+    summary: 'Set server config to PORT because it should work correctly.',
+    key_conclusions: ['Decision: Set server config to PORT because it should work correctly.'],
+    raw_payload: {
+      summary: 'Set server config to PORT because it should work correctly.',
+      outcome_type: 'decision',
+      decisions: ['Set server config to PORT because it should work correctly.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(dataDirResult.accepted, false);
+  assert.equal(dataDirResult.reason, 'low-note-quality');
+  assert.ok(dataDirResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(portResult.accepted, false);
+  assert.equal(portResult.reason, 'low-note-quality');
+  assert.ok(portResult.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects generic readiness root cause and resolution', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Server readiness generic fix',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -250,6 +250,20 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
       resolution: 'Register /api/notes before request setup so API requests use the notes route.',
     },
   }), { mode: 'auto' });
+  const resolvedInvestigationResult = validateMaterializedNoteQuality(note({
+    title: 'Server request issue resolved after investigation',
+    summary: 'The server request issue was resolved after investigation and testing.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'The server request issue was resolved after investigation and testing.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(summaryResult.accepted, false);
   assert.equal(summaryResult.reason, 'low-note-quality');
@@ -263,6 +277,9 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
   assert.equal(routeBoilerplateResult.accepted, false);
   assert.equal(routeBoilerplateResult.reason, 'low-note-quality');
   assert.ok(routeBoilerplateResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(resolvedInvestigationResult.accepted, false);
+  assert.equal(resolvedInvestigationResult.reason, 'low-note-quality');
+  assert.ok(resolvedInvestigationResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects low-quality extra key conclusions', () => {
@@ -326,6 +343,21 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
       resolution: 'Register /api/notes before request setup so API requests use the notes route.',
     },
   }), { mode: 'auto' });
+  const validateBehaviorResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+      'Takeaway: Validate behavior.',
+    ],
+    raw_payload: {
+      summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(genericTakeawayResult.accepted, false);
   assert.equal(genericTakeawayResult.reason, 'low-note-quality');
@@ -339,6 +371,9 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
   assert.equal(routeBoilerplateResult.accepted, false);
   assert.equal(routeBoilerplateResult.reason, 'low-note-quality');
   assert.ok(routeBoilerplateResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(validateBehaviorResult.accepted, false);
+  assert.equal(validateBehaviorResult.reason, 'low-note-quality');
+  assert.ok(validateBehaviorResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects diary or status summaries with concrete conclusions', () => {
@@ -1222,6 +1257,27 @@ test('validateMaterializedNoteQuality accepts not-registered HTTP route fixes', 
       outcome_type: 'fix',
       root_cause: 'API requests returned HTTP 404 because /api/notes route was not registered before request setup.',
       resolution: 'Register /api/notes before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts concrete parser TypeError fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Codex JSONL parser skips partial response_item events',
+    summary: 'Validate response_item.content before reading Codex parser fields so partial JSONL events do not throw TypeError.',
+    key_conclusions: [
+      'Root cause: Codex JSONL parsing threw TypeError because response_item.content was read before validating the partial event shape.',
+      'Resolution: Validate response_item.content before reading parser fields and skip partial Codex events without content.',
+    ],
+    raw_payload: {
+      summary: 'Validate response_item.content before reading Codex parser fields so partial JSONL events do not throw TypeError.',
+      outcome_type: 'fix',
+      root_cause: 'Codex JSONL parsing threw TypeError because response_item.content was read before validating the partial event shape.',
+      resolution: 'Validate response_item.content before reading parser fields and skip partial Codex events without content.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1052,6 +1052,31 @@ test('validateMaterializedNoteQuality rejects fix outcomes without visible fix c
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects bare observation conclusions appended to concrete fixes', () => {
+  const summary = 'Ensure activeRequestId matches before setResults so stale /api/search responses cannot overwrite current results.';
+  const root_cause = 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.';
+  const resolution = 'Ensure activeRequestId matches before setResults so stale /api/search responses cannot overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Stale search responses overwrite current results',
+    summary,
+    key_conclusions: [
+      `Root cause: ${root_cause}`,
+      `Resolution: ${resolution}`,
+      'Observation: /api/search returned HTTP 500.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects diary or status summaries with concrete conclusions', () => {
   const diaryResult = validateMaterializedNoteQuality(note({
     title: 'Server readiness race returns ECONNREFUSED',
@@ -2951,6 +2976,27 @@ test('validateMaterializedNoteQuality accepts JSONL partial-write debounce fixes
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts JSONL event order normalization fixes', () => {
+  const summary = 'Normalize JSONL event order by timestamp before building the transcript so out-of-order writes do not invert user and assistant turns.';
+  const root_cause = 'JSONL sessions can flush events out of order, so file-order parsing can invert user and assistant turns.';
+  const resolution = 'Normalize parsed event order by timestamp before building the transcript so summarization receives the real conversation sequence.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'JSONL event order normalization preserves conversation order',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects generic import dedupe reliability fixes', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Import dedupe reliability fix',
@@ -2964,6 +3010,28 @@ test('validateMaterializedNoteQuality rejects generic import dedupe reliability 
       summary: 'Use import dedupe so imports are reliable.',
       root_cause: 'Import dedupe was unreliable.',
       resolution: 'Use import dedupe so imports are reliable.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic JSONL order reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'JSONL event order reliability fix',
+    summary: 'Normalize JSONL event order to improve transcript reliability.',
+    key_conclusions: [
+      'Root cause: JSONL event order was unreliable.',
+      'Resolution: Normalize JSONL event order to improve transcript reliability.',
+    ],
+    tags: ['jsonl', 'import'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Normalize JSONL event order to improve transcript reliability.',
+      root_cause: 'JSONL event order was unreliable.',
+      resolution: 'Normalize JSONL event order to improve transcript reliability.',
     },
   }), { mode: 'auto' });
 
@@ -5334,6 +5402,24 @@ test('validateMaterializedNoteQuality rejects generic API request validation bef
       reusable_patterns: [
         'Validate API requests before release to prevent /api/notes HTTP 404.',
       ],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects endpoint validation before release boilerplate', () => {
+  const summary = 'Validate /api/search before release because HTTP 500 request failures can happen.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Validate /api/search before release HTTP 500',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1969,6 +1969,27 @@ test('validateMaterializedNoteQuality rejects boilerplate API validation pattern
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects generic API request validation before release', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'API request validation before release prevents HTTP 404',
+    summary: 'Validate API requests before release to prevent /api/notes HTTP 404.',
+    key_conclusions: [
+      'Pattern: Validate API requests before release to prevent /api/notes HTTP 404.',
+    ],
+    raw_payload: {
+      summary: 'Validate API requests before release to prevent /api/notes HTTP 404.',
+      outcome_type: 'pattern',
+      reusable_patterns: [
+        'Validate API requests before release to prevent /api/notes HTTP 404.',
+      ],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects boilerplate config pattern claims', () => {
   const apiResult = validateMaterializedNoteQuality(note({
     title: 'Generic API config indexing decision',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -320,6 +320,20 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
       resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
     },
   }), { mode: 'auto' });
+  const localTestsSucceededResult = validateMaterializedNoteQuality(note({
+    title: 'Local tests succeeded for /api/notes HTTP 404',
+    summary: 'Local tests succeeded for the /api/notes HTTP 404 fix.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+    ],
+    raw_payload: {
+      summary: 'Local tests succeeded for the /api/notes HTTP 404 fix.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(summaryResult.accepted, false);
   assert.equal(summaryResult.reason, 'low-note-quality');
@@ -348,6 +362,9 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
   assert.equal(allGoodRouteResult.accepted, false);
   assert.equal(allGoodRouteResult.reason, 'low-note-quality');
   assert.ok(allGoodRouteResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(localTestsSucceededResult.accepted, false);
+  assert.equal(localTestsSucceededResult.reason, 'low-note-quality');
+  assert.ok(localTestsSucceededResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects low-quality extra key conclusions', () => {
@@ -593,6 +610,36 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
       resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
     },
   }), { mode: 'auto' });
+  const routeCiGreenResult = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+      'Build: CI green for /api/notes HTTP 404.',
+    ],
+    raw_payload: {
+      summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
+  const routeTestsSucceededResult = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+      'Test: Local tests succeeded for /api/notes HTTP 404.',
+    ],
+    raw_payload: {
+      summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(genericTakeawayResult.accepted, false);
   assert.equal(genericTakeawayResult.reason, 'low-note-quality');
@@ -642,6 +689,12 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
   assert.equal(routeAllGoodTakeawayResult.accepted, false);
   assert.equal(routeAllGoodTakeawayResult.reason, 'low-note-quality');
   assert.ok(routeAllGoodTakeawayResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(routeCiGreenResult.accepted, false);
+  assert.equal(routeCiGreenResult.reason, 'low-note-quality');
+  assert.ok(routeCiGreenResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(routeTestsSucceededResult.accepted, false);
+  assert.equal(routeTestsSucceededResult.reason, 'low-note-quality');
+  assert.ok(routeTestsSucceededResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects fix outcomes without visible fix conclusions', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3446,6 +3446,27 @@ test('validateMaterializedNoteQuality accepts transaction-scoped advisory lock f
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts offset commits after durable processing', () => {
+  const summary = 'Commit Kafka consumer offsets only after the database transaction commits so a crash cannot acknowledge unprocessed messages.';
+  const root_cause = 'The consumer committed offsets before the database transaction committed, so a crash acknowledged messages whose rows were never persisted.';
+  const resolution = 'Commit offsets after the database transaction commits and retry the same partition offset when persistence fails.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Kafka offset commit after processing prevents message loss',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality accepts indexed lookup timeout fixes', () => {
   const summary = 'Add idx_messages_conversation_id on messages.conversation_id because note detail lookups scanned the full messages table and timed out on large imports.';
   const root_cause = 'Note detail lookups filtered messages by conversation_id without an index, so large imports caused full table scans and request timeouts.';
@@ -4527,6 +4548,30 @@ test('validateMaterializedNoteQuality rejects smoke and acceptance pass status s
   assert.equal(englishResult.reason, 'low-note-quality');
   assert.ok(englishResult.warnings.includes('durable_reusable_lesson'));
 
+  const englishShells = [
+    'Acceptance passed activeRequestId gates stale /api/search responses before setResults so older responses cannot overwrite current results.',
+    'E2E passed activeRequestId gates stale /api/search responses before setResults so older responses cannot overwrite current results.',
+    'Scenario passed activeRequestId gates stale /api/search responses before setResults so older responses cannot overwrite current results.',
+  ];
+
+  for (const text of englishShells) {
+    const result = validateMaterializedNoteQuality(note({
+      title: text,
+      summary: text,
+      key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+      raw_payload: {
+        outcome_type: 'fix',
+        summary: text,
+        root_cause,
+        resolution,
+      },
+    }), { mode: 'auto' });
+
+    assert.equal(result.accepted, false, text);
+    assert.equal(result.reason, 'low-note-quality', text);
+    assert.ok(result.warnings.includes('durable_reusable_lesson'), text);
+  }
+
   const chineseSummary = '在 setResults 前校验 activeRequestId，避免旧的 /api/search 响应覆盖当前查询结果。';
   const chineseRootCause = '旧的 /api/search 响应覆盖当前查询结果，因为 setResults 前没有校验 activeRequestId。';
   const chineseResolution = '在 setResults 前校验 activeRequestId，避免旧的 /api/search 响应覆盖当前查询结果。';
@@ -5089,6 +5134,27 @@ test('validateMaterializedNoteQuality rejects generic lock reliability fixes', (
       summary: 'Use transaction locks to improve queue reliability.',
       root_cause: 'Queue locks were unreliable.',
       resolution: 'Use transaction locks to improve queue reliability.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic offset commit reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Kafka offset reliability fix',
+    summary: 'Commit offsets properly to improve message reliability.',
+    key_conclusions: [
+      'Root cause: Offset commits were unreliable.',
+      'Resolution: Commit offsets properly to improve message reliability.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Commit offsets properly to improve message reliability.',
+      root_cause: 'Offset commits were unreliable.',
+      resolution: 'Commit offsets properly to improve message reliability.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -2892,6 +2892,48 @@ test('validateMaterializedNoteQuality accepts import transaction atomicity fixes
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts natural import transaction atomicity fixes', () => {
+  const summary = 'Wrap each imported conversation and its messages in a sql.js transaction so a thrown message insert does not leave an incomplete conversation.';
+  const root_cause = 'The import wrote the conversation before its messages, so a thrown message insert left an incomplete conversation in sql.js.';
+  const resolution = 'Begin a sql.js transaction around each conversation and message insert and roll back when any message insert throws.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Import transaction prevents incomplete conversations',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts indexed lookup timeout fixes', () => {
+  const summary = 'Add idx_messages_conversation_id on messages.conversation_id because note detail lookups scanned the full messages table and timed out on large imports.';
+  const root_cause = 'Note detail lookups filtered messages by conversation_id without an index, so large imports caused full table scans and request timeouts.';
+  const resolution = 'Add idx_messages_conversation_id on messages.conversation_id before note detail lookups so SQLite uses an indexed lookup instead of scanning every message row.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Add messages conversation_id index to avoid request timeouts',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality accepts stale Vectra index cleanup fixes', () => {
   const root = 'Semantic search returned stale note_id hits because note deletion removed sql.js rows without removing Vectra index entries.';
   const resolution = 'Remove Vectra index entries after deleting sql.js note rows so semantic search cannot return deleted notes.';
@@ -2947,6 +2989,27 @@ test('validateMaterializedNoteQuality rejects generic transaction reliability fi
       summary: 'Use transactions for database reliability.',
       root_cause: 'Database writes were unreliable.',
       resolution: 'Use transactions for database reliability.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic index performance reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Database index reliability fix',
+    summary: 'Add indexes to improve database performance and reliability.',
+    key_conclusions: [
+      'Root cause: Database performance was unreliable.',
+      'Resolution: Add indexes to improve database performance and reliability.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Add indexes to improve database performance and reliability.',
+      root_cause: 'Database performance was unreliable.',
+      resolution: 'Add indexes to improve database performance and reliability.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -839,6 +839,36 @@ test('validateMaterializedNoteQuality rejects default data directory fallback ex
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects fallback-to-default-directory existence decisions', () => {
+  const existedResult = validateMaterializedNoteQuality(note({
+    title: 'DATA_DIR fallback existence decision',
+    summary: 'Set DATA_DIR before importing the Electron server entrypoint because fallback to the default data directory existed.',
+    key_conclusions: ['Decision: Set DATA_DIR before importing the Electron server entrypoint because fallback to the default data directory existed.'],
+    raw_payload: {
+      summary: 'Set DATA_DIR before importing the Electron server entrypoint because fallback to the default data directory existed.',
+      outcome_type: 'decision',
+      decisions: ['Set DATA_DIR before importing the Electron server entrypoint because fallback to the default data directory existed.'],
+    },
+  }), { mode: 'auto' });
+  const onDiskResult = validateMaterializedNoteQuality(note({
+    title: 'DATA_DIR fallback existence decision',
+    summary: 'Set DATA_DIR before importing the Electron server entrypoint because fallback to the default data directory was on disk.',
+    key_conclusions: ['Decision: Set DATA_DIR before importing the Electron server entrypoint because fallback to the default data directory was on disk.'],
+    raw_payload: {
+      summary: 'Set DATA_DIR before importing the Electron server entrypoint because fallback to the default data directory was on disk.',
+      outcome_type: 'decision',
+      decisions: ['Set DATA_DIR before importing the Electron server entrypoint because fallback to the default data directory was on disk.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(existedResult.accepted, false);
+  assert.equal(existedResult.reason, 'low-note-quality');
+  assert.ok(existedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(onDiskResult.accepted, false);
+  assert.equal(onDiskResult.reason, 'low-note-quality');
+  assert.ok(onDiskResult.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects generic object-only mechanisms', () => {
   const addResult = validateMaterializedNoteQuality(note({
     title: 'Generic API config addition',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -264,6 +264,20 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const reliabilityImprovementResult = validateMaterializedNoteQuality(note({
+    title: 'Server reliability improvement',
+    summary: 'Improve server reliability and correctness for future requests.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Improve server reliability and correctness for future requests.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(summaryResult.accepted, false);
   assert.equal(summaryResult.reason, 'low-note-quality');
@@ -280,6 +294,9 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
   assert.equal(resolvedInvestigationResult.accepted, false);
   assert.equal(resolvedInvestigationResult.reason, 'low-note-quality');
   assert.ok(resolvedInvestigationResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(reliabilityImprovementResult.accepted, false);
+  assert.equal(reliabilityImprovementResult.reason, 'low-note-quality');
+  assert.ok(reliabilityImprovementResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects low-quality extra key conclusions', () => {
@@ -373,6 +390,21 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const buildPassedResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+      'Build: npm test passed.',
+    ],
+    raw_payload: {
+      summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(genericTakeawayResult.accepted, false);
   assert.equal(genericTakeawayResult.reason, 'low-note-quality');
@@ -392,6 +424,28 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
   assert.equal(localTestingResult.accepted, false);
   assert.equal(localTestingResult.reason, 'low-note-quality');
   assert.ok(localTestingResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(buildPassedResult.accepted, false);
+  assert.equal(buildPassedResult.reason, 'low-note-quality');
+  assert.ok(buildPassedResult.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects fix outcomes without visible fix conclusions', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Fastify readiness prevents ECONNREFUSED',
+    summary: 'Wait for Fastify readiness before issuing API requests because ECONNREFUSED happens when client calls race server startup.',
+    key_conclusions: [
+      'Pattern: Wait for Fastify readiness before issuing API requests because ECONNREFUSED happens when client calls race server startup.',
+    ],
+    raw_payload: {
+      summary: 'Wait for Fastify readiness before issuing API requests because ECONNREFUSED happens when client calls race server startup.',
+      outcome_type: 'fix',
+      reusable_patterns: ['Wait for Fastify readiness before issuing API requests because ECONNREFUSED happens when client calls race server startup.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects diary or status summaries with concrete conclusions', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1875,6 +1875,34 @@ test('validateMaterializedNoteQuality accepts concrete parser TypeError fixes', 
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts fenced LLM JSON parsing fixes', () => {
+  const fence = '```';
+  const summary = `Strip ${fence}json markdown fences in extractJSON before JSON.parse because LLM summaries can return fenced objects that throw SyntaxError.`;
+  const root_cause = `generateText returned ${fence}json fenced output, and extractJSON passed the fence text to JSON.parse, so parsing threw SyntaxError before note fields were persisted.`;
+  const resolution = `Strip optional ${fence}json fences in extractJSON before calling JSON.parse so summarized notes persist parsed title, summary, and conclusions.`;
+  const result = validateMaterializedNoteQuality(note({
+    title: 'extractJSON must strip fenced LLM JSON',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    tags: ['llm', 'json'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+      code_snippets: [{
+        language: 'ts',
+        code: 'const parsed = JSON.parse(stripOptionalJsonFence(output));',
+        description: 'Strip optional fenced JSON before calling JSON.parse.',
+      }],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality accepts concrete schema default array fixes', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Zod optional arrays can throw during iteration',
@@ -1899,6 +1927,28 @@ test('validateMaterializedNoteQuality accepts concrete schema default array fixe
   assert.equal(result.accepted, true);
   assert.equal(result.reason, 'note-quality-ok');
   assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects placeholder snippets and generic tags', () => {
+  const result = validateMaterializedNoteQuality(note({
+    tags: ['success', 'fixed', 'reliable'],
+    raw_payload: {
+      summary: 'Requests must wait for server readiness before client calls.',
+      outcome_type: 'fix',
+      root_cause: 'Client calls raced server startup.',
+      resolution: 'Block request setup until readiness resolves.',
+      code_snippets: [{
+        language: 'text',
+        code: 'TODO',
+        description: 'fix the issue',
+      }],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('code_snippets'));
+  assert.ok(result.warnings.includes('tags'));
 });
 
 test('validateMaterializedNoteQuality accepts imported content sanitization fixes', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -2002,6 +2002,50 @@ test('validateMaterializedNoteQuality accepts concrete parser TypeError fixes', 
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts Codex content array import fixes', () => {
+  const summary = 'Extract text from response_item.content arrays while parsing Codex JSONL so imported conversations keep assistant messages instead of empty turns.';
+  const root_cause = 'The Codex adapter treated response_item.content as a plain string, so array-shaped assistant content produced empty imported conversation messages.';
+  const resolution = 'Parse response_item.content arrays and join text fragments before saving Codex conversation messages.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Codex response_item content arrays lost assistant text',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    tags: ['codex', 'import'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects generic imported content reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Imported content reliability fix',
+    summary: 'Parse imported content so messages are reliable.',
+    key_conclusions: [
+      'Root cause: Imported content reliability mattered for messages.',
+      'Resolution: Parse imported content so messages are reliable.',
+    ],
+    tags: ['import'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Parse imported content so messages are reliable.',
+      root_cause: 'Imported content reliability mattered for messages.',
+      resolution: 'Parse imported content so messages are reliable.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality accepts fenced LLM JSON parsing fixes', () => {
   const fence = '```';
   const summary = `Strip ${fence}json markdown fences in extractJSON before JSON.parse because LLM summaries can return fenced objects that throw SyntaxError.`;
@@ -2190,6 +2234,25 @@ test('validateMaterializedNoteQuality rejects identifier-only snippets', () => {
       }],
     },
   }), { mode: 'auto' });
+  const quotedPlaceholderCallResult = validateMaterializedNoteQuality(note({
+    title: 'Set DATA_DIR before importing Electron server',
+    summary: 'Set DATA_DIR before importing the Electron server so embedded startup uses the intended ChatCrystal data directory.',
+    key_conclusions: [
+      'Root cause: The Electron main process imported the server before DATA_DIR was configured, so startup used the default data directory.',
+      'Resolution: Set DATA_DIR before importing the Electron server entrypoint.',
+    ],
+    raw_payload: {
+      summary: 'Set DATA_DIR before importing the Electron server so embedded startup uses the intended ChatCrystal data directory.',
+      outcome_type: 'fix',
+      root_cause: 'The Electron main process imported the server before DATA_DIR was configured, so startup used the default data directory.',
+      resolution: 'Set DATA_DIR before importing the Electron server entrypoint.',
+      code_snippets: [{
+        language: 'ts',
+        code: 'handle("DATA_DIR")',
+        description: 'Set DATA_DIR before importing the Electron server entrypoint.',
+      }],
+    },
+  }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
@@ -2200,6 +2263,9 @@ test('validateMaterializedNoteQuality rejects identifier-only snippets', () => {
   assert.equal(placeholderCallResult.accepted, false);
   assert.equal(placeholderCallResult.reason, 'low-note-quality');
   assert.ok(placeholderCallResult.warnings.includes('code_snippets'));
+  assert.equal(quotedPlaceholderCallResult.accepted, false);
+  assert.equal(quotedPlaceholderCallResult.reason, 'low-note-quality');
+  assert.ok(quotedPlaceholderCallResult.warnings.includes('code_snippets'));
 });
 
 test('validateMaterializedNoteQuality accepts imported content sanitization fixes', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -64,6 +64,27 @@ test('validateMaterializedNoteQuality rejects one-off status records disguised a
   assert.ok(result.warnings.includes('one_off_status'));
 });
 
+test('validateMaterializedNoteQuality accepts reusable package version fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Normalize package version parsing before dist comparison',
+    summary: 'Normalize package version parsing before comparing generated dist output during local release checks.',
+    key_conclusions: [
+      'Root cause: Inconsistent package version parsing made local release dist comparisons unreliable.',
+      'Resolution: Normalize package version parsing before comparing generated dist output during local release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package version parsing before comparing generated dist output during local release checks.',
+      outcome_type: 'fix',
+      root_cause: 'Inconsistent package version parsing made local release dist comparisons unreliable.',
+      resolution: 'Normalize package version parsing before comparing generated dist output during local release checks.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects placeholder root cause and resolution fields', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Server readiness note with placeholder diagnosis',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -112,6 +112,48 @@ test('validateMaterializedNoteQuality rejects generic resolutions with concrete 
   assert.ok(validateResult.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects generic visible fixes with concrete raw payloads', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Server readiness issue resolved',
+    summary: 'The task now works correctly after the expected behavior was fixed.',
+    key_conclusions: [
+      'Root cause: The issue was fixed successfully.',
+      'Resolution: The correct behavior now works.',
+    ],
+    raw_payload: {
+      summary: 'The task now works correctly after the expected behavior was fixed.',
+      outcome_type: 'fix',
+      root_cause: 'Client calls raced server startup and produced ECONNREFUSED.',
+      resolution: 'Add request setup wait for Fastify readiness before client calls.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects visible status fixes with concrete raw payloads', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Local package version status check',
+    summary: 'Checked current local package version status and generated dist output.',
+    key_conclusions: [
+      'Root cause: Current local package status was checked.',
+      'Resolution: Generated dist output was present.',
+    ],
+    raw_payload: {
+      summary: 'Checked current local package version status and generated dist output.',
+      outcome_type: 'fix',
+      root_cause: 'Generated dist output kept stale package metadata because the version bump ran after dist generation.',
+      resolution: 'Regenerate generated dist output after bumping package metadata so release artifacts carry the new package version.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects #87-like one-off status records in auto mode', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Check local dist and linked core',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -949,6 +949,21 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
       resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
     },
   }), { mode: 'auto' });
+  const currentRunObservationResult = validateMaterializedNoteQuality(note({
+    title: 'API search activeRequestId gate prevents stale responses',
+    summary: 'Gate setResults with activeRequestId so stale /api/search responses cannot overwrite current results.',
+    key_conclusions: [
+      'Root cause: Older /api/search responses overwrote current results because setResults did not check activeRequestId.',
+      'Resolution: Gate setResults with activeRequestId so stale responses cannot overwrite current results.',
+      'Observation: /api/search returned HTTP 500 during this run.',
+    ],
+    raw_payload: {
+      summary: 'Gate setResults with activeRequestId so stale /api/search responses cannot overwrite current results.',
+      outcome_type: 'fix',
+      root_cause: 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.',
+      resolution: 'Gate setResults with activeRequestId so stale responses cannot overwrite current results.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(genericTakeawayResult.accepted, false);
   assert.equal(genericTakeawayResult.reason, 'low-note-quality');
@@ -1013,6 +1028,9 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
   assert.equal(routeCiCompletedResult.accepted, false);
   assert.equal(routeCiCompletedResult.reason, 'low-note-quality');
   assert.ok(routeCiCompletedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(currentRunObservationResult.accepted, false);
+  assert.equal(currentRunObservationResult.reason, 'low-note-quality');
+  assert.ok(currentRunObservationResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects fix outcomes without visible fix conclusions', () => {
@@ -3203,6 +3221,27 @@ test('validateMaterializedNoteQuality accepts writeback receipt uniqueness fixes
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts queue conversation_id dedupe fixes', () => {
+  const summary = 'Deduplicate queue jobs by conversation_id before enqueueing summarize work so retries reuse the pending job instead of writing duplicate notes.';
+  const root_cause = 'summarize --all retries enqueued the same conversation_id more than once, so two queue jobs wrote duplicate notes for the same conversation.';
+  const resolution = 'Deduplicate queue jobs by conversation_id before enqueueing summarize work so retries reuse the pending job instead of writing duplicate notes.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Queue conversation_id dedupe prevents duplicate notes',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality accepts SQL parameterized tag lookup fixes', () => {
   const summary = 'Bind tag names as SQL parameters because interpolated tag strings with quotes broke note tag lookup queries.';
   const root_cause = 'Tag names containing quotes broke SQL lookup queries because the notes route interpolated tag text directly into WHERE clauses.';
@@ -3300,6 +3339,27 @@ test('validateMaterializedNoteQuality accepts activeRequestId setResults stale r
     key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
     raw_payload: {
       outcome_type: 'fix',
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts activeRequestId invariant stale response fixes', () => {
+  const summary = 'Ensure activeRequestId matches before setResults so stale /api/search responses cannot overwrite current results.';
+  const root_cause = 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.';
+  const resolution = 'Ensure activeRequestId matches before setResults so stale /api/search responses cannot overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Stale search responses overwrite current results',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
       root_cause,
       resolution,
     },
@@ -3641,6 +3701,8 @@ test('validateMaterializedNoteQuality rejects Chinese technical-prefix status up
 
 test('validateMaterializedNoteQuality rejects descriptor-prefix status update shells', () => {
   const summary = 'API search status update: activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.';
+  const semanticSummary = 'Semantic search status update: activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.';
+  const chineseSummary = '语义搜索状态更新：activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.';
   const root_cause = 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.';
   const resolution = 'Gate setResults with activeRequestId so stale responses cannot overwrite current results.';
   const result = validateMaterializedNoteQuality(note({
@@ -3654,10 +3716,38 @@ test('validateMaterializedNoteQuality rejects descriptor-prefix status update sh
       resolution,
     },
   }), { mode: 'auto' });
+  const semanticResult = validateMaterializedNoteQuality(note({
+    title: semanticSummary,
+    summary: semanticSummary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: semanticSummary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+  const chineseResult = validateMaterializedNoteQuality(note({
+    title: chineseSummary,
+    summary: chineseSummary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: chineseSummary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
+  assert.equal(semanticResult.accepted, false);
+  assert.equal(semanticResult.reason, 'low-note-quality');
+  assert.ok(semanticResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(chineseResult.accepted, false);
+  assert.equal(chineseResult.reason, 'low-note-quality');
+  assert.ok(chineseResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects English work record structured items', () => {
@@ -3702,6 +3792,26 @@ test('validateMaterializedNoteQuality rejects in-this-run implementation shells'
     title: 'Search request id gate prevents stale responses',
     summary,
     key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects during-this-run implementation shells', () => {
+  const summary = 'During this run, gate setResults by activeRequestId so stale /api/search responses cannot overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    tags: [],
+    embedding_text: '',
     raw_payload: {
       outcome_type: 'decision',
       summary,
@@ -3856,6 +3966,27 @@ test('validateMaterializedNoteQuality accepts Vite proxy path rewrite fixes', ()
   const resolution = 'Disable proxy path rewrite for /api/search so search requests reach the registered Fastify route.';
   const result = validateMaterializedNoteQuality(note({
     title: 'Vite proxy preserves /api/search path',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts SPA fallback route-ordering fixes', () => {
+  const summary = 'Register /api/notes before the SPA fallback handler so API requests return JSON instead of index.html.';
+  const root_cause = '/api/notes fell through to the SPA fallback because the API route was registered after the fallback handler, so clients received index.html instead of JSON.';
+  const resolution = 'Register /api/notes before the SPA fallback handler so API requests return JSON instead of index.html.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'API route before SPA fallback returns JSON',
     summary,
     key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
     raw_payload: {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1250,6 +1250,7 @@ test('validateMaterializedNoteQuality rejects first-person implementation decisi
     'I block request setup until Fastify readiness resolves to prevent ECONNREFUSED.',
     'I place /api/notes registration before request setup so API requests do not return HTTP 404.',
     '我把 DATA_DIR set before importing the Electron server entrypoint to prevent default data directory fallback.',
+    '我已将 DATA_DIR set before importing the Electron server entrypoint to prevent fallback to the default data directory.',
   ];
 
   for (const decision of decisions) {
@@ -1976,6 +1977,9 @@ test('validateMaterializedNoteQuality rejects generic fix tags', () => {
   const statusResult = validateMaterializedNoteQuality(note({
     tags: ['bug', 'reliability', '已修复'],
   }), { mode: 'auto' });
+  const chineseStatusResult = validateMaterializedNoteQuality(note({
+    tags: ['已完成', '通过', '状态'],
+  }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
@@ -1983,6 +1987,9 @@ test('validateMaterializedNoteQuality rejects generic fix tags', () => {
   assert.equal(statusResult.accepted, false);
   assert.equal(statusResult.reason, 'low-note-quality');
   assert.ok(statusResult.warnings.includes('tags'));
+  assert.equal(chineseStatusResult.accepted, false);
+  assert.equal(chineseStatusResult.reason, 'low-note-quality');
+  assert.ok(chineseStatusResult.warnings.includes('tags'));
 });
 
 test('validateMaterializedNoteQuality rejects identifier-only snippets', () => {
@@ -2225,6 +2232,50 @@ test('validateMaterializedNoteQuality rejects generic import dedupe reliability 
       summary: 'Use import dedupe so imports are reliable.',
       root_cause: 'Import dedupe was unreliable.',
       resolution: 'Use import dedupe so imports are reliable.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality accepts React Query cache invalidation fixes', () => {
+  const summary = 'Invalidate React Query notes and tags cache after deleting a note so the sidebar does not show stale tag filters.';
+  const root_cause = 'The note delete mutation removed the SQL row but did not invalidate the React Query tags cache, so the sidebar kept stale filter chips.';
+  const resolution = 'Invalidate the notes and tags query keys after deleteNote succeeds so the UI reloads the derived tag counts.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'React Query deletion leaves stale note tags',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    tags: ['react-query', 'tags'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects generic UI cache reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'UI cache reliability fix',
+    summary: 'Invalidate UI cache for reliability.',
+    key_conclusions: [
+      'Root cause: UI cache was unreliable.',
+      'Resolution: Invalidate UI cache for reliability.',
+    ],
+    tags: ['react-query'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Invalidate UI cache for reliability.',
+      root_cause: 'UI cache was unreliable.',
+      resolution: 'Invalidate UI cache for reliability.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -189,6 +189,27 @@ test('validateMaterializedNoteQuality rejects package and dist co-occurrence wit
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects package and dist existence under because clauses', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Package version release checks',
+    summary: 'Normalize package version parsing before comparing generated dist output during release checks.',
+    key_conclusions: [
+      'Root cause: Package version existed because generated dist output was present during release checks.',
+      'Resolution: Normalize package version parsing before comparing generated dist output during release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package version parsing before comparing generated dist output during release checks.',
+      outcome_type: 'fix',
+      root_cause: 'Package version existed because generated dist output was present during release checks.',
+      resolution: 'Normalize package version parsing before comparing generated dist output during release checks.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality accepts API registration ordering HTTP failures', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'API registration ordering caused HTTP 404',
@@ -202,6 +223,27 @@ test('validateMaterializedNoteQuality accepts API registration ordering HTTP fai
       outcome_type: 'fix',
       root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
       resolution: 'Add /api/notes before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts register-based HTTP failure fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before issuing API requests.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -245,6 +245,57 @@ test('validateMaterializedNoteQuality rejects boilerplate API validation pattern
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects boilerplate config pattern claims', () => {
+  const apiResult = validateMaterializedNoteQuality(note({
+    title: 'Generic API config indexing decision',
+    summary: 'API config should index the correct pattern because correctness matters.',
+    key_conclusions: ['Decision: API config should index the correct pattern because correctness matters.'],
+    raw_payload: {
+      summary: 'API config should index the correct pattern because correctness matters.',
+      outcome_type: 'decision',
+      decisions: ['API config should index the correct pattern because correctness matters.'],
+    },
+  }), { mode: 'auto' });
+  const serverResult = validateMaterializedNoteQuality(note({
+    title: 'Generic server config cache pattern',
+    summary: 'Server config should cache the correct pattern because correctness matters.',
+    key_conclusions: ['Pattern: Server config should cache the correct pattern because correctness matters.'],
+    raw_payload: {
+      summary: 'Server config should cache the correct pattern because correctness matters.',
+      outcome_type: 'pattern',
+      reusable_patterns: ['Server config should cache the correct pattern because correctness matters.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(apiResult.accepted, false);
+  assert.equal(apiResult.reason, 'low-note-quality');
+  assert.ok(apiResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(serverResult.accepted, false);
+  assert.equal(serverResult.reason, 'low-note-quality');
+  assert.ok(serverResult.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality accepts concrete DATA_DIR Electron config fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Set DATA_DIR before importing Electron server',
+    summary: 'Set DATA_DIR before importing the Electron server so embedded startup uses the intended ChatCrystal data directory.',
+    key_conclusions: [
+      'Root cause: The Electron main process imported the server before DATA_DIR was configured, so startup used the default data directory.',
+      'Resolution: Set DATA_DIR before importing the Electron server entrypoint.',
+    ],
+    raw_payload: {
+      summary: 'Set DATA_DIR before importing the Electron server so embedded startup uses the intended ChatCrystal data directory.',
+      outcome_type: 'fix',
+      root_cause: 'The Electron main process imported the server before DATA_DIR was configured, so startup used the default data directory.',
+      resolution: 'Set DATA_DIR before importing the Electron server entrypoint.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects generic readiness root cause and resolution', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Server readiness generic fix',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -30,6 +30,27 @@ test('validateMaterializedNoteQuality accepts a readable reusable fix', () => {
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts natural readiness race fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+    key_conclusions: [
+      'Root cause: Client calls hit ECONNREFUSED because they ran before the local server was ready.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client calls hit ECONNREFUSED because they ran before the local server was ready.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects #87-like one-off status records in auto mode', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Check local dist and linked core',
@@ -77,6 +98,27 @@ test('validateMaterializedNoteQuality accepts reusable package version fixes', (
       outcome_type: 'fix',
       root_cause: 'Inconsistent package version parsing made local release dist comparisons unreliable.',
       resolution: 'Normalize package version parsing before comparing generated dist output during local release checks.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts natural package metadata and dist fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Normalize package metadata before dist comparison',
+    summary: 'Normalize package metadata before comparing generated dist output so release checks use the same version source.',
+    key_conclusions: [
+      'Root cause: Package metadata and generated dist output diverged because version parsing used different formats.',
+      'Resolution: Normalize package metadata before comparing generated dist output during release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package metadata before comparing generated dist output so release checks use the same version source.',
+      outcome_type: 'fix',
+      root_cause: 'Package metadata and generated dist output diverged because version parsing used different formats.',
+      resolution: 'Normalize package metadata before comparing generated dist output during release checks.',
     },
   }), { mode: 'auto' });
 
@@ -296,6 +338,27 @@ test('validateMaterializedNoteQuality accepts concrete DATA_DIR Electron config 
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts natural DATA_DIR import-ordering fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Configure DATA_DIR before Electron server import',
+    summary: 'Set DATA_DIR before importing the Electron server entrypoint so embedded startup uses the intended data directory.',
+    key_conclusions: [
+      'Root cause: The Electron main process imported the server before DATA_DIR was set, so startup fell back to the default data directory.',
+      'Resolution: Set DATA_DIR before importing the Electron server entrypoint.',
+    ],
+    raw_payload: {
+      summary: 'Set DATA_DIR before importing the Electron server entrypoint so embedded startup uses the intended data directory.',
+      outcome_type: 'fix',
+      root_cause: 'The Electron main process imported the server before DATA_DIR was set, so startup fell back to the default data directory.',
+      resolution: 'Set DATA_DIR before importing the Electron server entrypoint.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects generic object-only mechanisms', () => {
   const addResult = validateMaterializedNoteQuality(note({
     title: 'Generic API config addition',
@@ -401,6 +464,36 @@ test('validateMaterializedNoteQuality rejects concrete identifiers with vague wo
   assert.equal(apiResult.accepted, false);
   assert.equal(apiResult.reason, 'low-note-quality');
   assert.ok(apiResult.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects reliability rationales with concrete identifiers', () => {
+  const routeResult = validateMaterializedNoteQuality(note({
+    title: 'API notes route reliability decision',
+    summary: 'Index /api/notes before request setup timing so the route is reliable.',
+    key_conclusions: ['Decision: Index /api/notes before request setup timing so the route is reliable.'],
+    raw_payload: {
+      summary: 'Index /api/notes before request setup timing so the route is reliable.',
+      outcome_type: 'decision',
+      decisions: ['Index /api/notes before request setup timing so the route is reliable.'],
+    },
+  }), { mode: 'auto' });
+  const portResult = validateMaterializedNoteQuality(note({
+    title: 'PORT configuration reliability decision',
+    summary: 'Set PORT before importing the default data directory so configuration is reliable.',
+    key_conclusions: ['Decision: Set PORT before importing the default data directory so configuration is reliable.'],
+    raw_payload: {
+      summary: 'Set PORT before importing the default data directory so configuration is reliable.',
+      outcome_type: 'decision',
+      decisions: ['Set PORT before importing the default data directory so configuration is reliable.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(routeResult.accepted, false);
+  assert.equal(routeResult.reason, 'low-note-quality');
+  assert.ok(routeResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(portResult.accepted, false);
+  assert.equal(portResult.reason, 'low-note-quality');
+  assert.ok(portResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects generic readiness root cause and resolution', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -325,6 +325,20 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const confirmedResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'I confirmed API requests hit ECONNREFUSED before Fastify readiness.',
+    key_conclusions: [
+      'Root cause: I confirmed client calls hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'I confirmed API requests hit ECONNREFUSED before Fastify readiness.',
+      outcome_type: 'fix',
+      root_cause: 'I confirmed client calls hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(foundResult.accepted, false);
   assert.equal(foundResult.reason, 'low-note-quality');
@@ -338,6 +352,9 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
   assert.equal(discoveredResult.accepted, false);
   assert.equal(discoveredResult.reason, 'low-note-quality');
   assert.ok(discoveredResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(confirmedResult.accepted, false);
+  assert.equal(confirmedResult.reason, 'low-note-quality');
+  assert.ok(confirmedResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects #87-like one-off status records in auto mode', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -133,6 +133,65 @@ test('validateMaterializedNoteQuality rejects generic visible fixes with concret
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects generic title and summary with concrete conclusions', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Task works correctly after fix',
+    summary: 'Unknown expected behavior was fixed and task works correctly.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Unknown expected behavior was fixed and task works correctly.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects diary or status summaries with concrete conclusions', () => {
+  const diaryResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'I checked API requests and added the readiness wait.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'I checked API requests and added the readiness wait.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+  const statusResult = validateMaterializedNoteQuality(note({
+    title: 'Package version status check',
+    summary: 'Checked current local package version status and generated dist output.',
+    key_conclusions: [
+      'Root cause: Generated dist output kept stale package metadata because the version bump ran after dist generation.',
+      'Resolution: Regenerate generated dist output after bumping package metadata so release artifacts carry the new package version.',
+    ],
+    raw_payload: {
+      summary: 'Checked current local package version status and generated dist output.',
+      outcome_type: 'fix',
+      root_cause: 'Generated dist output kept stale package metadata because the version bump ran after dist generation.',
+      resolution: 'Regenerate generated dist output after bumping package metadata so release artifacts carry the new package version.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(diaryResult.accepted, false);
+  assert.equal(diaryResult.reason, 'low-note-quality');
+  assert.ok(diaryResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(statusResult.accepted, false);
+  assert.equal(statusResult.reason, 'low-note-quality');
+  assert.ok(statusResult.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects generic visible patterns with concrete raw payloads', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Reusable API request pattern',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3148,6 +3148,28 @@ test('validateMaterializedNoteQuality accepts writeback receipt uniqueness fixes
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts SQL parameterized tag lookup fixes', () => {
+  const summary = 'Bind tag names as SQL parameters because interpolated tag strings with quotes broke note tag lookup queries.';
+  const root_cause = 'Tag names containing quotes broke SQL lookup queries because the notes route interpolated tag text directly into WHERE clauses.';
+  const resolution = 'Bind tag names with sql.js parameters before running note tag lookups so quotes stay data instead of SQL syntax.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Parameterized tag queries prevent quote breakage',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    tags: ['sql-js', 'tags'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality accepts stale async search response fixes', () => {
   const summary = 'Cancel older /api/search requests because slower previous responses overwrote the current query results in the React search view.';
   const root_cause = 'React search fired overlapping /api/search requests, so a slower previous response overwrote the current query results.';
@@ -3289,6 +3311,43 @@ test('validateMaterializedNoteQuality rejects English worklog structured items',
 
 test('validateMaterializedNoteQuality rejects English result report structured items', () => {
   const summary = 'Result report: AbortController cancel older /api/search requests before stale responses overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects English change summary structured items', () => {
+  const summary = 'Change summary: use active request id gate for /api/search result updates, avoiding stale responses that overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
+    },
+    tags: ['search', 'frontend'],
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects Chinese change summary structured items', () => {
+  const summary = '变更摘要：使用 active request id gate /api/search result updates，避免 stale responses overwrite current results.';
   const result = validateMaterializedNoteQuality(note({
     title: 'Search request id gate prevents stale responses',
     summary,
@@ -3725,6 +3784,28 @@ test('validateMaterializedNoteQuality rejects generic activeRequestId reliabilit
       summary: 'Use activeRequestId to improve reliability.',
       root_cause: 'Search result reliability mattered.',
       resolution: 'Gate setResults for reliability.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic SQL parameterization reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'SQL parameter reliability fix',
+    summary: 'Bind SQL parameters for reliability.',
+    key_conclusions: [
+      'Root cause: SQL query reliability mattered.',
+      'Resolution: Use parameterized queries to improve quality.',
+    ],
+    tags: ['sql-js', 'tags'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Bind SQL parameters for reliability.',
+      root_cause: 'SQL query reliability mattered.',
+      resolution: 'Use parameterized queries to improve quality.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -85,6 +85,24 @@ test('validateMaterializedNoteQuality accepts reusable package version fixes', (
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality rejects generic environment decisions', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Checked NODE_ENV value because deployment should use production',
+    summary: 'Checked NODE_ENV value because deployment should use production.',
+    key_conclusions: ['Decision: NODE_ENV should use production pattern.'],
+    raw_payload: {
+      summary: 'Checked NODE_ENV value because deployment should use production.',
+      outcome_type: 'decision',
+      decisions: ['NODE_ENV should use production pattern.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+  assert.ok(result.warnings.includes('one_off_status'));
+});
+
 test('validateMaterializedNoteQuality rejects placeholder root cause and resolution fields', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Server readiness note with placeholder diagnosis',
@@ -98,6 +116,27 @@ test('validateMaterializedNoteQuality rejects placeholder root cause and resolut
       outcome_type: 'fix',
       root_cause: 'n/a',
       resolution: 'ok',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects long placeholder root cause and resolution fields', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Generic fix note with vague diagnosis',
+    summary: 'The task needed investigation and an appropriate change was applied.',
+    key_conclusions: [
+      'Root cause: The root cause was unknown because the task needed investigation.',
+      'Resolution: The resolution was to fix the issue with the appropriate change.',
+    ],
+    raw_payload: {
+      summary: 'The task needed investigation and an appropriate change was applied.',
+      outcome_type: 'fix',
+      root_cause: 'The root cause was unknown because the task needed investigation',
+      resolution: 'The resolution was to fix the issue with the appropriate change',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1951,6 +1951,16 @@ test('validateMaterializedNoteQuality rejects placeholder snippets and generic t
   assert.ok(result.warnings.includes('tags'));
 });
 
+test('validateMaterializedNoteQuality rejects generic fix tags', () => {
+  const result = validateMaterializedNoteQuality(note({
+    tags: ['fix'],
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('tags'));
+});
+
 test('validateMaterializedNoteQuality accepts imported content sanitization fixes', () => {
   const root = 'The Claude Code adapter saved raw JSONL message content, so <system-reminder> and <command-name> tags leaked into human-facing notes.';
   const resolution = 'Strip Claude system XML tags in sanitizeContent before saving imported conversation messages.';
@@ -1984,6 +1994,50 @@ test('validateMaterializedNoteQuality rejects generic import sanitization reliab
       summary: 'Sanitize imported content so notes are reliable.',
       root_cause: 'Imported content was unreliable.',
       resolution: 'Sanitize imported content so notes are reliable.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality accepts Electron packaged WASM resource fixes', () => {
+  const summary = 'Resolve sql-wasm.wasm from process.resourcesPath in packaged Electron builds because sql.js initialization throws ENOENT when the wasm file is not copied beside bundled server code.';
+  const root_cause = 'Packaged Electron builds threw ENOENT because sql.js loaded sql-wasm.wasm relative to bundled server code, but electron-builder did not copy the wasm resource into that location.';
+  const resolution = 'Add sql-wasm.wasm to electron-builder extraResources and resolve the sql.js wasm path from process.resourcesPath before opening chatcrystal.db.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Electron package must include sql-wasm.wasm resource',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    tags: ['electron', 'sqljs'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects generic Electron resource reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Electron resource reliability fix',
+    summary: 'Add Electron resources so packaging is reliable.',
+    key_conclusions: [
+      'Root cause: Electron packaging was unreliable.',
+      'Resolution: Add Electron resources so packaging is reliable.',
+    ],
+    tags: ['electron'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Add Electron resources so packaging is reliable.',
+      root_cause: 'Electron packaging was unreliable.',
+      resolution: 'Add Electron resources so packaging is reliable.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -486,6 +486,20 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
       resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
     },
   }), { mode: 'auto' });
+  const testsPassedMechanismResult = validateMaterializedNoteQuality(note({
+    title: 'Tests passed for Codex response_item.content array parsing',
+    summary: 'Tests passed after parsing response_item.content arrays before saving assistant messages.',
+    key_conclusions: [
+      'Root cause: Codex adapter treated response_item.content arrays as plain strings, so imported conversation messages lost assistant text.',
+      'Resolution: Parse response_item.content arrays and join text fragments before saving assistant messages.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Tests passed after parsing response_item.content arrays before saving assistant messages.',
+      root_cause: 'Codex adapter treated response_item.content arrays as plain strings, so imported conversation messages lost assistant text.',
+      resolution: 'Parse response_item.content arrays and join text fragments before saving assistant messages.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(summaryResult.accepted, false);
   assert.equal(summaryResult.reason, 'low-note-quality');
@@ -550,6 +564,9 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
   assert.equal(chineseRecoveredResult.accepted, false);
   assert.equal(chineseRecoveredResult.reason, 'low-note-quality');
   assert.ok(chineseRecoveredResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(testsPassedMechanismResult.accepted, false);
+  assert.equal(testsPassedMechanismResult.reason, 'low-note-quality');
+  assert.ok(testsPassedMechanismResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality accepts Chinese summaries with concrete route mechanisms', () => {
@@ -1285,6 +1302,20 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
       resolution: '我将 markdown fences 去掉 before JSON.parse so fenced LLM summaries persist parsed title, summary, and conclusions.',
     },
   }), { mode: 'auto' });
+  const chineseSubjectElidedResult = validateMaterializedNoteQuality(note({
+    title: 'DATA_DIR import ordering prevents default fallback',
+    summary: '已将 DATA_DIR set before importing the Electron server entrypoint to prevent fallback to the default data directory.',
+    key_conclusions: [
+      'Root cause: The Electron main process imported the server before DATA_DIR was configured, so startup used the default data directory.',
+      'Resolution: 已将 DATA_DIR set before importing the Electron server entrypoint to prevent fallback to the default data directory.',
+    ],
+    raw_payload: {
+      summary: '已将 DATA_DIR set before importing the Electron server entrypoint to prevent fallback to the default data directory.',
+      outcome_type: 'fix',
+      root_cause: 'The Electron main process imported the server before DATA_DIR was configured, so startup used the default data directory.',
+      resolution: '已将 DATA_DIR set before importing the Electron server entrypoint to prevent fallback to the default data directory.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(foundResult.accepted, false);
   assert.equal(foundResult.reason, 'low-note-quality');
@@ -1313,6 +1344,9 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
   assert.equal(chineseStripResult.accepted, false);
   assert.equal(chineseStripResult.reason, 'low-note-quality');
   assert.ok(chineseStripResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(chineseSubjectElidedResult.accepted, false);
+  assert.equal(chineseSubjectElidedResult.reason, 'low-note-quality');
+  assert.ok(chineseSubjectElidedResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects #87-like one-off status records in auto mode', () => {
@@ -2253,6 +2287,25 @@ test('validateMaterializedNoteQuality rejects identifier-only snippets', () => {
       }],
     },
   }), { mode: 'auto' });
+  const genericParseCallResult = validateMaterializedNoteQuality(note({
+    title: 'Codex response_item content arrays lost assistant text',
+    summary: 'Extract text from response_item.content arrays while parsing Codex JSONL so imported conversations keep assistant messages instead of empty turns.',
+    key_conclusions: [
+      'Root cause: The Codex adapter treated response_item.content as a plain string, so array-shaped assistant content produced empty imported conversation messages.',
+      'Resolution: Parse response_item.content arrays and join text fragments before saving Codex conversation messages.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Extract text from response_item.content arrays while parsing Codex JSONL so imported conversations keep assistant messages instead of empty turns.',
+      root_cause: 'The Codex adapter treated response_item.content as a plain string, so array-shaped assistant content produced empty imported conversation messages.',
+      resolution: 'Parse response_item.content arrays and join text fragments before saving Codex conversation messages.',
+      code_snippets: [{
+        language: 'ts',
+        code: 'parse(response_item.content)',
+        description: 'Parse response_item.content arrays before saving assistant messages.',
+      }],
+    },
+  }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
@@ -2266,6 +2319,9 @@ test('validateMaterializedNoteQuality rejects identifier-only snippets', () => {
   assert.equal(quotedPlaceholderCallResult.accepted, false);
   assert.equal(quotedPlaceholderCallResult.reason, 'low-note-quality');
   assert.ok(quotedPlaceholderCallResult.warnings.includes('code_snippets'));
+  assert.equal(genericParseCallResult.accepted, false);
+  assert.equal(genericParseCallResult.reason, 'low-note-quality');
+  assert.ok(genericParseCallResult.warnings.includes('code_snippets'));
 });
 
 test('validateMaterializedNoteQuality accepts imported content sanitization fixes', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1037,6 +1037,34 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects first-person implementation decisions with action verbs', () => {
+  const decisions = [
+    'I set DATA_DIR before importing the Electron server entrypoint to prevent fallback to the default data directory.',
+    'I configure DATA_DIR before importing the Electron server entrypoint to prevent fallback to the default data directory.',
+    'I register /api/notes before request setup so API requests do not return HTTP 404.',
+    'I wait for Fastify readiness before issuing API requests because ECONNREFUSED happens when requests race startup.',
+    'I block request setup until Fastify readiness resolves to prevent ECONNREFUSED.',
+    'I place /api/notes registration before request setup so API requests do not return HTTP 404.',
+  ];
+
+  for (const decision of decisions) {
+    const result = validateMaterializedNoteQuality(note({
+      title: decision,
+      summary: decision,
+      key_conclusions: [`Decision: ${decision}`],
+      raw_payload: {
+        summary: decision,
+        outcome_type: 'decision',
+        decisions: [decision],
+      },
+    }), { mode: 'auto' });
+
+    assert.equal(result.accepted, false, decision);
+    assert.equal(result.reason, 'low-note-quality', decision);
+    assert.ok(result.warnings.includes('durable_reusable_lesson'), decision);
+  }
+});
+
 test('validateMaterializedNoteQuality rejects one-off status records disguised as decisions', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Local package version matched dist output',
@@ -1652,6 +1680,32 @@ test('validateMaterializedNoteQuality accepts concrete parser TypeError fixes', 
       outcome_type: 'fix',
       root_cause: 'Codex JSONL parsing threw TypeError because response_item.content was read before validating the partial event shape.',
       resolution: 'Validate response_item.content before reading parser fields and skip partial Codex events without content.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts concrete schema default array fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Zod optional arrays can throw during iteration',
+    summary: 'Use z.array(ItemSchema).default([]) when handlers iterate request.items so omitted arrays do not become undefined.',
+    key_conclusions: [
+      'Root cause: z.array(ItemSchema).optional() allowed request.items to be undefined, and the handler iterated it as an array.',
+      'Resolution: Change the schema to z.array(ItemSchema).default([]) so omitted items are materialized as an empty array before handler logic runs.',
+    ],
+    raw_payload: {
+      summary: 'Use z.array(ItemSchema).default([]) when handlers iterate request.items so omitted arrays do not become undefined.',
+      outcome_type: 'fix',
+      root_cause: 'z.array(ItemSchema).optional() allowed request.items to be undefined, and the handler iterated it as an array.',
+      resolution: 'Change the schema to z.array(ItemSchema).default([]) so omitted items are materialized as an empty array before handler logic runs.',
+      code_snippets: [{
+        language: 'ts',
+        code: 'const RequestSchema = z.object({ items: z.array(ItemSchema).default([]) });',
+        description: 'Default omitted items to an empty array before iteration.',
+      }],
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -266,6 +266,49 @@ test('validateMaterializedNoteQuality rejects generic readiness root cause and r
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects error signatures with weak resolutions', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Server readiness weak ECONNREFUSED fix',
+    summary: 'Use a better approach to handle server readiness properly.',
+    key_conclusions: [
+      'Root cause: Client calls raced server startup and produced ECONNREFUSED.',
+      'Resolution: Use a better approach to handle server readiness properly.',
+      'Error signature: ECONNREFUSED.',
+    ],
+    raw_payload: {
+      summary: 'Use a better approach to handle server readiness properly.',
+      outcome_type: 'fix',
+      root_cause: 'Client calls raced server startup and produced ECONNREFUSED.',
+      resolution: 'Use a better approach to handle server readiness properly.',
+      error_signatures: ['ECONNREFUSED'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects persisted status/version decisions', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Persist local package version status',
+    summary: 'Persist checked current local package version status and generated dist output.',
+    key_conclusions: ['Decision: Persist checked current local package version status and generated dist output.'],
+    raw_payload: {
+      summary: 'Persist checked current local package version status and generated dist output.',
+      outcome_type: 'decision',
+      decisions: ['Persist checked current local package version status and generated dist output.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(
+    result.warnings.includes('one_off_status') ||
+    result.warnings.includes('durable_reusable_lesson'),
+  );
+});
+
 test('validateMaterializedNoteQuality requires visible key conclusions', () => {
   const result = validateMaterializedNoteQuality(note({
     key_conclusions: [],

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -228,6 +228,27 @@ test('validateMaterializedNoteQuality rejects generic compare and validate lesso
   assert.ok(validateResult.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects generic readiness root cause and resolution', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Server readiness generic fix',
+    summary: 'Use a better approach to handle server readiness properly.',
+    key_conclusions: [
+      'Root cause: Server readiness handling was incomplete during startup.',
+      'Resolution: Use a better approach to handle server readiness properly.',
+    ],
+    raw_payload: {
+      summary: 'Use a better approach to handle server readiness properly.',
+      outcome_type: 'fix',
+      root_cause: 'Server readiness handling was incomplete during startup.',
+      resolution: 'Use a better approach to handle server readiness properly.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality requires visible key conclusions', () => {
   const result = validateMaterializedNoteQuality(note({
     key_conclusions: [],

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -145,6 +145,57 @@ test('validateMaterializedNoteQuality rejects long placeholder root cause and re
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects vague behavior root cause and resolution claims', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Generic implementation behavior fix',
+    summary: 'Fix implementation behavior so the task works correctly going forward.',
+    key_conclusions: [
+      'Root cause: The implementation did not handle the expected behavior correctly in this task.',
+      'Resolution: Fix implementation behavior so the task works correctly going forward.',
+    ],
+    raw_payload: {
+      summary: 'Fix implementation behavior so the task works correctly going forward.',
+      outcome_type: 'fix',
+      root_cause: 'The implementation did not handle the expected behavior correctly in this task.',
+      resolution: 'Fix implementation behavior so the task works correctly going forward.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic compare and validate lessons', () => {
+  const compareResult = validateMaterializedNoteQuality(note({
+    title: 'Generic comparison decision',
+    summary: 'The task should compare values because that is the expected pattern.',
+    key_conclusions: ['Decision: The task should compare values because that is the expected pattern.'],
+    raw_payload: {
+      summary: 'The task should compare values because that is the expected pattern.',
+      outcome_type: 'decision',
+      decisions: ['The task should compare values because that is the expected pattern.'],
+    },
+  }), { mode: 'auto' });
+  const validateResult = validateMaterializedNoteQuality(note({
+    title: 'Generic validation pattern',
+    summary: 'The pattern should validate input because validation is important for correctness.',
+    key_conclusions: ['Pattern: The pattern should validate input because validation is important for correctness.'],
+    raw_payload: {
+      summary: 'The pattern should validate input because validation is important for correctness.',
+      outcome_type: 'pattern',
+      reusable_patterns: ['The pattern should validate input because validation is important for correctness.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(compareResult.accepted, false);
+  assert.equal(compareResult.reason, 'low-note-quality');
+  assert.ok(compareResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(validateResult.accepted, false);
+  assert.equal(validateResult.reason, 'low-note-quality');
+  assert.ok(validateResult.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality requires visible key conclusions', () => {
   const result = validateMaterializedNoteQuality(note({
     key_conclusions: [],

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -247,6 +247,27 @@ test('validateMaterializedNoteQuality rejects package parsing causes without dis
   assert.ok(inconsistentResult.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects package observation status causes with outcome words', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Package version release checks',
+    summary: 'Normalize package version parsing before comparing generated dist output during release checks.',
+    key_conclusions: [
+      'Root cause: Inconsistent package version parsing and generated dist output mismatch were present during release checks.',
+      'Resolution: Normalize package version parsing before comparing generated dist output during release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package version parsing before comparing generated dist output during release checks.',
+      outcome_type: 'fix',
+      root_cause: 'Inconsistent package version parsing and generated dist output mismatch were present during release checks.',
+      resolution: 'Normalize package version parsing before comparing generated dist output during release checks.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects package and dist co-occurrence without causal signal', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Package version release checks',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3980,6 +3980,45 @@ test('validateMaterializedNoteQuality rejects descriptor-prefix status update sh
   assert.ok(progressResult.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects broad status check shells with concrete fix payloads', () => {
+  const root_cause = 'Older /api/search responses overwrote current results because activeRequestId was not checked before setResults.';
+  const resolution = 'Ensure activeRequestId matches before setResults so stale /api/search responses cannot overwrite current results.';
+  const shells = [
+    'Status check: activeRequestId gates stale /api/search responses',
+    'Progress: activeRequestId gates stale /api/search responses',
+    'Search progress: activeRequestId gates stale /api/search responses',
+    'Verification: activeRequestId gates stale /api/search responses',
+    'Verification note: activeRequestId gates stale /api/search responses',
+    'Search completion check: activeRequestId gates stale /api/search responses',
+    'Result check: activeRequestId gates stale /api/search responses',
+    '状态检查：activeRequestId gates stale /api/search responses',
+    '进度：activeRequestId gates stale /api/search responses',
+    '验证：activeRequestId gates stale /api/search responses',
+    '完成检查：activeRequestId gates stale /api/search responses',
+    '结果检查：activeRequestId gates stale /api/search responses',
+  ];
+
+  for (const shell of shells) {
+    const result = validateMaterializedNoteQuality(note({
+      title: shell,
+      summary: shell,
+      key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+      raw_payload: {
+        outcome_type: 'fix',
+        summary: shell,
+        root_cause,
+        resolution,
+      },
+      tags: [],
+      embedding_text: '',
+    }), { mode: 'auto' });
+
+    assert.equal(result.accepted, false, shell);
+    assert.equal(result.reason, 'low-note-quality', shell);
+    assert.ok(result.warnings.includes('durable_reusable_lesson'), shell);
+  }
+});
+
 test('validateMaterializedNoteQuality rejects English work record structured items', () => {
   const summary = 'Work record - use active request id gate for /api/search result updates, avoiding stale responses that overwrite current results.';
   const result = validateMaterializedNoteQuality(note({

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3573,6 +3573,42 @@ test('validateMaterializedNoteQuality rejects current run implementation shells'
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects in-this-run implementation shells', () => {
+  const summary = 'In this run, gate setResults by activeRequestId so stale /api/search responses cannot overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects Chinese current-run implementation shells', () => {
+  const summary = '本轮执行 gate setResults by activeRequestId，避免 stale /api/search responses overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects completion shell structured items', () => {
   const summary = 'Completion: use active request id gate for /api/search result updates, avoiding stale responses that overwrite current results.';
   const result = validateMaterializedNoteQuality(note({
@@ -3639,6 +3675,27 @@ test('validateMaterializedNoteQuality accepts non-shell execution order notes', 
     raw_payload: {
       outcome_type: 'fix',
       summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts daemon child process lifecycle fixes', () => {
+  const summary = 'Treat child_process exit code 1 as serve failure because writing the daemon PID before the child is ready makes crystal status connect to a dead server.';
+  const root_cause = 'crystal serve -d wrote the daemon PID before observing the child_process exit event, so an exit code 1 still looked like a running server.';
+  const resolution = 'Wait for the child_process spawn handshake and reject nonzero exit codes before persisting the PID so status does not connect to a dead server.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Daemon exit code prevents false serve success',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
       root_cause,
       resolution,
     },
@@ -3876,6 +3933,27 @@ test('validateMaterializedNoteQuality rejects generic request-id gating reliabil
       summary: 'Gate requests by request id to improve search reliability.',
       root_cause: 'Search requests were unreliable.',
       resolution: 'Gate requests by request id to improve search reliability.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic daemon readiness reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Daemon readiness reliability fix',
+    summary: 'Wait for daemon readiness to improve reliability.',
+    key_conclusions: [
+      'Root cause: Daemon readiness reliability mattered.',
+      'Resolution: Handle exit code properly.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Wait for daemon readiness to improve reliability.',
+      root_cause: 'Daemon readiness reliability mattered.',
+      resolution: 'Handle exit code properly.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -2030,6 +2030,50 @@ test('validateMaterializedNoteQuality accepts fenced LLM JSON parsing fixes', ()
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts custom provider base URL HTTP fixes', () => {
+  const summary = 'Configure the custom provider base URL with /v1 because the OpenAI-compatible client calls /chat/completions relative to that base and otherwise receives HTTP 404.';
+  const root_cause = 'The custom provider returned HTTP 404 because CUSTOM_BASE_URL omitted /v1, so the OpenAI-compatible client called /chat/completions instead of /v1/chat/completions.';
+  const resolution = 'Configure CUSTOM_BASE_URL with the provider /v1 prefix before creating the OpenAI-compatible client.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Custom provider base URL causes LLM HTTP 404',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    tags: ['llm', 'custom-provider'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects generic custom provider reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Custom provider URL reliability fix',
+    summary: 'Configure provider URL so LLM is reliable.',
+    key_conclusions: [
+      'Root cause: Provider URL reliability mattered for LLM calls.',
+      'Resolution: Configure provider URL so LLM is reliable.',
+    ],
+    tags: ['llm', 'custom-provider'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Configure provider URL so LLM is reliable.',
+      root_cause: 'Provider URL reliability mattered for LLM calls.',
+      resolution: 'Configure provider URL so LLM is reliable.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality accepts concrete schema default array fixes', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Zod optional arrays can throw during iteration',
@@ -2133,6 +2177,19 @@ test('validateMaterializedNoteQuality rejects identifier-only snippets', () => {
       }],
     },
   }), { mode: 'auto' });
+  const placeholderCallResult = validateMaterializedNoteQuality(note({
+    raw_payload: {
+      summary: 'Requests must wait for server readiness before client calls.',
+      outcome_type: 'fix',
+      root_cause: 'Client calls raced server startup.',
+      resolution: 'Block request setup until readiness resolves.',
+      code_snippets: [{
+        language: 'ts',
+        code: 'fix(DATA_DIR)',
+        description: 'Set DATA_DIR before importing the Electron server entrypoint.',
+      }],
+    },
+  }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
@@ -2140,6 +2197,9 @@ test('validateMaterializedNoteQuality rejects identifier-only snippets', () => {
   assert.equal(wrappedResult.accepted, false);
   assert.equal(wrappedResult.reason, 'low-note-quality');
   assert.ok(wrappedResult.warnings.includes('code_snippets'));
+  assert.equal(placeholderCallResult.accepted, false);
+  assert.equal(placeholderCallResult.reason, 'low-note-quality');
+  assert.ok(placeholderCallResult.warnings.includes('code_snippets'));
 });
 
 test('validateMaterializedNoteQuality accepts imported content sanitization fixes', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -168,6 +168,48 @@ test('validateMaterializedNoteQuality accepts natural package metadata and dist 
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality rejects package and dist co-occurrence without causal signal', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Package version release checks',
+    summary: 'Normalize package version parsing before comparing generated dist output during release checks.',
+    key_conclusions: [
+      'Root cause: Package version and generated dist output existed during release checks.',
+      'Resolution: Normalize package version parsing before comparing generated dist output during release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package version parsing before comparing generated dist output during release checks.',
+      outcome_type: 'fix',
+      root_cause: 'Package version and generated dist output existed during release checks.',
+      resolution: 'Normalize package version parsing before comparing generated dist output during release checks.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality accepts API registration ordering HTTP failures', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Add /api/notes before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Add /api/notes before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects generic environment decisions', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Checked NODE_ENV value because deployment should use production',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -4331,6 +4331,33 @@ test('validateMaterializedNoteQuality rejects no-separator status prefix shells 
     assert.equal(result.reason, 'low-note-quality', text);
     assert.ok(result.warnings.includes('durable_reusable_lesson'), text);
   }
+
+  const descriptorPrefixes = [
+    'Status check',
+    'Progress',
+    'Verification note',
+    'Result check',
+    'Completion check',
+  ];
+
+  for (const prefix of descriptorPrefixes) {
+    const text = `${prefix} search requests gate activeRequestId before setResults so stale /api/search responses cannot overwrite current results.`;
+    const result = validateMaterializedNoteQuality(note({
+      title: text,
+      summary: text,
+      key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+      raw_payload: {
+        outcome_type: 'fix',
+        summary: text,
+        root_cause,
+        resolution,
+      },
+    }), { mode: 'auto' });
+
+    assert.equal(result.accepted, false, text);
+    assert.equal(result.reason, 'low-note-quality', text);
+    assert.ok(result.warnings.includes('durable_reusable_lesson'), text);
+  }
 });
 
 test('validateMaterializedNoteQuality rejects broad test and diagnostic shells with concrete fix payloads', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1819,6 +1819,48 @@ test('validateMaterializedNoteQuality accepts HTTP 429 queue retry fixes', () =>
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts serialized DB persistence fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Serialize sql.js writes to prevent stale DB snapshots',
+    summary: 'Queue sql.js DB writes because auto-save can persist stale chatcrystal.db bytes when imports and note updates mutate the same in-memory connection concurrently.',
+    key_conclusions: [
+      'Root cause: Import and note update tasks mutated the same sql.js Database while the 30s auto-save read chatcrystal.db bytes, so a later save could overwrite newer rows with stale state.',
+      'Resolution: Route import, summarize, and writeback DB mutations through one p-queue and call saveDatabase after the transaction so chatcrystal.db snapshots match committed rows.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Queue sql.js DB writes because auto-save can persist stale chatcrystal.db bytes when imports and note updates mutate the same in-memory connection concurrently.',
+      root_cause: 'Import and note update tasks mutated the same sql.js Database while the 30s auto-save read chatcrystal.db bytes, so a later save could overwrite newer rows with stale state.',
+      resolution: 'Route import, summarize, and writeback DB mutations through one p-queue and call saveDatabase after the transaction so chatcrystal.db snapshots match committed rows.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects generic DB queue reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'DB queue reliability fix',
+    summary: 'Queue chatcrystal.db writes so database reliability improves.',
+    key_conclusions: [
+      'Root cause: DB writes were unreliable.',
+      'Resolution: Queue chatcrystal.db writes so database reliability improves.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Queue chatcrystal.db writes so database reliability improves.',
+      root_cause: 'DB writes were unreliable.',
+      resolution: 'Queue chatcrystal.db writes so database reliability improves.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects generic HTTP root cause rationales', () => {
   const correctnessResult = validateMaterializedNoteQuality(note({
     title: 'NODE_ENV HTTP 500 fix',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -2271,6 +2271,48 @@ test('validateMaterializedNoteQuality accepts concrete schema default array fixe
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts Zod date coercion boundary fixes', () => {
+  const summary = 'Use z.coerce.date() at HTTP boundaries because JSON request bodies carry dates as strings and z.date() rejects them before handler logic runs.';
+  const root_cause = 'The route returned HTTP 400 because z.date() expected a Date instance while JSON request bodies supplied ISO date strings.';
+  const resolution = 'Use z.coerce.date() in the request schema so ISO strings convert before validation reaches handler logic.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Zod date schemas need coercion for JSON payloads',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects generic Zod validation reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Zod validation reliability fix',
+    summary: 'Use Zod validation to improve reliability.',
+    key_conclusions: [
+      'Root cause: Zod validation reliability mattered.',
+      'Resolution: Coerce inputs to avoid future issues.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Use Zod validation to improve reliability.',
+      root_cause: 'Zod validation reliability mattered.',
+      resolution: 'Coerce inputs to avoid future issues.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects placeholder snippets and generic tags', () => {
   const result = validateMaterializedNoteQuality(note({
     tags: ['success', 'fixed', 'reliable'],
@@ -3117,6 +3159,26 @@ test('validateMaterializedNoteQuality rejects English worklog structured items',
       summary,
       decisions: [summary],
     },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects English worklog dash structured items', () => {
+  const summary = 'Work log - use active request id gate for /api/search result updates, avoiding stale responses that overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
+    },
+    tags: [],
+    embedding_text: '',
   }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3327,6 +3327,60 @@ test('validateMaterializedNoteQuality rejects English result report structured i
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects bare English result structured items', () => {
+  const summary = 'Result: use active request id gate for /api/search result updates, avoiding stale responses that overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects implementation result structured items', () => {
+  const summary = 'Implementation result: use active request id gate for /api/search result updates, avoiding stale responses that overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects bare Chinese result structured items', () => {
+  const summary = '结果：使用 active request id gate /api/search result updates，避免 stale responses overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects English change summary structured items', () => {
   const summary = 'Change summary: use active request id gate for /api/search result updates, avoiding stale responses that overwrite current results.';
   const result = validateMaterializedNoteQuality(note({

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1316,6 +1316,20 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
       resolution: '已将 DATA_DIR set before importing the Electron server entrypoint to prevent fallback to the default data directory.',
     },
   }), { mode: 'auto' });
+  const chineseParsedStatusResult = validateMaterializedNoteQuality(note({
+    title: '已解析 Codex response_item.content arrays。',
+    summary: '已解析 Codex response_item.content arrays。',
+    key_conclusions: [
+      'Root cause: Codex adapter treated response_item.content arrays as plain strings, so imported conversation messages lost assistant text.',
+      'Resolution: Parse response_item.content arrays and join text fragments before saving assistant messages.',
+    ],
+    raw_payload: {
+      summary: '已解析 Codex response_item.content arrays。',
+      outcome_type: 'fix',
+      root_cause: 'Codex adapter treated response_item.content arrays as plain strings, so imported conversation messages lost assistant text.',
+      resolution: 'Parse response_item.content arrays and join text fragments before saving assistant messages.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(foundResult.accepted, false);
   assert.equal(foundResult.reason, 'low-note-quality');
@@ -1347,6 +1361,9 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
   assert.equal(chineseSubjectElidedResult.accepted, false);
   assert.equal(chineseSubjectElidedResult.reason, 'low-note-quality');
   assert.ok(chineseSubjectElidedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(chineseParsedStatusResult.accepted, false);
+  assert.equal(chineseParsedStatusResult.reason, 'low-note-quality');
+  assert.ok(chineseParsedStatusResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects #87-like one-off status records in auto mode', () => {
@@ -2213,6 +2230,9 @@ test('validateMaterializedNoteQuality rejects generic fix tags', () => {
   const decoratedResult = validateMaterializedNoteQuality(note({
     tags: ['#fixed', 'fixed.', '[fixed]', '已修复。', '#测试通过'],
   }), { mode: 'auto' });
+  const quotedDecoratedResult = validateMaterializedNoteQuality(note({
+    tags: ['`fixed`', '「测试通过」'],
+  }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
@@ -2226,6 +2246,9 @@ test('validateMaterializedNoteQuality rejects generic fix tags', () => {
   assert.equal(decoratedResult.accepted, false);
   assert.equal(decoratedResult.reason, 'low-note-quality');
   assert.ok(decoratedResult.warnings.includes('tags'));
+  assert.equal(quotedDecoratedResult.accepted, false);
+  assert.equal(quotedDecoratedResult.reason, 'low-note-quality');
+  assert.ok(quotedDecoratedResult.warnings.includes('tags'));
 });
 
 test('validateMaterializedNoteQuality rejects identifier-only snippets', () => {
@@ -2306,6 +2329,44 @@ test('validateMaterializedNoteQuality rejects identifier-only snippets', () => {
       }],
     },
   }), { mode: 'auto' });
+  const returnedGenericParseCallResult = validateMaterializedNoteQuality(note({
+    title: 'Codex response_item content arrays lost assistant text',
+    summary: 'Extract text from response_item.content arrays while parsing Codex JSONL so imported conversations keep assistant messages instead of empty turns.',
+    key_conclusions: [
+      'Root cause: The Codex adapter treated response_item.content as a plain string, so array-shaped assistant content produced empty imported conversation messages.',
+      'Resolution: Parse response_item.content arrays and join text fragments before saving Codex conversation messages.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Extract text from response_item.content arrays while parsing Codex JSONL so imported conversations keep assistant messages instead of empty turns.',
+      root_cause: 'The Codex adapter treated response_item.content as a plain string, so array-shaped assistant content produced empty imported conversation messages.',
+      resolution: 'Parse response_item.content arrays and join text fragments before saving Codex conversation messages.',
+      code_snippets: [{
+        language: 'ts',
+        code: 'return parse(response_item.content);',
+        description: 'Parse response_item.content arrays before saving assistant messages.',
+      }],
+    },
+  }), { mode: 'auto' });
+  const assignedGenericParseCallResult = validateMaterializedNoteQuality(note({
+    title: 'Codex response_item content arrays lost assistant text',
+    summary: 'Extract text from response_item.content arrays while parsing Codex JSONL so imported conversations keep assistant messages instead of empty turns.',
+    key_conclusions: [
+      'Root cause: The Codex adapter treated response_item.content as a plain string, so array-shaped assistant content produced empty imported conversation messages.',
+      'Resolution: Parse response_item.content arrays and join text fragments before saving Codex conversation messages.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Extract text from response_item.content arrays while parsing Codex JSONL so imported conversations keep assistant messages instead of empty turns.',
+      root_cause: 'The Codex adapter treated response_item.content as a plain string, so array-shaped assistant content produced empty imported conversation messages.',
+      resolution: 'Parse response_item.content arrays and join text fragments before saving Codex conversation messages.',
+      code_snippets: [{
+        language: 'ts',
+        code: 'const result = parse(response_item.content);',
+        description: 'Parse response_item.content arrays before saving assistant messages.',
+      }],
+    },
+  }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
@@ -2322,6 +2383,12 @@ test('validateMaterializedNoteQuality rejects identifier-only snippets', () => {
   assert.equal(genericParseCallResult.accepted, false);
   assert.equal(genericParseCallResult.reason, 'low-note-quality');
   assert.ok(genericParseCallResult.warnings.includes('code_snippets'));
+  assert.equal(returnedGenericParseCallResult.accepted, false);
+  assert.equal(returnedGenericParseCallResult.reason, 'low-note-quality');
+  assert.ok(returnedGenericParseCallResult.warnings.includes('code_snippets'));
+  assert.equal(assignedGenericParseCallResult.accepted, false);
+  assert.equal(assignedGenericParseCallResult.reason, 'low-note-quality');
+  assert.ok(assignedGenericParseCallResult.warnings.includes('code_snippets'));
 });
 
 test('validateMaterializedNoteQuality accepts imported content sanitization fixes', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -210,6 +210,27 @@ test('validateMaterializedNoteQuality rejects package and dist existence under b
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects package metadata existence even with dist divergence words', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Package metadata release checks',
+    summary: 'Normalize package metadata before comparing generated dist output during release checks.',
+    key_conclusions: [
+      'Root cause: Package metadata existed because generated dist output diverged during release checks.',
+      'Resolution: Normalize package metadata before comparing generated dist output during release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package metadata before comparing generated dist output during release checks.',
+      outcome_type: 'fix',
+      root_cause: 'Package metadata existed because generated dist output diverged during release checks.',
+      resolution: 'Normalize package metadata before comparing generated dist output during release checks.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality accepts API registration ordering HTTP failures', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'API registration ordering caused HTTP 404',
@@ -510,6 +531,23 @@ test('validateMaterializedNoteQuality rejects generic unreliable behavior conseq
       summary: 'Set DATA_DIR before importing the Electron server entrypoint to prevent unreliable behavior.',
       outcome_type: 'decision',
       decisions: ['Set DATA_DIR before importing the Electron server entrypoint to prevent unreliable behavior.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects default data directory existence decisions', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'DATA_DIR default directory existence decision',
+    summary: 'Set DATA_DIR before importing the Electron server entrypoint because the default data directory exists.',
+    key_conclusions: ['Decision: Set DATA_DIR before importing the Electron server entrypoint because the default data directory exists.'],
+    raw_payload: {
+      summary: 'Set DATA_DIR before importing the Electron server entrypoint because the default data directory exists.',
+      outcome_type: 'decision',
+      decisions: ['Set DATA_DIR before importing the Electron server entrypoint because the default data directory exists.'],
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3513,6 +3513,27 @@ test('validateMaterializedNoteQuality accepts activeRequestId invariant stale re
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts Chinese activeRequestId stale response fixes', () => {
+  const summary = '在 setResults 前校验 activeRequestId，避免旧的 /api/search 响应覆盖当前查询结果。';
+  const root_cause = '旧的 /api/search 响应覆盖当前查询结果，因为 setResults 前没有校验 activeRequestId。';
+  const resolution = '在 setResults 前校验 activeRequestId，避免旧的 /api/search 响应覆盖当前查询结果。';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'activeRequestId 防止语义搜索旧响应覆盖新结果',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality accepts WebSocket listener cleanup fixes', () => {
   const summary = 'Pair socket.addEventListener with socket.removeEventListener in the React useEffect cleanup so remounts do not duplicate WebSocket messages.';
   const root_cause = 'React remounts called socket.addEventListener without removing the previous message listener, so each incoming WebSocket message was appended twice.';
@@ -4016,6 +4037,61 @@ test('validateMaterializedNoteQuality rejects broad status check shells with con
     assert.equal(result.accepted, false, shell);
     assert.equal(result.reason, 'low-note-quality', shell);
     assert.ok(result.warnings.includes('durable_reusable_lesson'), shell);
+  }
+});
+
+test('validateMaterializedNoteQuality rejects broad test and diagnostic shells with concrete fix payloads', () => {
+  const root_cause = 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.';
+  const resolution = 'Gate setResults with activeRequestId so stale responses cannot overwrite current results.';
+  const shells = [
+    [
+      'Test: activeRequestId gates stale /api/search responses',
+      'Test: activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.',
+    ],
+    [
+      'Smoke test: activeRequestId gates stale /api/search responses',
+      'Smoke test: activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.',
+    ],
+    [
+      'Diagnostics: activeRequestId gates stale /api/search responses',
+      'Diagnostics: activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.',
+    ],
+    [
+      'Search diagnostics: activeRequestId gates stale /api/search responses',
+      'Search diagnostics: activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.',
+    ],
+    [
+      '测试：activeRequestId gates stale /api/search responses',
+      '测试：activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.',
+    ],
+    [
+      '测试记录：activeRequestId gates stale /api/search responses',
+      '测试记录：activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.',
+    ],
+    [
+      '诊断：activeRequestId gates stale /api/search responses',
+      '诊断：activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.',
+    ],
+  ];
+
+  for (const [title, summary] of shells) {
+    const result = validateMaterializedNoteQuality(note({
+      title,
+      summary,
+      key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+      raw_payload: {
+        outcome_type: 'fix',
+        summary,
+        root_cause,
+        resolution,
+      },
+      tags: [],
+      embedding_text: '',
+    }), { mode: 'auto' });
+
+    assert.equal(result.accepted, false, title);
+    assert.equal(result.reason, 'low-note-quality', title);
+    assert.ok(result.warnings.includes('durable_reusable_lesson'), title);
   }
 });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { MaterializedTaskMemoryNote } from '@chatcrystal/shared';
+import { validateMaterializedNoteQuality } from './quality.js';
+
+function note(overrides: Partial<MaterializedTaskMemoryNote>): MaterializedTaskMemoryNote {
+  return {
+    title: 'Server readiness race causes ECONNREFUSED',
+    summary: 'Requests must wait for server readiness before client calls.',
+    key_conclusions: [
+      'Root cause: Client calls raced server startup.',
+      'Resolution: Block request setup until readiness resolves.',
+    ],
+    embedding_text: '',
+    tags: [],
+    raw_payload: {
+      summary: 'Requests must wait for server readiness before client calls.',
+      outcome_type: 'fix',
+      root_cause: 'Client calls raced server startup.',
+      resolution: 'Block request setup until readiness resolves.',
+    },
+    ...overrides,
+  };
+}
+
+test('validateMaterializedNoteQuality accepts a readable reusable fix', () => {
+  const result = validateMaterializedNoteQuality(note({}), { mode: 'auto' });
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects #87-like one-off status records in auto mode', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Check local dist and linked core',
+    summary: 'Checked npm link, current package version, and local dist output.',
+    key_conclusions: ['Version check: local dist was behind package 0.4.9.'],
+    raw_payload: {
+      summary: 'Checked npm link, current package version, and local dist output.',
+      outcome_type: 'pattern',
+      reusable_patterns: ['Version check: local dist was behind package 0.4.9.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality requires visible key conclusions', () => {
+  const result = validateMaterializedNoteQuality(note({
+    key_conclusions: [],
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.ok(result.warnings.includes('key_conclusions'));
+});
+
+test('validateMaterializedNoteQuality allows manual readable notes with reuse warning', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Manual note about release check',
+    summary: 'The release check confirmed the current local package state.',
+    key_conclusions: ['The local package state was checked before release.'],
+    raw_payload: {
+      summary: 'The release check confirmed the current local package state.',
+      outcome_type: 'decision',
+      decisions: ['The local package state was checked before release.'],
+    },
+  }), { mode: 'manual' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'manual-note-quality-warning');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1399,6 +1399,20 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
       resolution: 'I used activeRequestId to gate setResults so stale /api/search responses do not overwrite current results.',
     },
   }), { mode: 'auto' });
+  const myFixResult = validateMaterializedNoteQuality(note({
+    title: 'My fix uses activeRequestId for search results',
+    summary: 'My fix uses activeRequestId to gate setResults so stale /api/search responses cannot overwrite current results.',
+    key_conclusions: [
+      'Root cause: Older /api/search responses overwrote current results because setResults did not check activeRequestId.',
+      'Resolution: My fix uses activeRequestId to gate setResults so stale /api/search responses cannot overwrite current results.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'My fix uses activeRequestId to gate setResults so stale /api/search responses cannot overwrite current results.',
+      root_cause: 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.',
+      resolution: 'My fix uses activeRequestId to gate setResults so stale /api/search responses cannot overwrite current results.',
+    },
+  }), { mode: 'auto' });
   const chineseLetResult = validateMaterializedNoteQuality(note({
     title: '我让 /api/notes register before request setup',
     summary: '我让 /api/notes register before request setup so API requests do not return HTTP 404.',
@@ -1454,6 +1468,9 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
   assert.equal(usedResult.accepted, false);
   assert.equal(usedResult.reason, 'low-note-quality');
   assert.ok(usedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(myFixResult.accepted, false);
+  assert.equal(myFixResult.reason, 'low-note-quality');
+  assert.ok(myFixResult.warnings.includes('durable_reusable_lesson'));
   assert.equal(chineseLetResult.accepted, false);
   assert.equal(chineseLetResult.reason, 'low-note-quality');
   assert.ok(chineseLetResult.warnings.includes('durable_reusable_lesson'));
@@ -3601,6 +3618,27 @@ test('validateMaterializedNoteQuality rejects Chinese technical-prefix status up
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects descriptor-prefix status update shells', () => {
+  const summary = 'API search status update: activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.';
+  const root_cause = 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.';
+  const resolution = 'Gate setResults with activeRequestId so stale responses cannot overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: summary,
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects English work record structured items', () => {
   const summary = 'Work record - use active request id gate for /api/search result updates, avoiding stale responses that overwrite current results.';
   const result = validateMaterializedNoteQuality(note({
@@ -3776,6 +3814,27 @@ test('validateMaterializedNoteQuality accepts route initialization HTTP failures
   const resolution = 'Wait for db initialization before accepting /api/import requests.';
   const result = validateMaterializedNoteQuality(note({
     title: 'Import route returns HTTP 500 before sql.js initialization',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts Vite proxy path rewrite fixes', () => {
+  const summary = 'Preserve the /api/search path in the Vite proxy so Fastify sees the registered route.';
+  const root_cause = 'The Vite dev proxy rewrote /api/search to /search, so Fastify returned HTTP 404 for search requests.';
+  const resolution = 'Disable proxy path rewrite for /api/search so search requests reach the registered Fastify route.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Vite proxy preserves /api/search path',
     summary,
     key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
     raw_payload: {
@@ -4181,6 +4240,27 @@ test('validateMaterializedNoteQuality rejects generic initialization reliability
       summary: 'Wait for initialization to improve API reliability.',
       root_cause: 'API initialization was unreliable.',
       resolution: 'Wait for initialization to improve API reliability.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic proxy rewrite reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Proxy routing reliability fix',
+    summary: 'Fix proxy routing for reliability.',
+    key_conclusions: [
+      'Root cause: Proxy routing reliability mattered.',
+      'Resolution: Disable proxy rewrite to improve quality.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Fix proxy routing for reliability.',
+      root_cause: 'Proxy routing reliability mattered.',
+      resolution: 'Disable proxy rewrite to improve quality.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -404,6 +404,45 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
       resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
     },
   }), { mode: 'auto' });
+  const chineseVerifiedResult = validateMaterializedNoteQuality(note({
+    title: 'API 注册顺序导致 /api/notes HTTP 404',
+    summary: '已验证 /api/notes HTTP 404 修复，测试通过。',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
+  const chineseFixedReliabilityResult = validateMaterializedNoteQuality(note({
+    title: 'API 注册顺序导致 /api/notes HTTP 404',
+    summary: '已修复 /api/notes HTTP 404，接口可靠性提高。',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
+  const chineseBuildPassedResult = validateMaterializedNoteQuality(note({
+    title: 'API 注册顺序导致 /api/notes HTTP 404',
+    summary: '构建通过，/api/notes HTTP 404 修复已验证。',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(summaryResult.accepted, false);
   assert.equal(summaryResult.reason, 'low-note-quality');
@@ -450,6 +489,15 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
   assert.equal(lintCompletedResult.accepted, false);
   assert.equal(lintCompletedResult.reason, 'low-note-quality');
   assert.ok(lintCompletedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(chineseVerifiedResult.accepted, false);
+  assert.equal(chineseVerifiedResult.reason, 'low-note-quality');
+  assert.ok(chineseVerifiedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(chineseFixedReliabilityResult.accepted, false);
+  assert.equal(chineseFixedReliabilityResult.reason, 'low-note-quality');
+  assert.ok(chineseFixedReliabilityResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(chineseBuildPassedResult.accepted, false);
+  assert.equal(chineseBuildPassedResult.reason, 'low-note-quality');
+  assert.ok(chineseBuildPassedResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects low-quality extra key conclusions', () => {
@@ -1928,6 +1976,47 @@ test('validateMaterializedNoteQuality rejects generic fixture privacy reliabilit
       summary: 'Add privacy checks to fixtures so data is safer and reliable.',
       root_cause: 'Fixture data was unreliable.',
       resolution: 'Add privacy checks to fixtures so data is safer and reliable.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality accepts watcher import dedupe fixes', () => {
+  const root_cause = 'Chokidar emitted repeated events for unchanged Claude JSONL files, so the import scan reparsed the same conversation and attempted duplicate inserts.';
+  const resolution = 'Use source file size and mtime as the import dedupe key and skip parsing when the adapter sees the same file revision again.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Watcher import dedupe prevents repeated JSONL parsing',
+    summary: 'Use source file size and mtime as the import dedupe key because unchanged Claude JSONL files can otherwise be reparsed on every chokidar event.',
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Use source file size and mtime as the import dedupe key because unchanged Claude JSONL files can otherwise be reparsed on every chokidar event.',
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects generic import dedupe reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Import dedupe reliability fix',
+    summary: 'Use import dedupe so imports are reliable.',
+    key_conclusions: [
+      'Root cause: Import dedupe was unreliable.',
+      'Resolution: Use import dedupe so imports are reliable.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Use import dedupe so imports are reliable.',
+      root_cause: 'Import dedupe was unreliable.',
+      resolution: 'Use import dedupe so imports are reliable.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1169,6 +1169,20 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const stripResult = validateMaterializedNoteQuality(note({
+    title: 'I strip fenced JSON before JSON.parse',
+    summary: 'I strip markdown fences before JSON.parse so fenced LLM summaries persist parsed title, summary, and conclusions.',
+    key_conclusions: [
+      'Root cause: LLM summaries can return fenced JSON, so passing the markdown fence text directly into JSON.parse threw SyntaxError before note fields were persisted.',
+      'Resolution: I strip markdown fences before JSON.parse so fenced LLM summaries persist parsed title, summary, and conclusions.',
+    ],
+    raw_payload: {
+      summary: 'I strip markdown fences before JSON.parse so fenced LLM summaries persist parsed title, summary, and conclusions.',
+      outcome_type: 'fix',
+      root_cause: 'LLM summaries can return fenced JSON, so passing the markdown fence text directly into JSON.parse threw SyntaxError before note fields were persisted.',
+      resolution: 'I strip markdown fences before JSON.parse so fenced LLM summaries persist parsed title, summary, and conclusions.',
+    },
+  }), { mode: 'auto' });
   const chineseDiaryResult = validateMaterializedNoteQuality(note({
     title: 'Fastify readiness 竞态导致 ECONNREFUSED',
     summary: '我添加了 Fastify readiness 等待，所以 API requests 不会在 server startup 前触发 ECONNREFUSED。',
@@ -1181,6 +1195,20 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
       outcome_type: 'fix',
       root_cause: 'API requests hit ECONNREFUSED because they ran before Fastify readiness during server startup.',
       resolution: '我添加了 Fastify readiness wait before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+  const chineseStripResult = validateMaterializedNoteQuality(note({
+    title: 'extractJSON must strip fenced LLM JSON',
+    summary: '我将 markdown fences 去掉 before JSON.parse so fenced LLM summaries persist parsed title, summary, and conclusions.',
+    key_conclusions: [
+      'Root cause: LLM summaries can return fenced JSON, so passing the markdown fence text directly into JSON.parse threw SyntaxError before note fields were persisted.',
+      'Resolution: 我将 markdown fences 去掉 before JSON.parse so fenced LLM summaries persist parsed title, summary, and conclusions.',
+    ],
+    raw_payload: {
+      summary: '我将 markdown fences 去掉 before JSON.parse so fenced LLM summaries persist parsed title, summary, and conclusions.',
+      outcome_type: 'fix',
+      root_cause: 'LLM summaries can return fenced JSON, so passing the markdown fence text directly into JSON.parse threw SyntaxError before note fields were persisted.',
+      resolution: '我将 markdown fences 去掉 before JSON.parse so fenced LLM summaries persist parsed title, summary, and conclusions.',
     },
   }), { mode: 'auto' });
 
@@ -1202,9 +1230,15 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
   assert.equal(laterSentenceResult.accepted, false);
   assert.equal(laterSentenceResult.reason, 'low-note-quality');
   assert.ok(laterSentenceResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(stripResult.accepted, false);
+  assert.equal(stripResult.reason, 'low-note-quality');
+  assert.ok(stripResult.warnings.includes('durable_reusable_lesson'));
   assert.equal(chineseDiaryResult.accepted, false);
   assert.equal(chineseDiaryResult.reason, 'low-note-quality');
   assert.ok(chineseDiaryResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(chineseStripResult.accepted, false);
+  assert.equal(chineseStripResult.reason, 'low-note-quality');
+  assert.ok(chineseStripResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects #87-like one-off status records in auto mode', () => {
@@ -1980,6 +2014,9 @@ test('validateMaterializedNoteQuality rejects generic fix tags', () => {
   const chineseStatusResult = validateMaterializedNoteQuality(note({
     tags: ['已完成', '通过', '状态'],
   }), { mode: 'auto' });
+  const decoratedResult = validateMaterializedNoteQuality(note({
+    tags: ['#fixed', 'fixed.', '[fixed]', '已修复。', '#测试通过'],
+  }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
@@ -1990,6 +2027,9 @@ test('validateMaterializedNoteQuality rejects generic fix tags', () => {
   assert.equal(chineseStatusResult.accepted, false);
   assert.equal(chineseStatusResult.reason, 'low-note-quality');
   assert.ok(chineseStatusResult.warnings.includes('tags'));
+  assert.equal(decoratedResult.accepted, false);
+  assert.equal(decoratedResult.reason, 'low-note-quality');
+  assert.ok(decoratedResult.warnings.includes('tags'));
 });
 
 test('validateMaterializedNoteQuality rejects identifier-only snippets', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -209,6 +209,27 @@ test('validateMaterializedNoteQuality accepts causal package metadata inclusion 
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality rejects package parsing causes without dist consequence', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Normalize package version parsing before dist output',
+    summary: 'Normalize package version parsing before comparing generated dist output during release checks.',
+    key_conclusions: [
+      'Root cause: Wrong package version parsing was used during generated dist output checks.',
+      'Resolution: Normalize package version parsing before comparing generated dist output during release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package version parsing before comparing generated dist output during release checks.',
+      outcome_type: 'fix',
+      root_cause: 'Wrong package version parsing was used during generated dist output checks.',
+      resolution: 'Normalize package version parsing before comparing generated dist output during release checks.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects package and dist co-occurrence without causal signal', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Package version release checks',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3127,6 +3127,27 @@ test('validateMaterializedNoteQuality accepts React Query cache invalidation fix
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts React Query queryKey filter fixes', () => {
+  const summary = 'Include the active tag filter in the React Query queryKey so the notes cache cannot reuse stale filtered rows.';
+  const root_cause = 'The React Query notes cache reused stale filtered rows because the queryKey omitted the active tag filter while the request URL changed.';
+  const resolution = 'Include the active tag filter in the React Query queryKey before fetching notes so each filter owns a separate notes cache entry.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'React Query queryKey omits tag filter',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects generic UI cache reliability fixes', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'UI cache reliability fix',
@@ -3141,6 +3162,27 @@ test('validateMaterializedNoteQuality rejects generic UI cache reliability fixes
       summary: 'Invalidate UI cache for reliability.',
       root_cause: 'UI cache was unreliable.',
       resolution: 'Invalidate UI cache for reliability.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic React Query queryKey reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'React Query key reliability fix',
+    summary: 'Include filters in React Query keys to improve cache reliability.',
+    key_conclusions: [
+      'Root cause: React Query cache reliability was wrong.',
+      'Resolution: Include filters in React Query keys to improve cache reliability.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Include filters in React Query keys to improve cache reliability.',
+      root_cause: 'React Query cache reliability was wrong.',
+      resolution: 'Include filters in React Query keys to improve cache reliability.',
     },
   }), { mode: 'auto' });
 
@@ -4314,6 +4356,46 @@ test('validateMaterializedNoteQuality rejects confirmation done and verified res
     assert.equal(result.reason, 'low-note-quality', title);
     assert.ok(result.warnings.includes('durable_reusable_lesson'), title);
   }
+});
+
+test('validateMaterializedNoteQuality rejects check-passed status shells with concrete fix payloads', () => {
+  const englishText = 'Search check passed because activeRequestId gates stale /api/search responses before setResults.';
+  const englishRootCause = 'Older /api/search responses overwrote current results because setResults ran without checking activeRequestId.';
+  const englishResolution = 'Ensure activeRequestId matches before setResults so stale /api/search responses cannot overwrite current results.';
+  const englishResult = validateMaterializedNoteQuality(note({
+    title: englishText,
+    summary: englishText,
+    key_conclusions: [`Root cause: ${englishRootCause}`, `Resolution: ${englishResolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: englishText,
+      root_cause: englishRootCause,
+      resolution: englishResolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(englishResult.accepted, false);
+  assert.equal(englishResult.reason, 'low-note-quality');
+  assert.ok(englishResult.warnings.includes('durable_reusable_lesson'));
+
+  const chineseText = '语义搜索检查已通过，因为 setResults 前校验 activeRequestId 防止旧的 /api/search 响应覆盖当前查询结果。';
+  const chineseRootCause = '旧的 /api/search 响应覆盖当前查询结果，因为 setResults 前没有校验 activeRequestId。';
+  const chineseResolution = '在 setResults 前校验 activeRequestId，防止旧的 /api/search 响应覆盖当前查询结果。';
+  const chineseResult = validateMaterializedNoteQuality(note({
+    title: chineseText,
+    summary: chineseText,
+    key_conclusions: [`Root cause: ${chineseRootCause}`, `Resolution: ${chineseResolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: chineseText,
+      root_cause: chineseRootCause,
+      resolution: chineseResolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(chineseResult.accepted, false);
+  assert.equal(chineseResult.reason, 'low-note-quality');
+  assert.ok(chineseResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects shows and is result shells with concrete fix payloads', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3774,6 +3774,39 @@ test('validateMaterializedNoteQuality accepts activeRequestId invariant stale re
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts progress UI stale loading state fixes', () => {
+  const cases = [
+    {
+      summary: 'Progress indicator API requests avoid stale loading state by gating activeRequestId before setResults.',
+      root_cause: 'Older /api/search responses overwrote the progress indicator loading state because setResults did not check activeRequestId.',
+      resolution: 'Gate progress indicator setResults on activeRequestId before applying /api/search responses.',
+    },
+    {
+      summary: 'Progress bar API requests avoid stale loading state by gating activeRequestId before setResults.',
+      root_cause: 'Older /api/search responses overwrote the progress bar loading state because setResults did not check activeRequestId.',
+      resolution: 'Gate progress bar setResults on activeRequestId before applying /api/search responses.',
+    },
+  ];
+
+  for (const item of cases) {
+    const result = validateMaterializedNoteQuality(note({
+      title: item.summary,
+      summary: item.summary,
+      key_conclusions: [`Root cause: ${item.root_cause}`, `Resolution: ${item.resolution}`],
+      raw_payload: {
+        outcome_type: 'fix',
+        summary: item.summary,
+        root_cause: item.root_cause,
+        resolution: item.resolution,
+      },
+    }), { mode: 'auto' });
+
+    assert.equal(result.accepted, true, item.summary);
+    assert.equal(result.reason, 'note-quality-ok', item.summary);
+    assert.deepEqual(result.warnings, [], item.summary);
+  }
+});
+
 test('validateMaterializedNoteQuality accepts Chinese activeRequestId stale response fixes', () => {
   const summary = '在 setResults 前校验 activeRequestId，避免旧的 /api/search 响应覆盖当前查询结果。';
   const root_cause = '旧的 /api/search 响应覆盖当前查询结果，因为 setResults 前没有校验 activeRequestId。';

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -2245,6 +2245,48 @@ test('validateMaterializedNoteQuality rejects generic custom provider reliabilit
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality accepts embedding model capability fixes', () => {
+  const summary = 'Configure embedding.provider and embedding.model separately from the LLM so semantic search calls a model that supports /v1/embeddings.';
+  const root_cause = 'Semantic search returned HTTP 500 because the configured embedding model reused the chat LLM, which did not expose a /v1/embeddings endpoint.';
+  const resolution = 'Set embedding.model to a real embedding model such as text-embedding-3-small before running semantic search.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Embedding model mismatch caused semantic search 500',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects generic embedding config reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Embedding search reliability fix',
+    summary: 'Configure embeddings for reliability.',
+    key_conclusions: [
+      'Root cause: Embedding configuration reliability mattered.',
+      'Resolution: Set embedding model to improve search.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Configure embeddings for reliability.',
+      root_cause: 'Embedding configuration reliability mattered.',
+      resolution: 'Set embedding model to improve search.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality accepts concrete schema default array fixes', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Zod optional arrays can throw during iteration',
@@ -3199,6 +3241,42 @@ test('validateMaterializedNoteQuality rejects English execution record structure
     },
     tags: [],
     embedding_text: '',
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects completion shell structured items', () => {
+  const summary = 'Completion: use active request id gate for /api/search result updates, avoiding stale responses that overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects Chinese completion shell structured items', () => {
+  const summary = '已完成：使用 active request id gate /api/search result updates，避免 stale responses overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
+    },
   }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -168,6 +168,27 @@ test('validateMaterializedNoteQuality accepts natural package metadata and dist 
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts causal package metadata inclusion fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Normalize package metadata before dist generation',
+    summary: 'Normalize package metadata before generating dist output so release checks compare the same version format.',
+    key_conclusions: [
+      'Root cause: Generated dist output included stale package metadata and diverged from package version because version normalization used different formats.',
+      'Resolution: Normalize package metadata before generating dist output during release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package metadata before generating dist output so release checks compare the same version format.',
+      outcome_type: 'fix',
+      root_cause: 'Generated dist output included stale package metadata and diverged from package version because version normalization used different formats.',
+      resolution: 'Normalize package metadata before generating dist output during release checks.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects package and dist co-occurrence without causal signal', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Package version release checks',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -91,6 +91,25 @@ test('validateMaterializedNoteQuality rejects generic resolutions with concrete 
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
+
+  const validateResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness validation prevents ECONNREFUSED',
+    summary: 'Validate server readiness to prevent future failures.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Validate server readiness to prevent future failures.',
+    ],
+    raw_payload: {
+      summary: 'Validate server readiness to prevent future failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Validate server readiness to prevent future failures.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(validateResult.accepted, false);
+  assert.equal(validateResult.reason, 'low-note-quality');
+  assert.ok(validateResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects #87-like one-off status records in auto mode', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -210,7 +210,7 @@ test('validateMaterializedNoteQuality accepts causal package metadata inclusion 
 });
 
 test('validateMaterializedNoteQuality rejects package parsing causes without dist consequence', () => {
-  const result = validateMaterializedNoteQuality(note({
+  const wrongResult = validateMaterializedNoteQuality(note({
     title: 'Normalize package version parsing before dist output',
     summary: 'Normalize package version parsing before comparing generated dist output during release checks.',
     key_conclusions: [
@@ -224,10 +224,27 @@ test('validateMaterializedNoteQuality rejects package parsing causes without dis
       resolution: 'Normalize package version parsing before comparing generated dist output during release checks.',
     },
   }), { mode: 'auto' });
+  const inconsistentResult = validateMaterializedNoteQuality(note({
+    title: 'Normalize package version parsing before dist output',
+    summary: 'Normalize package version parsing before comparing generated dist output during release checks.',
+    key_conclusions: [
+      'Root cause: Inconsistent package version parsing was used during generated dist output checks.',
+      'Resolution: Normalize package version parsing before comparing generated dist output during release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package version parsing before comparing generated dist output during release checks.',
+      outcome_type: 'fix',
+      root_cause: 'Inconsistent package version parsing was used during generated dist output checks.',
+      resolution: 'Normalize package version parsing before comparing generated dist output during release checks.',
+    },
+  }), { mode: 'auto' });
 
-  assert.equal(result.accepted, false);
-  assert.equal(result.reason, 'low-note-quality');
-  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+  assert.equal(wrongResult.accepted, false);
+  assert.equal(wrongResult.reason, 'low-note-quality');
+  assert.ok(wrongResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(inconsistentResult.accepted, false);
+  assert.equal(inconsistentResult.reason, 'low-note-quality');
+  assert.ok(inconsistentResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects package and dist co-occurrence without causal signal', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3192,6 +3192,27 @@ test('validateMaterializedNoteQuality accepts React Query queryKey filter fixes'
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts Redis cache key dimension fixes', () => {
+  const summary = 'Include tenant_id and locale in i18n cache keys because caching translations only by phrase_id reused English strings for zh-CN users.';
+  const root_cause = 'The i18n Redis cache key used phrase_id without locale, so zh-CN requests reused the cached English translation.';
+  const resolution = 'Build the cache key from tenant_id, locale, and phrase_id, and invalidate that key when translation rows change.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Redis cache key omits locale causing stale translations',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects generic UI cache reliability fixes', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'UI cache reliability fix',
@@ -4291,6 +4312,29 @@ test('validateMaterializedNoteQuality rejects broad test and diagnostic shells w
     assert.equal(result.reason, 'low-note-quality', title);
     assert.ok(result.warnings.includes('durable_reusable_lesson'), title);
   }
+});
+
+test('validateMaterializedNoteQuality rejects diagnostic evidence status wrappers with concrete fix payloads', () => {
+  const summary = 'Diagnostic evidence found /api/search returned HTTP 404 because route registration ran after request setup.';
+  const root_cause = 'API requests returned HTTP 404 because /api/search registration ran after request setup.';
+  const resolution = 'Register /api/search before request setup so API requests do not return HTTP 404.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Diagnostic evidence found /api/search route ordering caused HTTP 404',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+    tags: [],
+    embedding_text: '',
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects validation regression and QA result shells with concrete fix payloads', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1413,6 +1413,24 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
       resolution: 'My fix uses activeRequestId to gate setResults so stale /api/search responses cannot overwrite current results.',
     },
   }), { mode: 'auto' });
+  const exactMyFix = 'My fix uses activeRequestId to gate setResults so stale /api/search responses cannot overwrite current results.';
+  const exactMyFixRoot = 'Older /api/search responses overwrote current results because setResults ran without checking activeRequestId.';
+  const exactMyFixResult = validateMaterializedNoteQuality(note({
+    title: exactMyFix,
+    summary: exactMyFix,
+    key_conclusions: [
+      `Root cause: ${exactMyFixRoot}`,
+      `Resolution: ${exactMyFix}`,
+    ],
+    embedding_text: '',
+    tags: [],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: exactMyFix,
+      root_cause: exactMyFixRoot,
+      resolution: exactMyFix,
+    },
+  }), { mode: 'auto' });
   const chineseLetResult = validateMaterializedNoteQuality(note({
     title: '我让 /api/notes register before request setup',
     summary: '我让 /api/notes register before request setup so API requests do not return HTTP 404.',
@@ -1471,6 +1489,9 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
   assert.equal(myFixResult.accepted, false);
   assert.equal(myFixResult.reason, 'low-note-quality');
   assert.ok(myFixResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(exactMyFixResult.accepted, false);
+  assert.equal(exactMyFixResult.reason, 'low-note-quality');
+  assert.ok(exactMyFixResult.warnings.includes('durable_reusable_lesson'));
   assert.equal(chineseLetResult.accepted, false);
   assert.equal(chineseLetResult.reason, 'low-note-quality');
   assert.ok(chineseLetResult.warnings.includes('durable_reusable_lesson'));

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3191,6 +3191,26 @@ test('validateMaterializedNoteQuality accepts request-id gated stale response fi
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts activeRequestId setResults stale response fixes', () => {
+  const summary = 'Gate setResults by activeRequestId so stale /api/search responses cannot overwrite current results.';
+  const root_cause = 'Older /api/search responses overwrote current results because activeRequestId was not checked before setResults.';
+  const resolution = 'Gate setResults by activeRequestId so stale /api/search responses cannot overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'activeRequestId gates stale /api/search responses',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects Chinese status-shell structured items', () => {
   const summary = '状态记录：使用 active request id gate /api/search result updates，避免 stale responses overwrite current results.';
   const result = validateMaterializedNoteQuality(note({
@@ -3205,6 +3225,23 @@ test('validateMaterializedNoteQuality rejects Chinese status-shell structured it
       decisions: [
         summary,
       ],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects Chinese result-shell structured items', () => {
+  const summary = '运行结果：AbortController cancel older /api/search requests before stale responses overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: '运行结果：AbortController cancel older /api/search responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      decisions: [summary],
     },
   }), { mode: 'auto' });
 
@@ -3238,6 +3275,24 @@ test('validateMaterializedNoteQuality rejects English worklog structured items',
     summary,
     key_conclusions: [`Decision: ${summary}`],
     tags: ['search', 'frontend'],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects English result report structured items', () => {
+  const summary = 'Result report: AbortController cancel older /api/search requests before stale responses overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
     raw_payload: {
       outcome_type: 'decision',
       summary,
@@ -3649,6 +3704,27 @@ test('validateMaterializedNoteQuality rejects generic request-id gating reliabil
       summary: 'Gate requests by request id to improve search reliability.',
       root_cause: 'Search requests were unreliable.',
       resolution: 'Gate requests by request id to improve search reliability.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic activeRequestId reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search result reliability fix',
+    summary: 'Use activeRequestId to improve reliability.',
+    key_conclusions: [
+      'Root cause: Search result reliability mattered.',
+      'Resolution: Gate setResults for reliability.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Use activeRequestId to improve reliability.',
+      root_cause: 'Search result reliability mattered.',
+      resolution: 'Gate setResults for reliability.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -250,6 +250,21 @@ test('validateMaterializedNoteQuality rejects diary or status summaries with con
     },
   }), { mode: 'auto' });
 
+  const observedResult = validateMaterializedNoteQuality(note({
+    title: 'Observed Fastify readiness during API checks',
+    summary: 'Observed Fastify readiness behavior during API request checks.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Observed Fastify readiness behavior during API request checks.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+
   assert.equal(diaryResult.accepted, false);
   assert.equal(diaryResult.reason, 'low-note-quality');
   assert.ok(diaryResult.warnings.includes('durable_reusable_lesson'));
@@ -262,6 +277,9 @@ test('validateMaterializedNoteQuality rejects diary or status summaries with con
   assert.equal(foundResult.accepted, false);
   assert.equal(foundResult.reason, 'low-note-quality');
   assert.ok(foundResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(observedResult.accepted, false);
+  assert.equal(observedResult.reason, 'low-note-quality');
+  assert.ok(observedResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects generic visible patterns with concrete raw payloads', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -51,6 +51,27 @@ test('validateMaterializedNoteQuality accepts natural readiness race fixes', () 
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts readiness fixes with reliable outcome wording', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'Wait for Fastify readiness before issuing API requests so startup calls are reliable.',
+    key_conclusions: [
+      'Root cause: Client calls hit ECONNREFUSED because they ran before the local server was ready.',
+      'Resolution: Wait for Fastify readiness before issuing API requests so startup calls are reliable.',
+    ],
+    raw_payload: {
+      summary: 'Wait for Fastify readiness before issuing API requests so startup calls are reliable.',
+      outcome_type: 'fix',
+      root_cause: 'Client calls hit ECONNREFUSED because they ran before the local server was ready.',
+      resolution: 'Wait for Fastify readiness before issuing API requests so startup calls are reliable.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects #87-like one-off status records in auto mode', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Check local dist and linked core',
@@ -359,6 +380,23 @@ test('validateMaterializedNoteQuality accepts natural DATA_DIR import-ordering f
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts causal self-contained DATA_DIR decisions', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'DATA_DIR Electron import ordering decision',
+    summary: 'Set DATA_DIR before importing the Electron server entrypoint to prevent fallback to the default data directory.',
+    key_conclusions: ['Decision: Set DATA_DIR before importing the Electron server entrypoint to prevent fallback to the default data directory.'],
+    raw_payload: {
+      summary: 'Set DATA_DIR before importing the Electron server entrypoint to prevent fallback to the default data directory.',
+      outcome_type: 'decision',
+      decisions: ['Set DATA_DIR before importing the Electron server entrypoint to prevent fallback to the default data directory.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects generic object-only mechanisms', () => {
   const addResult = validateMaterializedNoteQuality(note({
     title: 'Generic API config addition',
@@ -494,6 +532,23 @@ test('validateMaterializedNoteQuality rejects reliability rationales with concre
   assert.equal(portResult.accepted, false);
   assert.equal(portResult.reason, 'low-note-quality');
   assert.ok(portResult.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects identifier order decisions without consequences', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'DATA_DIR PORT API ordering decision',
+    summary: 'Set DATA_DIR before PORT when configuring /api/notes request setup.',
+    key_conclusions: ['Decision: Set DATA_DIR before PORT when configuring /api/notes request setup.'],
+    raw_payload: {
+      summary: 'Set DATA_DIR before PORT when configuring /api/notes request setup.',
+      outcome_type: 'decision',
+      decisions: ['Set DATA_DIR before PORT when configuring /api/notes request setup.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects generic readiness root cause and resolution', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -47,6 +47,26 @@ test('validateMaterializedNoteQuality rejects #87-like one-off status records in
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects one-off status records disguised as decisions', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Local package version matched dist output',
+    summary: 'Current local package version matched the generated dist output.',
+    key_conclusions: ['Decision: Current local package version matched dist output.'],
+    raw_payload: {
+      summary: 'Current local package version matched the generated dist output.',
+      outcome_type: 'decision',
+      decisions: ['Current local package version matched the generated dist output.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(
+    result.warnings.includes('one_off_status') ||
+    result.warnings.includes('durable_reusable_lesson'),
+  );
+});
+
 test('validateMaterializedNoteQuality requires visible key conclusions', () => {
   const result = validateMaterializedNoteQuality(note({
     key_conclusions: [],

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1385,6 +1385,20 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
       resolution: 'I made /api/notes register before request setup so API requests do not return HTTP 404.',
     },
   }), { mode: 'auto' });
+  const usedResult = validateMaterializedNoteQuality(note({
+    title: 'API search activeRequestId gate prevents stale responses',
+    summary: 'I used activeRequestId to gate setResults so stale /api/search responses do not overwrite current results.',
+    key_conclusions: [
+      'Root cause: Older /api/search responses overwrote current results because setResults was not gated by the latest activeRequestId.',
+      'Resolution: I used activeRequestId to gate setResults so stale /api/search responses do not overwrite current results.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'I used activeRequestId to gate setResults so stale /api/search responses do not overwrite current results.',
+      root_cause: 'Older /api/search responses overwrote current results because setResults was not gated by the latest activeRequestId.',
+      resolution: 'I used activeRequestId to gate setResults so stale /api/search responses do not overwrite current results.',
+    },
+  }), { mode: 'auto' });
   const chineseLetResult = validateMaterializedNoteQuality(note({
     title: '我让 /api/notes register before request setup',
     summary: '我让 /api/notes register before request setup so API requests do not return HTTP 404.',
@@ -1437,6 +1451,9 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
   assert.equal(madeResult.accepted, false);
   assert.equal(madeResult.reason, 'low-note-quality');
   assert.ok(madeResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(usedResult.accepted, false);
+  assert.equal(usedResult.reason, 'low-note-quality');
+  assert.ok(usedResult.warnings.includes('durable_reusable_lesson'));
   assert.equal(chineseLetResult.accepted, false);
   assert.equal(chineseLetResult.reason, 'low-note-quality');
   assert.ok(chineseLetResult.warnings.includes('durable_reusable_lesson'));
@@ -3233,6 +3250,27 @@ test('validateMaterializedNoteQuality accepts activeRequestId setResults stale r
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts WebSocket listener cleanup fixes', () => {
+  const summary = 'Pair socket.addEventListener with socket.removeEventListener in the React useEffect cleanup so remounts do not duplicate WebSocket messages.';
+  const root_cause = 'React remounts called socket.addEventListener without removing the previous message listener, so each incoming WebSocket message was appended twice.';
+  const resolution = 'Return a useEffect cleanup that calls socket.removeEventListener before unmount so remounts keep one message listener.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'WebSocket listener cleanup prevents duplicate messages',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects Chinese status-shell structured items', () => {
   const summary = '状态记录：使用 active request id gate /api/search result updates，避免 stale responses overwrite current results.';
   const result = validateMaterializedNoteQuality(note({
@@ -3301,6 +3339,27 @@ test('validateMaterializedNoteQuality rejects English worklog structured items',
       outcome_type: 'decision',
       summary,
       decisions: [summary],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects English status entry fixes', () => {
+  const summary = 'Status entry: wait for db initialization before accepting /api/import requests so imports do not return HTTP 500.';
+  const root_cause = 'POST /api/import returned HTTP 500 because the route handled requests before sql.js finished initialization.';
+  const resolution = 'Wait for db initialization before accepting /api/import requests.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Import route returns HTTP 500 before sql.js initialization',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
     },
   }), { mode: 'auto' });
 
@@ -3860,6 +3919,27 @@ test('validateMaterializedNoteQuality rejects generic SQL parameterization relia
       summary: 'Bind SQL parameters for reliability.',
       root_cause: 'SQL query reliability mattered.',
       resolution: 'Use parameterized queries to improve quality.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic listener cleanup reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Listener cleanup reliability fix',
+    summary: 'Clean up listeners for reliability.',
+    key_conclusions: [
+      'Root cause: Listener reliability mattered.',
+      'Resolution: Use cleanup to improve quality.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Clean up listeners for reliability.',
+      root_cause: 'Listener reliability mattered.',
+      resolution: 'Use cleanup to improve quality.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -133,6 +133,23 @@ test('validateMaterializedNoteQuality rejects generic visible fixes with concret
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects generic visible patterns with concrete raw payloads', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Reusable API request pattern',
+    summary: 'Use the correct pattern so API behavior works reliably across future tasks.',
+    key_conclusions: ['Pattern: Use the correct pattern for API behavior.'],
+    raw_payload: {
+      summary: 'Use the correct pattern so API behavior works reliably across future tasks.',
+      outcome_type: 'pattern',
+      reusable_patterns: ['Wait for Fastify readiness before issuing API requests because ECONNREFUSED happens when client calls race server startup.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects visible status fixes with concrete raw payloads', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Local package version status check',
@@ -146,6 +163,27 @@ test('validateMaterializedNoteQuality rejects visible status fixes with concrete
       outcome_type: 'fix',
       root_cause: 'Generated dist output kept stale package metadata because the version bump ran after dist generation.',
       resolution: 'Regenerate generated dist output after bumping package metadata so release artifacts carry the new package version.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects first-person implementation diary fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Readiness implementation diary fix',
+    summary: 'I checked API requests and added the readiness wait.',
+    key_conclusions: [
+      'Root cause: I checked API requests and they hit ECONNREFUSED because client calls raced server startup.',
+      'Resolution: I added Fastify readiness wait before issuing API requests so startup calls are reliable.',
+    ],
+    raw_payload: {
+      summary: 'I checked API requests and added the readiness wait.',
+      outcome_type: 'fix',
+      root_cause: 'I checked API requests and they hit ECONNREFUSED because client calls raced server startup.',
+      resolution: 'I added Fastify readiness wait before issuing API requests so startup calls are reliable.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1231,6 +1231,25 @@ test('validateMaterializedNoteQuality rejects visible status fixes with concrete
   assert.equal(verificationResult.accepted, false);
   assert.equal(verificationResult.reason, 'low-note-quality');
   assert.ok(verificationResult.warnings.includes('durable_reusable_lesson'));
+
+  const verificationConfirmedResult = validateMaterializedNoteQuality(note({
+    title: 'Search verification confirmed activeRequestId gates stale /api/search responses',
+    summary: 'The verification confirmed activeRequestId matches before setResults so stale /api/search responses cannot overwrite current results.',
+    key_conclusions: [
+      'Root cause: Older /api/search responses overwrote current results because setResults did not check activeRequestId.',
+      'Resolution: Ensure activeRequestId matches before setResults so stale /api/search responses cannot overwrite current results.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'The verification confirmed activeRequestId matches before setResults so stale /api/search responses cannot overwrite current results.',
+      root_cause: 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.',
+      resolution: 'Ensure activeRequestId matches before setResults so stale /api/search responses cannot overwrite current results.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(verificationConfirmedResult.accepted, false);
+  assert.equal(verificationConfirmedResult.reason, 'low-note-quality');
+  assert.ok(verificationConfirmedResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects first-person implementation diary fixes', () => {
@@ -1436,6 +1455,20 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
       resolution: 'I used activeRequestId to gate setResults so stale /api/search responses do not overwrite current results.',
     },
   }), { mode: 'auto' });
+  const ensuredResult = validateMaterializedNoteQuality(note({
+    title: 'I ensured activeRequestId gates stale /api/search responses',
+    summary: 'I ensured activeRequestId matches before setResults so stale /api/search responses cannot overwrite current results.',
+    key_conclusions: [
+      'Root cause: Older /api/search responses overwrote current results because setResults did not check activeRequestId.',
+      'Resolution: Ensure activeRequestId matches before setResults so stale /api/search responses cannot overwrite current results.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'I ensured activeRequestId matches before setResults so stale /api/search responses cannot overwrite current results.',
+      root_cause: 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.',
+      resolution: 'Ensure activeRequestId matches before setResults so stale /api/search responses cannot overwrite current results.',
+    },
+  }), { mode: 'auto' });
   const myFixResult = validateMaterializedNoteQuality(note({
     title: 'My fix uses activeRequestId for search results',
     summary: 'My fix uses activeRequestId to gate setResults so stale /api/search responses cannot overwrite current results.',
@@ -1523,6 +1556,9 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
   assert.equal(usedResult.accepted, false);
   assert.equal(usedResult.reason, 'low-note-quality');
   assert.ok(usedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(ensuredResult.accepted, false);
+  assert.equal(ensuredResult.reason, 'low-note-quality');
+  assert.ok(ensuredResult.warnings.includes('durable_reusable_lesson'));
   assert.equal(myFixResult.accepted, false);
   assert.equal(myFixResult.reason, 'low-note-quality');
   assert.ok(myFixResult.warnings.includes('durable_reusable_lesson'));
@@ -3314,6 +3350,25 @@ test('validateMaterializedNoteQuality accepts SQL parameterized tag lookup fixes
   assert.equal(syntaxResult.accepted, true);
   assert.equal(syntaxResult.reason, 'note-quality-ok');
   assert.deepEqual(syntaxResult.warnings, []);
+
+  const payloadSummary = 'Use SQL parameters for tag filters so user-controlled tag text stays data instead of executable SQL.';
+  const payloadRootCause = 'Interpolated tag text let a crafted tag payload change the SQL WHERE clause syntax.';
+  const payloadResolution = 'Bind tag values as sql.js parameters instead of interpolating tag text into WHERE clauses.';
+  const payloadResult = validateMaterializedNoteQuality(note({
+    title: 'Parameterized tag queries prevent SQL syntax injection',
+    summary: payloadSummary,
+    key_conclusions: [`Root cause: ${payloadRootCause}`, `Resolution: ${payloadResolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: payloadSummary,
+      root_cause: payloadRootCause,
+      resolution: payloadResolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(payloadResult.accepted, true);
+  assert.equal(payloadResult.reason, 'note-quality-ok');
+  assert.deepEqual(payloadResult.warnings, []);
 });
 
 test('validateMaterializedNoteQuality accepts SQLite migration backfill constraint fixes', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -328,6 +328,44 @@ test('validateMaterializedNoteQuality rejects package metadata detected or obser
   assert.ok(observedResult.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects active package artifact observation causes', () => {
+  const observedResult = validateMaterializedNoteQuality(note({
+    title: 'Package metadata release checks',
+    summary: 'Normalize package metadata before comparing generated dist output during release checks.',
+    key_conclusions: [
+      'Root cause: Observed package metadata because generated dist output diverged during release checks.',
+      'Resolution: Normalize package metadata before comparing generated dist output during release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package metadata before comparing generated dist output during release checks.',
+      outcome_type: 'fix',
+      root_cause: 'Observed package metadata because generated dist output diverged during release checks.',
+      resolution: 'Normalize package metadata before comparing generated dist output during release checks.',
+    },
+  }), { mode: 'auto' });
+  const foundResult = validateMaterializedNoteQuality(note({
+    title: 'Package version release checks',
+    summary: 'Normalize package version parsing before comparing generated dist output during release checks.',
+    key_conclusions: [
+      'Root cause: Found package version because generated dist output diverged during release checks.',
+      'Resolution: Normalize package version parsing before comparing generated dist output during release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package version parsing before comparing generated dist output during release checks.',
+      outcome_type: 'fix',
+      root_cause: 'Found package version because generated dist output diverged during release checks.',
+      resolution: 'Normalize package version parsing before comparing generated dist output during release checks.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(observedResult.accepted, false);
+  assert.equal(observedResult.reason, 'low-note-quality');
+  assert.ok(observedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(foundResult.accepted, false);
+  assert.equal(foundResult.reason, 'low-note-quality');
+  assert.ok(foundResult.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality accepts API registration ordering HTTP failures', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'API registration ordering caused HTTP 404',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -50,21 +50,39 @@ test('validateMaterializedNoteQuality rejects #87-like one-off status records in
 test('validateMaterializedNoteQuality rejects one-off status records disguised as decisions', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Local package version matched dist output',
-    summary: 'Current local package version matched the generated dist output.',
-    key_conclusions: ['Decision: Current local package version matched dist output.'],
+    summary: 'Current local package version should match the generated dist output.',
+    key_conclusions: ['Decision: Current local package version should match generated dist output.'],
     raw_payload: {
-      summary: 'Current local package version matched the generated dist output.',
+      summary: 'Current local package version should match the generated dist output.',
       outcome_type: 'decision',
-      decisions: ['Current local package version matched the generated dist output.'],
+      decisions: ['Current local package version should match the generated dist output.'],
     },
   }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
-  assert.ok(
-    result.warnings.includes('one_off_status') ||
-    result.warnings.includes('durable_reusable_lesson'),
-  );
+  assert.ok(result.warnings.includes('one_off_status'));
+});
+
+test('validateMaterializedNoteQuality rejects placeholder root cause and resolution fields', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Server readiness note with placeholder diagnosis',
+    summary: 'Requests must wait for server readiness before client calls.',
+    key_conclusions: [
+      'Root cause: n/a.',
+      'Resolution: ok.',
+    ],
+    raw_payload: {
+      summary: 'Requests must wait for server readiness before client calls.',
+      outcome_type: 'fix',
+      root_cause: 'n/a',
+      resolution: 'ok',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality requires visible key conclusions', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -417,6 +417,23 @@ test('validateMaterializedNoteQuality accepts causal self-contained DATA_DIR dec
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality rejects generic unreliable behavior consequences', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'DATA_DIR import ordering prevents unreliable behavior',
+    summary: 'Set DATA_DIR before importing the Electron server entrypoint to prevent unreliable behavior.',
+    key_conclusions: ['Decision: Set DATA_DIR before importing the Electron server entrypoint to prevent unreliable behavior.'],
+    raw_payload: {
+      summary: 'Set DATA_DIR before importing the Electron server entrypoint to prevent unreliable behavior.',
+      outcome_type: 'decision',
+      decisions: ['Set DATA_DIR before importing the Electron server entrypoint to prevent unreliable behavior.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects generic object-only mechanisms', () => {
   const addResult = validateMaterializedNoteQuality(note({
     title: 'Generic API config addition',
@@ -601,6 +618,27 @@ test('validateMaterializedNoteQuality rejects generic readiness root cause and r
       outcome_type: 'fix',
       root_cause: 'Server readiness handling was incomplete during startup.',
       resolution: 'Use a better approach to handle server readiness properly.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects readiness fixes with weak root causes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Server readiness generic fix',
+    summary: 'Wait for server readiness before API requests.',
+    key_conclusions: [
+      'Root cause: Server readiness was not correct before API requests.',
+      'Resolution: Wait for server readiness before API requests.',
+    ],
+    raw_payload: {
+      summary: 'Wait for server readiness before API requests.',
+      outcome_type: 'fix',
+      root_cause: 'Server readiness was not correct before API requests.',
+      resolution: 'Wait for server readiness before API requests.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -2658,6 +2658,28 @@ test('validateMaterializedNoteQuality accepts watcher import dedupe fixes', () =
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts JSONL partial-write debounce fixes', () => {
+  const summary = 'Debounce chokidar JSONL imports until file size and mtime stop changing because parsing while Claude Code is appending can read truncated lines and drop the latest messages.';
+  const root_cause = 'Chokidar fired while Claude Code was still appending JSONL, so the adapter parsed a truncated line and dropped the latest imported conversation messages.';
+  const resolution = 'Debounce imports until file size and mtime stay stable before parsing the JSONL file so partial writes are skipped.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Debounce JSONL imports until appends stabilize',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    tags: ['import', 'jsonl'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects generic import dedupe reliability fixes', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Import dedupe reliability fix',
@@ -2671,6 +2693,28 @@ test('validateMaterializedNoteQuality rejects generic import dedupe reliability 
       summary: 'Use import dedupe so imports are reliable.',
       root_cause: 'Import dedupe was unreliable.',
       resolution: 'Use import dedupe so imports are reliable.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic JSONL import debounce reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'JSONL import reliability fix',
+    summary: 'Debounce imports to improve reliability.',
+    key_conclusions: [
+      'Root cause: JSONL imports were unreliable.',
+      'Resolution: Debounce imports to improve reliability.',
+    ],
+    tags: ['import', 'jsonl'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Debounce imports to improve reliability.',
+      root_cause: 'JSONL imports were unreliable.',
+      resolution: 'Debounce imports to improve reliability.',
     },
   }), { mode: 'auto' });
 
@@ -3052,6 +3096,25 @@ test('validateMaterializedNoteQuality rejects Chinese worklog structured items',
     raw_payload: {
       summary,
       outcome_type: 'decision',
+      decisions: [summary],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects English worklog structured items', () => {
+  const summary = 'Worklog: use active request id gate for /api/search result updates, avoiding stale responses that overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    tags: ['search', 'frontend'],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
       decisions: [summary],
     },
   }), { mode: 'auto' });

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -500,6 +500,21 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
       resolution: 'Parse response_item.content arrays and join text fragments before saving assistant messages.',
     },
   }), { mode: 'auto' });
+  const httpSuccessStatusResult = validateMaterializedNoteQuality(note({
+    title: '/api/notes returns HTTP 200 after registration before request setup',
+    summary: '/api/notes now returns HTTP 200 after route registration runs before request setup.',
+    key_conclusions: [
+      'Root cause: /api/notes returned HTTP 404 because route registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+    ],
+    tags: ['api-route'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: '/api/notes now returns HTTP 200 after route registration runs before request setup.',
+      root_cause: '/api/notes returned HTTP 404 because route registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(summaryResult.accepted, false);
   assert.equal(summaryResult.reason, 'low-note-quality');
@@ -567,6 +582,9 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
   assert.equal(testsPassedMechanismResult.accepted, false);
   assert.equal(testsPassedMechanismResult.reason, 'low-note-quality');
   assert.ok(testsPassedMechanismResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(httpSuccessStatusResult.accepted, false);
+  assert.equal(httpSuccessStatusResult.reason, 'low-note-quality');
+  assert.ok(httpSuccessStatusResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality accepts Chinese summaries with concrete route mechanisms', () => {
@@ -1330,6 +1348,36 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
       resolution: 'Parse response_item.content arrays and join text fragments before saving assistant messages.',
     },
   }), { mode: 'auto' });
+  const madeResult = validateMaterializedNoteQuality(note({
+    title: 'I made /api/notes register before request setup',
+    summary: 'I made /api/notes register before request setup so API requests do not return HTTP 404.',
+    key_conclusions: [
+      'Root cause: /api/notes returned HTTP 404 because route registration ran after request setup.',
+      'Resolution: I made /api/notes register before request setup so API requests do not return HTTP 404.',
+    ],
+    tags: ['api-route'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'I made /api/notes register before request setup so API requests do not return HTTP 404.',
+      root_cause: '/api/notes returned HTTP 404 because route registration ran after request setup.',
+      resolution: 'I made /api/notes register before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
+  const chineseLetResult = validateMaterializedNoteQuality(note({
+    title: '我让 /api/notes register before request setup',
+    summary: '我让 /api/notes register before request setup so API requests do not return HTTP 404.',
+    key_conclusions: [
+      'Root cause: /api/notes returned HTTP 404 because route registration ran after request setup.',
+      'Resolution: 我让 /api/notes register before request setup so API requests do not return HTTP 404.',
+    ],
+    tags: ['api-route'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: '我让 /api/notes register before request setup so API requests do not return HTTP 404.',
+      root_cause: '/api/notes returned HTTP 404 because route registration ran after request setup.',
+      resolution: '我让 /api/notes register before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(foundResult.accepted, false);
   assert.equal(foundResult.reason, 'low-note-quality');
@@ -1364,6 +1412,12 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
   assert.equal(chineseParsedStatusResult.accepted, false);
   assert.equal(chineseParsedStatusResult.reason, 'low-note-quality');
   assert.ok(chineseParsedStatusResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(madeResult.accepted, false);
+  assert.equal(madeResult.reason, 'low-note-quality');
+  assert.ok(madeResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(chineseLetResult.accepted, false);
+  assert.equal(chineseLetResult.reason, 'low-note-quality');
+  assert.ok(chineseLetResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects #87-like one-off status records in auto mode', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -413,6 +413,7 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
     ],
     raw_payload: {
       outcome_type: 'fix',
+      summary: '已验证 /api/notes HTTP 404 修复，测试通过。',
       root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
       resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
     },
@@ -426,6 +427,7 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
     ],
     raw_payload: {
       outcome_type: 'fix',
+      summary: '已修复 /api/notes HTTP 404，接口可靠性提高。',
       root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
       resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
     },
@@ -439,6 +441,7 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
     ],
     raw_payload: {
       outcome_type: 'fix',
+      summary: '构建通过，/api/notes HTTP 404 修复已验证。',
       root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
       resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
     },
@@ -3743,6 +3746,7 @@ test('validateMaterializedNoteQuality accepts activeRequestId setResults stale r
     key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
     raw_payload: {
       outcome_type: 'fix',
+      summary,
       root_cause,
       resolution,
     },
@@ -3879,6 +3883,7 @@ test('validateMaterializedNoteQuality rejects Chinese result-shell structured it
     key_conclusions: [`Decision: ${summary}`],
     raw_payload: {
       outcome_type: 'decision',
+      summary,
       decisions: [summary],
     },
   }), { mode: 'auto' });

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -249,6 +249,25 @@ test('validateMaterializedNoteQuality accepts package version bump dist regenera
   assert.equal(result.accepted, true);
   assert.equal(result.reason, 'note-quality-ok');
   assert.deepEqual(result.warnings, []);
+
+  const inverseResult = validateMaterializedNoteQuality(note({
+    title: 'Regenerate dist after package version bump',
+    summary: 'Regenerate generated dist output after bumping package metadata so release artifacts carry the new package version.',
+    key_conclusions: [
+      'Root cause: Generated dist output stayed stale because dist generation ran before the package metadata version bump.',
+      'Resolution: Regenerate generated dist output after bumping package metadata so release artifacts carry the new package version.',
+    ],
+    raw_payload: {
+      summary: 'Regenerate generated dist output after bumping package metadata so release artifacts carry the new package version.',
+      outcome_type: 'fix',
+      root_cause: 'Generated dist output stayed stale because dist generation ran before the package metadata version bump.',
+      resolution: 'Regenerate generated dist output after bumping package metadata so release artifacts carry the new package version.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(inverseResult.accepted, true);
+  assert.equal(inverseResult.reason, 'note-quality-ok');
+  assert.deepEqual(inverseResult.warnings, []);
 });
 
 test('validateMaterializedNoteQuality rejects package parsing causes without dist consequence', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -236,6 +236,20 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const routeBoilerplateResult = validateMaterializedNoteQuality(note({
+    title: 'API reliability fix for /api/notes',
+    summary: 'This /api/notes reliability fix prevents future failures in the expected workflow.',
+    key_conclusions: [
+      'Root cause: /api/notes returned HTTP 404 because the route was not registered before request setup.',
+      'Resolution: Register /api/notes before request setup so API requests use the notes route.',
+    ],
+    raw_payload: {
+      summary: 'This /api/notes reliability fix prevents future failures in the expected workflow.',
+      outcome_type: 'fix',
+      root_cause: '/api/notes returned HTTP 404 because the route was not registered before request setup.',
+      resolution: 'Register /api/notes before request setup so API requests use the notes route.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(summaryResult.accepted, false);
   assert.equal(summaryResult.reason, 'low-note-quality');
@@ -246,6 +260,9 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
   assert.equal(futureFailureResult.accepted, false);
   assert.equal(futureFailureResult.reason, 'low-note-quality');
   assert.ok(futureFailureResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(routeBoilerplateResult.accepted, false);
+  assert.equal(routeBoilerplateResult.reason, 'low-note-quality');
+  assert.ok(routeBoilerplateResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects low-quality extra key conclusions', () => {
@@ -294,6 +311,21 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const routeBoilerplateResult = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Register /api/notes before request setup to prevent HTTP 404.',
+    key_conclusions: [
+      'Root cause: /api/notes returned HTTP 404 because the route was not registered before request setup.',
+      'Resolution: Register /api/notes before request setup so API requests use the notes route.',
+      'Takeaway: This /api/notes reliability fix prevents future failures in the expected workflow.',
+    ],
+    raw_payload: {
+      summary: 'Register /api/notes before request setup to prevent HTTP 404.',
+      outcome_type: 'fix',
+      root_cause: '/api/notes returned HTTP 404 because the route was not registered before request setup.',
+      resolution: 'Register /api/notes before request setup so API requests use the notes route.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(genericTakeawayResult.accepted, false);
   assert.equal(genericTakeawayResult.reason, 'low-note-quality');
@@ -304,6 +336,9 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
   assert.equal(releaseValidationResult.accepted, false);
   assert.equal(releaseValidationResult.reason, 'low-note-quality');
   assert.ok(releaseValidationResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(routeBoilerplateResult.accepted, false);
+  assert.equal(routeBoilerplateResult.reason, 'low-note-quality');
+  assert.ok(routeBoilerplateResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects diary or status summaries with concrete conclusions', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3186,6 +3186,66 @@ test('validateMaterializedNoteQuality rejects English worklog dash structured it
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects English execution record structured items', () => {
+  const summary = 'Execution record: use active request id gate for /api/search result updates, avoiding stale responses that overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
+    },
+    tags: [],
+    embedding_text: '',
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects Chinese execution record structured items', () => {
+  const summary = '执行记录：使用 active request id gate /api/search result updates，避免 stale responses overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
+    },
+    tags: [],
+    embedding_text: '',
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality accepts non-shell execution order notes', () => {
+  const root_cause = 'API requests returned HTTP 404 because /api/notes registration ran after request setup.';
+  const resolution = 'Register /api/notes before request setup so API requests do not return HTTP 404.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'API registration execution order caused HTTP 404',
+    summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality accepts route initialization HTTP failures', () => {
   const summary = 'POST /api/import returned HTTP 500 because the route handled requests before sql.js finished initialization; wait for db initialization before accepting import requests.';
   const root_cause = 'POST /api/import returned HTTP 500 because the route handled requests before sql.js finished initialization.';

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -150,6 +150,25 @@ test('validateMaterializedNoteQuality rejects generic visible fixes with concret
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
+
+  const reusableResult = validateMaterializedNoteQuality(note({
+    title: 'Reusable lesson for future tasks',
+    summary: 'This note captures a reusable API request fix for future tasks.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'This note captures a reusable API request fix for future tasks.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(reusableResult.accepted, false);
+  assert.equal(reusableResult.reason, 'low-note-quality');
+  assert.ok(reusableResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects generic title and summary with concrete conclusions', () => {
@@ -339,6 +358,20 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const laterSentenceResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness. I checked the request setup during implementation.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness. I checked the request setup during implementation.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(foundResult.accepted, false);
   assert.equal(foundResult.reason, 'low-note-quality');
@@ -355,6 +388,9 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
   assert.equal(confirmedResult.accepted, false);
   assert.equal(confirmedResult.reason, 'low-note-quality');
   assert.ok(confirmedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(laterSentenceResult.accepted, false);
+  assert.equal(laterSentenceResult.reason, 'low-note-quality');
+  assert.ok(laterSentenceResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects #87-like one-off status records in auto mode', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3328,6 +3328,24 @@ test('validateMaterializedNoteQuality rejects English work record structured ite
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects current run implementation shells', () => {
+  const summary = 'This run uses active request id gate on /api/search result updates, avoiding stale responses that overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects completion shell structured items', () => {
   const summary = 'Completion: use active request id gate for /api/search result updates, avoiding stale responses that overwrite current results.';
   const result = validateMaterializedNoteQuality(note({

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -2415,6 +2415,50 @@ test('validateMaterializedNoteQuality rejects generic custom provider reliabilit
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality accepts raw-body HMAC signature verification fixes', () => {
+  const summary = 'Verify Stripe webhook HMAC over rawBody before JSON parsing because parsing can normalize bytes and make valid signatures fail with HTTP 400.';
+  const root_cause = 'Stripe webhook signature verification returned HTTP 400 because JSON.parse reconstructed the request body before HMAC verification and changed the signed bytes.';
+  const resolution = 'Read rawBody and verify the HMAC before JSON.parse so valid Stripe webhook signatures are not rejected.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Stripe webhook HMAC must use raw request body',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    tags: ['backend'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects generic webhook signature reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Webhook signature reliability fix',
+    summary: 'Verify webhook signatures properly to improve webhook reliability.',
+    key_conclusions: [
+      'Root cause: Webhook signature verification was unreliable.',
+      'Resolution: Verify webhook signatures properly to improve webhook reliability.',
+    ],
+    tags: ['backend'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Verify webhook signatures properly to improve webhook reliability.',
+      root_cause: 'Webhook signature verification was unreliable.',
+      resolution: 'Verify webhook signatures properly to improve webhook reliability.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality accepts embedding model capability fixes', () => {
   const summary = 'Configure embedding.provider and embedding.model separately from the LLM so semantic search calls a model that supports /v1/embeddings.';
   const root_cause = 'Semantic search returned HTTP 500 because the configured embedding model reused the chat LLM, which did not expose a /v1/embeddings endpoint.';
@@ -4396,6 +4440,82 @@ test('validateMaterializedNoteQuality rejects check-passed status shells with co
   assert.equal(chineseResult.accepted, false);
   assert.equal(chineseResult.reason, 'low-note-quality');
   assert.ok(chineseResult.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects smoke and acceptance pass status shells', () => {
+  const root_cause = 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.';
+  const resolution = 'Ensure activeRequestId matches before setResults so stale /api/search responses cannot overwrite current results.';
+  const englishResult = validateMaterializedNoteQuality(note({
+    title: 'Search smoke passed activeRequestId gates stale /api/search responses',
+    summary: 'Search smoke passed activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.',
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    tags: ['react-search'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Search smoke passed activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.',
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(englishResult.accepted, false);
+  assert.equal(englishResult.reason, 'low-note-quality');
+  assert.ok(englishResult.warnings.includes('durable_reusable_lesson'));
+
+  const chineseSummary = '在 setResults 前校验 activeRequestId，避免旧的 /api/search 响应覆盖当前查询结果。';
+  const chineseRootCause = '旧的 /api/search 响应覆盖当前查询结果，因为 setResults 前没有校验 activeRequestId。';
+  const chineseResolution = '在 setResults 前校验 activeRequestId，避免旧的 /api/search 响应覆盖当前查询结果。';
+  const chineseTitles = [
+    '语义搜索冒烟通过 activeRequestId 防止 /api/search 旧响应覆盖新结果',
+    '语义搜索验收通过 activeRequestId 防止 /api/search 旧响应覆盖新结果',
+    '语义搜索验证已通过 activeRequestId 防止 /api/search 旧响应覆盖新结果',
+  ];
+
+  for (const title of chineseTitles) {
+    const result = validateMaterializedNoteQuality(note({
+      title,
+      summary: chineseSummary,
+      key_conclusions: [`Root cause: ${chineseRootCause}`, `Resolution: ${chineseResolution}`],
+      raw_payload: {
+        outcome_type: 'fix',
+        summary: chineseSummary,
+        root_cause: chineseRootCause,
+        resolution: chineseResolution,
+      },
+    }), { mode: 'auto' });
+
+    assert.equal(result.accepted, false, title);
+    assert.equal(result.reason, 'low-note-quality', title);
+    assert.ok(result.warnings.includes('durable_reusable_lesson'), title);
+  }
+});
+
+test('validateMaterializedNoteQuality rejects release validation status shells before release or shipping', () => {
+  const root_cause = '/api/search returned HTTP 500 because route registration ran after request setup.';
+  const resolution = 'Register /api/search before request setup so API requests do not return HTTP 500.';
+  const shells = [
+    'Release validated /api/search before release HTTP 500 after route registration moved before request setup.',
+    '/api/search verified before shipping HTTP 500 after route registration moved before request setup.',
+  ];
+
+  for (const text of shells) {
+    const result = validateMaterializedNoteQuality(note({
+      title: text,
+      summary: text,
+      key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+      tags: ['api-search'],
+      raw_payload: {
+        outcome_type: 'fix',
+        summary: text,
+        root_cause,
+        resolution,
+      },
+    }), { mode: 'auto' });
+
+    assert.equal(result.accepted, false, text);
+    assert.equal(result.reason, 'low-note-quality', text);
+    assert.ok(result.warnings.includes('durable_reusable_lesson'), text);
+  }
 });
 
 test('validateMaterializedNoteQuality rejects shows and is result shells with concrete fix payloads', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1469,6 +1469,20 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
       resolution: 'Ensure activeRequestId matches before setResults so stale /api/search responses cannot overwrite current results.',
     },
   }), { mode: 'auto' });
+  const adverbResult = validateMaterializedNoteQuality(note({
+    title: 'I now gate setResults by activeRequestId so stale /api/search responses cannot overwrite current results.',
+    summary: 'I now gate setResults by activeRequestId so stale /api/search responses cannot overwrite current results.',
+    key_conclusions: [
+      'Root cause: Older /api/search responses overwrote current results because setResults did not check activeRequestId.',
+      'Resolution: I now gate setResults by activeRequestId so stale /api/search responses cannot overwrite current results.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'I now gate setResults by activeRequestId so stale /api/search responses cannot overwrite current results.',
+      root_cause: 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.',
+      resolution: 'I now gate setResults by activeRequestId so stale /api/search responses cannot overwrite current results.',
+    },
+  }), { mode: 'auto' });
   const myFixResult = validateMaterializedNoteQuality(note({
     title: 'My fix uses activeRequestId for search results',
     summary: 'My fix uses activeRequestId to gate setResults so stale /api/search responses cannot overwrite current results.',
@@ -1559,6 +1573,9 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
   assert.equal(ensuredResult.accepted, false);
   assert.equal(ensuredResult.reason, 'low-note-quality');
   assert.ok(ensuredResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(adverbResult.accepted, false);
+  assert.equal(adverbResult.reason, 'low-note-quality');
+  assert.ok(adverbResult.warnings.includes('durable_reusable_lesson'));
   assert.equal(myFixResult.accepted, false);
   assert.equal(myFixResult.reason, 'low-note-quality');
   assert.ok(myFixResult.warnings.includes('durable_reusable_lesson'));
@@ -3369,6 +3386,25 @@ test('validateMaterializedNoteQuality accepts SQL parameterized tag lookup fixes
   assert.equal(payloadResult.accepted, true);
   assert.equal(payloadResult.reason, 'note-quality-ok');
   assert.deepEqual(payloadResult.warnings, []);
+
+  const querySummary = 'Use parameterized queries for tag lookups so user-controlled tag text stays data instead of executable SQL.';
+  const queryRootCause = 'Interpolating user-controlled tag text into SQL lookup queries let crafted tag payloads change WHERE clause syntax.';
+  const queryResolution = 'Use parameterized queries for tag lookups so user-controlled tag text stays data instead of executable SQL.';
+  const queryResult = validateMaterializedNoteQuality(note({
+    title: 'Parameterized tag queries prevent SQL syntax injection',
+    summary: querySummary,
+    key_conclusions: [`Root cause: ${queryRootCause}`, `Resolution: ${queryResolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: querySummary,
+      root_cause: queryRootCause,
+      resolution: queryResolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(queryResult.accepted, true);
+  assert.equal(queryResult.reason, 'note-quality-ok');
+  assert.deepEqual(queryResult.warnings, []);
 });
 
 test('validateMaterializedNoteQuality accepts SQLite migration backfill constraint fixes', () => {
@@ -3814,6 +3850,7 @@ test('validateMaterializedNoteQuality rejects descriptor-prefix status update sh
   const chineseStatusSummary = '语义搜索状态：/api/search 因为路由在 request setup 之后注册而返回 HTTP 500。';
   const statusNoSeparatorSummary = 'Search status /api/search returned HTTP 500 because route registration ran after request setup.';
   const chineseStatusNoSeparatorSummary = '语义搜索状态 /api/search 因为路由在 request setup 之后注册而返回 HTTP 500。';
+  const progressSummary = '/api/search progress update: activeRequestId gates setResults so stale responses cannot overwrite current results.';
   const root_cause = 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.';
   const resolution = 'Gate setResults with activeRequestId so stale responses cannot overwrite current results.';
   const result = validateMaterializedNoteQuality(note({
@@ -3905,6 +3942,17 @@ test('validateMaterializedNoteQuality rejects descriptor-prefix status update sh
       resolution: '在 request setup 前注册 /api/search 路由，避免 API 请求返回 HTTP 500。',
     },
   }), { mode: 'auto' });
+  const progressResult = validateMaterializedNoteQuality(note({
+    title: '/api/search progress update: activeRequestId gates stale responses',
+    summary: progressSummary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: progressSummary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
@@ -3927,6 +3975,9 @@ test('validateMaterializedNoteQuality rejects descriptor-prefix status update sh
   assert.equal(chineseStatusNoSeparatorResult.accepted, false);
   assert.equal(chineseStatusNoSeparatorResult.reason, 'low-note-quality');
   assert.ok(chineseStatusNoSeparatorResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(progressResult.accepted, false);
+  assert.equal(progressResult.reason, 'low-note-quality');
+  assert.ok(progressResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects English work record structured items', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3236,10 +3236,24 @@ test('validateMaterializedNoteQuality accepts queue conversation_id dedupe fixes
       resolution,
     },
   }), { mode: 'auto' });
+  const naturalTitleResult = validateMaterializedNoteQuality(note({
+    title: 'Summarize retries enqueue duplicate conversation jobs',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
 
   assert.equal(result.accepted, true);
   assert.equal(result.reason, 'note-quality-ok');
   assert.deepEqual(result.warnings, []);
+  assert.equal(naturalTitleResult.accepted, true);
+  assert.equal(naturalTitleResult.reason, 'note-quality-ok');
+  assert.deepEqual(naturalTitleResult.warnings, []);
 });
 
 test('validateMaterializedNoteQuality accepts SQL parameterized tag lookup fixes', () => {
@@ -3996,10 +4010,24 @@ test('validateMaterializedNoteQuality accepts SPA fallback route-ordering fixes'
       resolution,
     },
   }), { mode: 'auto' });
+  const naturalTitleResult = validateMaterializedNoteQuality(note({
+    title: 'SPA fallback route order returns HTML for API JSON',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
 
   assert.equal(result.accepted, true);
   assert.equal(result.reason, 'note-quality-ok');
   assert.deepEqual(result.warnings, []);
+  assert.equal(naturalTitleResult.accepted, true);
+  assert.equal(naturalTitleResult.reason, 'note-quality-ok');
+  assert.deepEqual(naturalTitleResult.warnings, []);
 });
 
 test('validateMaterializedNoteQuality accepts MCP stdio JSON-RPC transport fixes', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3405,6 +3405,27 @@ test('validateMaterializedNoteQuality accepts SQL parameterized tag lookup fixes
   assert.equal(queryResult.accepted, true);
   assert.equal(queryResult.reason, 'note-quality-ok');
   assert.deepEqual(queryResult.warnings, []);
+
+  const chineseSummary = '将用户控制的标签文本绑定为 sql.js 参数，避免引号改变 WHERE 子句语法。';
+  const chineseRootCause = '标签查询把用户控制的 tag 文本插入 WHERE 子句，带引号的标签会改变 SQL 语法并造成 SQL 语法注入。';
+  const chineseResolution = '使用参数化查询绑定 tag 值，让用户控制的标签文本作为数据而不是可执行 SQL。';
+  const chineseResult = validateMaterializedNoteQuality(note({
+    title: '参数化标签查询防止 SQL 语法注入',
+    summary: chineseSummary,
+    key_conclusions: [`Root cause: ${chineseRootCause}`, `Resolution: ${chineseResolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: chineseSummary,
+      root_cause: chineseRootCause,
+      resolution: chineseResolution,
+    },
+    tags: [],
+    embedding_text: '',
+  }), { mode: 'auto' });
+
+  assert.equal(chineseResult.accepted, true);
+  assert.equal(chineseResult.reason, 'note-quality-ok');
+  assert.deepEqual(chineseResult.warnings, []);
 });
 
 test('validateMaterializedNoteQuality accepts SQLite migration backfill constraint fixes', () => {
@@ -4071,6 +4092,45 @@ test('validateMaterializedNoteQuality rejects broad test and diagnostic shells w
     [
       '诊断：activeRequestId gates stale /api/search responses',
       '诊断：activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.',
+    ],
+  ];
+
+  for (const [title, summary] of shells) {
+    const result = validateMaterializedNoteQuality(note({
+      title,
+      summary,
+      key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+      raw_payload: {
+        outcome_type: 'fix',
+        summary,
+        root_cause,
+        resolution,
+      },
+      tags: [],
+      embedding_text: '',
+    }), { mode: 'auto' });
+
+    assert.equal(result.accepted, false, title);
+    assert.equal(result.reason, 'low-note-quality', title);
+    assert.ok(result.warnings.includes('durable_reusable_lesson'), title);
+  }
+});
+
+test('validateMaterializedNoteQuality rejects validation regression and QA result shells with concrete fix payloads', () => {
+  const root_cause = 'Older /api/search responses overwrote current results because setResults did not check activeRequestId before updating the search view.';
+  const resolution = 'Ensure activeRequestId matches before setResults so stale /api/search responses cannot overwrite current query results.';
+  const shells = [
+    [
+      'Search validation confirmed activeRequestId gates stale /api/search responses',
+      'Search validation confirmed activeRequestId gates stale /api/search responses',
+    ],
+    [
+      'Regression confirmed: activeRequestId gates stale /api/search responses',
+      'Regression confirmed: activeRequestId gates stale /api/search responses',
+    ],
+    [
+      'QA confirmed: activeRequestId gates stale /api/search responses',
+      'QA confirmed: activeRequestId gates stale /api/search responses',
     ],
   ];
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -103,6 +103,38 @@ test('validateMaterializedNoteQuality rejects generic environment decisions', ()
   assert.ok(result.warnings.includes('one_off_status'));
 });
 
+test('validateMaterializedNoteQuality rejects generic environment status decisions with action words', () => {
+  const validateResult = validateMaterializedNoteQuality(note({
+    title: 'Validate NODE_ENV deployment status',
+    summary: 'Validate NODE_ENV deployment status because production environment is expected.',
+    key_conclusions: ['Decision: Validate NODE_ENV deployment status because production environment is expected.'],
+    raw_payload: {
+      summary: 'Validate NODE_ENV deployment status because production environment is expected.',
+      outcome_type: 'decision',
+      decisions: ['Validate NODE_ENV deployment status because production environment is expected.'],
+    },
+  }), { mode: 'auto' });
+  const investigateResult = validateMaterializedNoteQuality(note({
+    title: 'Investigate local package version status',
+    summary: 'Investigate local package version status because deployment should use production.',
+    key_conclusions: ['Decision: Investigate local package version status because deployment should use production.'],
+    raw_payload: {
+      summary: 'Investigate local package version status because deployment should use production.',
+      outcome_type: 'decision',
+      decisions: ['Investigate local package version status because deployment should use production.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(validateResult.accepted, false);
+  assert.equal(validateResult.reason, 'low-note-quality');
+  assert.ok(validateResult.warnings.includes('durable_reusable_lesson'));
+  assert.ok(validateResult.warnings.includes('one_off_status'));
+  assert.equal(investigateResult.accepted, false);
+  assert.equal(investigateResult.reason, 'low-note-quality');
+  assert.ok(investigateResult.warnings.includes('durable_reusable_lesson'));
+  assert.ok(investigateResult.warnings.includes('one_off_status'));
+});
+
 test('validateMaterializedNoteQuality rejects placeholder root cause and resolution fields', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Server readiness note with placeholder diagnosis',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -499,6 +499,21 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const genericResolutionResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+      'Resolution: Use the correct pattern.',
+    ],
+    raw_payload: {
+      summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(genericTakeawayResult.accepted, false);
   assert.equal(genericTakeawayResult.reason, 'low-note-quality');
@@ -533,6 +548,9 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
   assert.equal(allGoodResult.accepted, false);
   assert.equal(allGoodResult.reason, 'low-note-quality');
   assert.ok(allGoodResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(genericResolutionResult.accepted, false);
+  assert.equal(genericResolutionResult.reason, 'low-note-quality');
+  assert.ok(genericResolutionResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects fix outcomes without visible fix conclusions', () => {
@@ -1553,6 +1571,27 @@ test('validateMaterializedNoteQuality accepts NODE_ENV import resolutions', () =
       outcome_type: 'fix',
       root_cause: 'Production API requests returned HTTP 500 because NODE_ENV config was imported after request setup.',
       resolution: 'Import NODE_ENV config before request setup to prevent HTTP 500 in production API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts HTTP 429 queue retry fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Queue rate-limit retries prevent HTTP 429 failures',
+    summary: 'Retry queued provider requests after HTTP 429 rate-limit responses so batch summarization continues.',
+    key_conclusions: [
+      'Root cause: Provider API requests returned HTTP 429 because the queue retried immediately without rate-limit backoff.',
+      'Resolution: Retry queued provider requests after the Retry-After delay before resuming batch summarization.',
+    ],
+    raw_payload: {
+      summary: 'Retry queued provider requests after HTTP 429 rate-limit responses so batch summarization continues.',
+      outcome_type: 'fix',
+      root_cause: 'Provider API requests returned HTTP 429 because the queue retried immediately without rate-limit backoff.',
+      resolution: 'Retry queued provider requests after the Retry-After delay before resuming batch summarization.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -222,6 +222,20 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const futureFailureResult = validateMaterializedNoteQuality(note({
+    title: 'Server request future failure prevention',
+    summary: 'Server requests now avoid future failures in the expected workflow.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Server requests now avoid future failures in the expected workflow.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(summaryResult.accepted, false);
   assert.equal(summaryResult.reason, 'low-note-quality');
@@ -229,6 +243,9 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
   assert.equal(conclusionResult.accepted, false);
   assert.equal(conclusionResult.reason, 'low-note-quality');
   assert.ok(conclusionResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(futureFailureResult.accepted, false);
+  assert.equal(futureFailureResult.reason, 'low-note-quality');
+  assert.ok(futureFailureResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects low-quality extra key conclusions', () => {
@@ -262,6 +279,21 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const releaseValidationResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+      'Takeaway: Always validate behavior before release.',
+    ],
+    raw_payload: {
+      summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(genericTakeawayResult.accepted, false);
   assert.equal(genericTakeawayResult.reason, 'low-note-quality');
@@ -269,6 +301,9 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
   assert.equal(diaryTakeawayResult.accepted, false);
   assert.equal(diaryTakeawayResult.reason, 'low-note-quality');
   assert.ok(diaryTakeawayResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(releaseValidationResult.accepted, false);
+  assert.equal(releaseValidationResult.reason, 'low-note-quality');
+  assert.ok(releaseValidationResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects diary or status summaries with concrete conclusions', () => {
@@ -649,6 +684,27 @@ test('validateMaterializedNoteQuality accepts natural package metadata and dist 
       outcome_type: 'fix',
       root_cause: 'Package metadata and generated dist output diverged because version parsing used different formats.',
       resolution: 'Normalize package metadata before comparing generated dist output during release checks.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts package metadata dist comparison patterns', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Normalize package metadata before dist comparison',
+    summary: 'Normalize package metadata before comparing generated dist output when version formats make dist comparisons unreliable.',
+    key_conclusions: [
+      'Pattern: Normalize package metadata before comparing generated dist output because inconsistent version formats made dist comparisons unreliable.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package metadata before comparing generated dist output when version formats make dist comparisons unreliable.',
+      outcome_type: 'pattern',
+      reusable_patterns: [
+        'Normalize package metadata before comparing generated dist output because inconsistent version formats made dist comparisons unreliable.',
+      ],
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3717,6 +3717,8 @@ test('validateMaterializedNoteQuality rejects descriptor-prefix status update sh
   const summary = 'API search status update: activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.';
   const semanticSummary = 'Semantic search status update: activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.';
   const chineseSummary = '语义搜索状态更新：activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.';
+  const statusForSummary = 'Search status update for /api/search returned HTTP 500 because route registration ran after request setup.';
+  const chineseStatusSummary = '语义搜索状态：/api/search 因为路由在 request setup 之后注册而返回 HTTP 500。';
   const root_cause = 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.';
   const resolution = 'Gate setResults with activeRequestId so stale responses cannot overwrite current results.';
   const result = validateMaterializedNoteQuality(note({
@@ -3752,6 +3754,34 @@ test('validateMaterializedNoteQuality rejects descriptor-prefix status update sh
       resolution,
     },
   }), { mode: 'auto' });
+  const statusForResult = validateMaterializedNoteQuality(note({
+    title: 'Search status update for /api/search HTTP 500',
+    summary: statusForSummary,
+    key_conclusions: [
+      'Root cause: /api/search returned HTTP 500 because route registration ran after request setup.',
+      'Resolution: Register /api/search before request setup so API requests do not return HTTP 500.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: statusForSummary,
+      root_cause: '/api/search returned HTTP 500 because route registration ran after request setup.',
+      resolution: 'Register /api/search before request setup so API requests do not return HTTP 500.',
+    },
+  }), { mode: 'auto' });
+  const chineseStatusResult = validateMaterializedNoteQuality(note({
+    title: '语义搜索状态：/api/search 返回 HTTP 500',
+    summary: chineseStatusSummary,
+    key_conclusions: [
+      'Root cause: /api/search 路由在 request setup 之后注册，导致 API 请求返回 HTTP 500。',
+      'Resolution: 在 request setup 前注册 /api/search 路由，避免 API 请求返回 HTTP 500。',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: chineseStatusSummary,
+      root_cause: '/api/search 路由在 request setup 之后注册，导致 API 请求返回 HTTP 500。',
+      resolution: '在 request setup 前注册 /api/search 路由，避免 API 请求返回 HTTP 500。',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
@@ -3762,6 +3792,12 @@ test('validateMaterializedNoteQuality rejects descriptor-prefix status update sh
   assert.equal(chineseResult.accepted, false);
   assert.equal(chineseResult.reason, 'low-note-quality');
   assert.ok(chineseResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(statusForResult.accepted, false);
+  assert.equal(statusForResult.reason, 'low-note-quality');
+  assert.ok(statusForResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(chineseStatusResult.accepted, false);
+  assert.equal(chineseStatusResult.reason, 'low-note-quality');
+  assert.ok(chineseStatusResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects English work record structured items', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -290,6 +290,44 @@ test('validateMaterializedNoteQuality rejects package metadata found or included
   assert.ok(includedResult.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects package metadata detected or observed existence claims', () => {
+  const detectedResult = validateMaterializedNoteQuality(note({
+    title: 'Package metadata release checks',
+    summary: 'Normalize package metadata before comparing generated dist output during release checks.',
+    key_conclusions: [
+      'Root cause: Package metadata was detected because generated dist output diverged during release checks.',
+      'Resolution: Normalize package metadata before comparing generated dist output during release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package metadata before comparing generated dist output during release checks.',
+      outcome_type: 'fix',
+      root_cause: 'Package metadata was detected because generated dist output diverged during release checks.',
+      resolution: 'Normalize package metadata before comparing generated dist output during release checks.',
+    },
+  }), { mode: 'auto' });
+  const observedResult = validateMaterializedNoteQuality(note({
+    title: 'Package metadata release checks',
+    summary: 'Normalize package metadata before comparing generated dist output during release checks.',
+    key_conclusions: [
+      'Root cause: Package metadata was observed because generated dist output diverged during release checks.',
+      'Resolution: Normalize package metadata before comparing generated dist output during release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package metadata before comparing generated dist output during release checks.',
+      outcome_type: 'fix',
+      root_cause: 'Package metadata was observed because generated dist output diverged during release checks.',
+      resolution: 'Normalize package metadata before comparing generated dist output during release checks.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(detectedResult.accepted, false);
+  assert.equal(detectedResult.reason, 'low-note-quality');
+  assert.ok(detectedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(observedResult.accepted, false);
+  assert.equal(observedResult.reason, 'low-note-quality');
+  assert.ok(observedResult.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality accepts API registration ordering HTTP failures', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'API registration ordering caused HTTP 404',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -192,6 +192,45 @@ test('validateMaterializedNoteQuality rejects generic title and summary with con
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects generic reliability visible fields with concrete conclusions', () => {
+  const summaryResult = validateMaterializedNoteQuality(note({
+    title: 'Backend reliability fix',
+    summary: 'This backend reliability fix prevents request failures in future work.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'This backend reliability fix prevents request failures in future work.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+  const conclusionResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+      'Takeaway: This note captures a reusable fix for future tasks.',
+    ],
+    raw_payload: {
+      summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(summaryResult.accepted, false);
+  assert.equal(summaryResult.reason, 'low-note-quality');
+  assert.ok(summaryResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(conclusionResult.accepted, false);
+  assert.equal(conclusionResult.reason, 'low-note-quality');
+  assert.ok(conclusionResult.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects diary or status summaries with concrete conclusions', () => {
   const diaryResult = validateMaterializedNoteQuality(note({
     title: 'Server readiness race returns ECONNREFUSED',
@@ -999,6 +1038,44 @@ test('validateMaterializedNoteQuality accepts natural HTTP registration ordering
   assert.equal(result.accepted, true);
   assert.equal(result.reason, 'note-quality-ok');
   assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts moved or placed HTTP registration ordering fixes', () => {
+  const moveResult = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Move /api/notes registration before request setup so API requests do not return HTTP 404.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Move /api/notes registration before request setup so API requests do not return HTTP 404.',
+    ],
+    raw_payload: {
+      summary: 'Move /api/notes registration before request setup so API requests do not return HTTP 404.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Move /api/notes registration before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
+  const placeResult = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Place /api/notes registration before request setup so API requests do not return HTTP 404.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Place /api/notes registration before request setup so API requests do not return HTTP 404.',
+    ],
+    raw_payload: {
+      summary: 'Place /api/notes registration before request setup so API requests do not return HTTP 404.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Place /api/notes registration before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(moveResult.accepted, true);
+  assert.equal(moveResult.reason, 'note-quality-ok');
+  assert.deepEqual(moveResult.warnings, []);
+  assert.equal(placeResult.accepted, true);
+  assert.equal(placeResult.reason, 'note-quality-ok');
+  assert.deepEqual(placeResult.warnings, []);
 });
 
 test('validateMaterializedNoteQuality accepts not-registered HTTP route fixes', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -358,6 +358,16 @@ test('validateMaterializedNoteQuality rejects concrete identifiers with vague wo
       decisions: ['Set API config to DATA_DIR so API config should work.'],
     },
   }), { mode: 'auto' });
+  const reliabilityResult = validateMaterializedNoteQuality(note({
+    title: 'DATA_DIR reliability decision',
+    summary: 'Set DATA_DIR to the right value for reliability.',
+    key_conclusions: ['Decision: Set DATA_DIR to the right value for reliability.'],
+    raw_payload: {
+      summary: 'Set DATA_DIR to the right value for reliability.',
+      outcome_type: 'decision',
+      decisions: ['Set DATA_DIR to the right value for reliability.'],
+    },
+  }), { mode: 'auto' });
   const portResult = validateMaterializedNoteQuality(note({
     title: 'PORT config correctness decision',
     summary: 'Set server config to PORT because it should work correctly.',
@@ -368,13 +378,29 @@ test('validateMaterializedNoteQuality rejects concrete identifiers with vague wo
       decisions: ['Set server config to PORT because it should work correctly.'],
     },
   }), { mode: 'auto' });
+  const apiResult = validateMaterializedNoteQuality(note({
+    title: 'API route reliability pattern',
+    summary: 'Add /api/notes config for reliability and correctness.',
+    key_conclusions: ['Pattern: Add /api/notes config for reliability and correctness.'],
+    raw_payload: {
+      summary: 'Add /api/notes config for reliability and correctness.',
+      outcome_type: 'pattern',
+      reusable_patterns: ['Add /api/notes config for reliability and correctness.'],
+    },
+  }), { mode: 'auto' });
 
   assert.equal(dataDirResult.accepted, false);
   assert.equal(dataDirResult.reason, 'low-note-quality');
   assert.ok(dataDirResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(reliabilityResult.accepted, false);
+  assert.equal(reliabilityResult.reason, 'low-note-quality');
+  assert.ok(reliabilityResult.warnings.includes('durable_reusable_lesson'));
   assert.equal(portResult.accepted, false);
   assert.equal(portResult.reason, 'low-note-quality');
   assert.ok(portResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(apiResult.accepted, false);
+  assert.equal(apiResult.reason, 'low-note-quality');
+  assert.ok(apiResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects generic readiness root cause and resolution', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -376,6 +376,34 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
       resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
     },
   }), { mode: 'auto' });
+  const typecheckCompletedResult = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Typecheck completed successfully for /api/notes HTTP 404 after the route registration ran before request setup.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+    ],
+    raw_payload: {
+      summary: 'Typecheck completed successfully for /api/notes HTTP 404 after the route registration ran before request setup.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
+  const lintCompletedResult = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Lint completed successfully for /api/notes HTTP 404 after the route registration ran before request setup.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+    ],
+    raw_payload: {
+      summary: 'Lint completed successfully for /api/notes HTTP 404 after the route registration ran before request setup.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(summaryResult.accepted, false);
   assert.equal(summaryResult.reason, 'low-note-quality');
@@ -416,6 +444,12 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
   assert.equal(ciCompletedResult.accepted, false);
   assert.equal(ciCompletedResult.reason, 'low-note-quality');
   assert.ok(ciCompletedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(typecheckCompletedResult.accepted, false);
+  assert.equal(typecheckCompletedResult.reason, 'low-note-quality');
+  assert.ok(typecheckCompletedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(lintCompletedResult.accepted, false);
+  assert.equal(lintCompletedResult.reason, 'low-note-quality');
+  assert.ok(lintCompletedResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects low-quality extra key conclusions', () => {
@@ -1817,6 +1851,47 @@ test('validateMaterializedNoteQuality accepts concrete schema default array fixe
   assert.equal(result.accepted, true);
   assert.equal(result.reason, 'note-quality-ok');
   assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts imported content sanitization fixes', () => {
+  const root = 'The Claude Code adapter saved raw JSONL message content, so <system-reminder> and <command-name> tags leaked into human-facing notes.';
+  const resolution = 'Strip Claude system XML tags in sanitizeContent before saving imported conversation messages.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Claude system-reminder tags leak into notes',
+    summary: 'Sanitize <system-reminder> and <command-name> tags while parsing Claude Code JSONL so system noise does not become note content.',
+    key_conclusions: [`Root cause: ${root}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Sanitize <system-reminder> and <command-name> tags while parsing Claude Code JSONL so system noise does not become note content.',
+      root_cause: root,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects generic import sanitization reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Imported content sanitization reliability fix',
+    summary: 'Sanitize imported content so notes are reliable.',
+    key_conclusions: [
+      'Root cause: Imported content was unreliable.',
+      'Resolution: Sanitize imported content so notes are reliable.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Sanitize imported content so notes are reliable.',
+      root_cause: 'Imported content was unreliable.',
+      resolution: 'Sanitize imported content so notes are reliable.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality accepts concrete negative parser pitfalls', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -2287,6 +2287,48 @@ test('validateMaterializedNoteQuality rejects generic embedding config reliabili
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality accepts TypeScript ESM import extension fixes', () => {
+  const summary = 'Use .js specifiers in server TypeScript imports so tsx resolves ESM modules the same way Node runs compiled output.';
+  const root_cause = 'Server TypeScript imported ./quality.ts directly, so compiled ESM emitted a .ts specifier that Node could not resolve in dist.';
+  const resolution = 'Use .js specifiers in TypeScript source imports so tsx maps them in development and Node resolves compiled dist files.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'TypeScript ESM import extension breaks tsx tests',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects generic ESM import reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'ESM import reliability fix',
+    summary: 'Use .js imports to improve reliability.',
+    key_conclusions: [
+      'Root cause: ESM imports needed a proper fix.',
+      'Resolution: Fix ESM imports properly.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Use .js imports to improve reliability.',
+      root_cause: 'ESM imports needed a proper fix.',
+      resolution: 'Fix ESM imports properly.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality accepts concrete schema default array fixes', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Zod optional arrays can throw during iteration',
@@ -3241,6 +3283,44 @@ test('validateMaterializedNoteQuality rejects English execution record structure
     },
     tags: [],
     embedding_text: '',
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects English status report structured items', () => {
+  const summary = 'Status report: use active request id gate for /api/search result updates, avoiding stale responses that overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
+    },
+    tags: ['search', 'frontend'],
+    embedding_text: '',
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects English work record structured items', () => {
+  const summary = 'Work record - use active request id gate for /api/search result updates, avoiding stale responses that overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary,
+      decisions: [summary],
+    },
   }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -228,6 +228,23 @@ test('validateMaterializedNoteQuality rejects generic compare and validate lesso
   assert.ok(validateResult.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects boilerplate API validation patterns', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Generic API validation pattern',
+    summary: 'The pattern should validate API input because validation is important for correctness.',
+    key_conclusions: ['Pattern: The pattern should validate API input because validation is important for correctness.'],
+    raw_payload: {
+      summary: 'The pattern should validate API input because validation is important for correctness.',
+      outcome_type: 'pattern',
+      reusable_patterns: ['The pattern should validate API input because validation is important for correctness.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects generic readiness root cause and resolution', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Server readiness generic fix',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -469,6 +469,36 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const investigationObservationResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+      'Observation: The issue was investigated.',
+    ],
+    raw_payload: {
+      summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+  const allGoodResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+      'All good now.',
+    ],
+    raw_payload: {
+      summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(genericTakeawayResult.accepted, false);
   assert.equal(genericTakeawayResult.reason, 'low-note-quality');
@@ -497,6 +527,12 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
   assert.equal(maintenanceReliabilityResult.accepted, false);
   assert.equal(maintenanceReliabilityResult.reason, 'low-note-quality');
   assert.ok(maintenanceReliabilityResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(investigationObservationResult.accepted, false);
+  assert.equal(investigationObservationResult.reason, 'low-note-quality');
+  assert.ok(investigationObservationResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(allGoodResult.accepted, false);
+  assert.equal(allGoodResult.reason, 'low-note-quality');
+  assert.ok(allGoodResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects fix outcomes without visible fix conclusions', () => {
@@ -604,6 +640,20 @@ test('validateMaterializedNoteQuality rejects diary or status summaries with con
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const embeddedDiaryResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'Requests hit ECONNREFUSED before Fastify readiness, and I added a wait before API requests.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Requests hit ECONNREFUSED before Fastify readiness, and I added a wait before API requests.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(diaryResult.accepted, false);
   assert.equal(diaryResult.reason, 'low-note-quality');
@@ -623,6 +673,9 @@ test('validateMaterializedNoteQuality rejects diary or status summaries with con
   assert.equal(testedResult.accepted, false);
   assert.equal(testedResult.reason, 'low-note-quality');
   assert.ok(testedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(embeddedDiaryResult.accepted, false);
+  assert.equal(embeddedDiaryResult.reason, 'low-note-quality');
+  assert.ok(embeddedDiaryResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects generic visible patterns with concrete raw payloads', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -110,6 +110,25 @@ test('validateMaterializedNoteQuality rejects generic resolutions with concrete 
   assert.equal(validateResult.accepted, false);
   assert.equal(validateResult.reason, 'low-note-quality');
   assert.ok(validateResult.warnings.includes('durable_reusable_lesson'));
+
+  const guardResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness guard prevents ECONNREFUSED',
+    summary: 'Add a server readiness guard before API requests to prevent future failures.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Add a server readiness guard before API requests to prevent future failures.',
+    ],
+    raw_payload: {
+      summary: 'Add a server readiness guard before API requests to prevent future failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Add a server readiness guard before API requests to prevent future failures.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(guardResult.accepted, false);
+  assert.equal(guardResult.reason, 'low-note-quality');
+  assert.ok(guardResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects generic visible fixes with concrete raw payloads', () => {
@@ -292,6 +311,20 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
       resolution: 'We switched request setup to wait for the Fastify readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const discoveredResult = validateMaterializedNoteQuality(note({
+    title: 'Readiness implementation diary fix',
+    summary: 'We discovered API requests hit ECONNREFUSED before Fastify readiness.',
+    key_conclusions: [
+      'Root cause: We discovered API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'We discovered API requests hit ECONNREFUSED before Fastify readiness.',
+      outcome_type: 'fix',
+      root_cause: 'We discovered API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(foundResult.accepted, false);
   assert.equal(foundResult.reason, 'low-note-quality');
@@ -302,6 +335,9 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
   assert.equal(switchedResult.accepted, false);
   assert.equal(switchedResult.reason, 'low-note-quality');
   assert.ok(switchedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(discoveredResult.accepted, false);
+  assert.equal(discoveredResult.reason, 'low-note-quality');
+  assert.ok(discoveredResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects #87-like one-off status records in auto mode', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -129,6 +129,23 @@ test('validateMaterializedNoteQuality rejects #87-like one-off status records in
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects first-person implementation diary patterns', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Readiness implementation diary',
+    summary: 'I added the readiness wait and then the API request passed after ECONNREFUSED.',
+    key_conclusions: ['Pattern: I added Fastify readiness wait before issuing API requests because ECONNREFUSED happens when requests race startup.'],
+    raw_payload: {
+      summary: 'I added the readiness wait and then the API request passed after ECONNREFUSED.',
+      outcome_type: 'pattern',
+      reusable_patterns: ['I added Fastify readiness wait before issuing API requests because ECONNREFUSED happens when requests race startup.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects one-off status records disguised as decisions', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Local package version matched dist output',
@@ -831,6 +848,23 @@ test('validateMaterializedNoteQuality rejects generic environment decisions', ()
   assert.equal(result.reason, 'low-note-quality');
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
   assert.ok(result.warnings.includes('one_off_status'));
+});
+
+test('validateMaterializedNoteQuality rejects environment verification snapshots', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'NODE_ENV production verification',
+    summary: 'Verified NODE_ENV production before request setup.',
+    key_conclusions: ['Decision: Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.'],
+    raw_payload: {
+      summary: 'Verified NODE_ENV production before request setup.',
+      outcome_type: 'decision',
+      decisions: ['Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects generic environment status decisions with action words', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -231,6 +231,46 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
   assert.ok(conclusionResult.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects low-quality extra key conclusions', () => {
+  const genericTakeawayResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+      'Takeaway: The task now works correctly.',
+    ],
+    raw_payload: {
+      summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+  const diaryTakeawayResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+      'Takeaway: I verified the fix during local testing.',
+    ],
+    raw_payload: {
+      summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(genericTakeawayResult.accepted, false);
+  assert.equal(genericTakeawayResult.reason, 'low-note-quality');
+  assert.ok(genericTakeawayResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(diaryTakeawayResult.accepted, false);
+  assert.equal(diaryTakeawayResult.reason, 'low-note-quality');
+  assert.ok(diaryTakeawayResult.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects diary or status summaries with concrete conclusions', () => {
   const diaryResult = validateMaterializedNoteQuality(note({
     title: 'Server readiness race returns ECONNREFUSED',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -2934,6 +2934,50 @@ test('validateMaterializedNoteQuality accepts indexed lookup timeout fixes', () 
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts writeback receipt uniqueness fixes', () => {
+  const summary = 'Add UNIQUE(source_agent, source_run_key) on the writeback_receipts table because retried write_task_memory calls inserted duplicate receipt rows and duplicate notes for the same run.';
+  const root_cause = 'Retried write_task_memory calls reused the same source_run_key, but the writeback_receipts table had no UNIQUE(source_agent, source_run_key) constraint, so duplicate receipt rows created duplicate notes for one agent run.';
+  const resolution = 'Add UNIQUE(source_agent, source_run_key) on writeback_receipts and return the existing receipt row so retries reuse the first note instead of inserting duplicate rows.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Writeback receipt unique key prevents duplicate notes',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    tags: ['writeback', 'database'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts stale async search response fixes', () => {
+  const summary = 'Cancel older /api/search requests because slower previous responses overwrote the current query results in the React search view.';
+  const root_cause = 'React search fired overlapping /api/search requests, so a slower previous response overwrote the current query results.';
+  const resolution = 'Use AbortController to cancel the previous /api/search request before starting the next query so stale responses cannot replace current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Cancel stale search requests before updating results',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    tags: ['search', 'frontend'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality accepts stale Vectra index cleanup fixes', () => {
   const root = 'Semantic search returned stale note_id hits because note deletion removed sql.js rows without removing Vectra index entries.';
   const resolution = 'Remove Vectra index entries after deleting sql.js note rows so semantic search cannot return deleted notes.';
@@ -3010,6 +3054,50 @@ test('validateMaterializedNoteQuality rejects generic index performance reliabil
       summary: 'Add indexes to improve database performance and reliability.',
       root_cause: 'Database performance was unreliable.',
       resolution: 'Add indexes to improve database performance and reliability.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic duplicate constraint reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Database duplicate prevention fix',
+    summary: 'Add constraints to prevent duplicates and improve database reliability.',
+    key_conclusions: [
+      'Root cause: Duplicate records were unreliable.',
+      'Resolution: Add constraints to prevent duplicates and improve database reliability.',
+    ],
+    tags: ['writeback', 'database'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Add constraints to prevent duplicates and improve database reliability.',
+      root_cause: 'Duplicate records were unreliable.',
+      resolution: 'Add constraints to prevent duplicates and improve database reliability.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic frontend cancel reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Frontend request reliability fix',
+    summary: 'Cancel requests to improve frontend reliability.',
+    key_conclusions: [
+      'Root cause: Frontend requests were unreliable.',
+      'Resolution: Cancel requests to improve frontend reliability.',
+    ],
+    tags: ['search', 'frontend'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Cancel requests to improve frontend reliability.',
+      root_cause: 'Frontend requests were unreliable.',
+      resolution: 'Cancel requests to improve frontend reliability.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -522,6 +522,23 @@ test('validateMaterializedNoteQuality accepts causal self-contained DATA_DIR dec
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts fallback decisions with existence context', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'DATA_DIR prevents default fallback',
+    summary: 'Set DATA_DIR before importing the Electron server entrypoint to prevent fallback to the default data directory when it exists.',
+    key_conclusions: ['Decision: Set DATA_DIR before importing the Electron server entrypoint to prevent fallback to the default data directory when it exists.'],
+    raw_payload: {
+      summary: 'Set DATA_DIR before importing the Electron server entrypoint to prevent fallback to the default data directory when it exists.',
+      outcome_type: 'decision',
+      decisions: ['Set DATA_DIR before importing the Electron server entrypoint to prevent fallback to the default data directory when it exists.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects generic unreliable behavior consequences', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'DATA_DIR import ordering prevents unreliable behavior',
@@ -548,6 +565,23 @@ test('validateMaterializedNoteQuality rejects default data directory existence d
       summary: 'Set DATA_DIR before importing the Electron server entrypoint because the default data directory exists.',
       outcome_type: 'decision',
       decisions: ['Set DATA_DIR before importing the Electron server entrypoint because the default data directory exists.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects default data directory on-disk decisions', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'DATA_DIR default directory ordering decision',
+    summary: 'Set DATA_DIR before importing the Electron server entrypoint because the default data directory is on disk.',
+    key_conclusions: ['Decision: Set DATA_DIR before importing the Electron server entrypoint because the default data directory is on disk.'],
+    raw_payload: {
+      summary: 'Set DATA_DIR before importing the Electron server entrypoint because the default data directory is on disk.',
+      outcome_type: 'decision',
+      decisions: ['Set DATA_DIR before importing the Electron server entrypoint because the default data directory is on disk.'],
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -278,6 +278,34 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const genericTitleResult = validateMaterializedNoteQuality(note({
+    title: 'Backend request fix',
+    summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+  const genericSummaryResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'The request setup reliability was improved.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'The request setup reliability was improved.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(summaryResult.accepted, false);
   assert.equal(summaryResult.reason, 'low-note-quality');
@@ -297,6 +325,12 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
   assert.equal(reliabilityImprovementResult.accepted, false);
   assert.equal(reliabilityImprovementResult.reason, 'low-note-quality');
   assert.ok(reliabilityImprovementResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(genericTitleResult.accepted, false);
+  assert.equal(genericTitleResult.reason, 'low-note-quality');
+  assert.ok(genericTitleResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(genericSummaryResult.accepted, false);
+  assert.equal(genericSummaryResult.reason, 'low-note-quality');
+  assert.ok(genericSummaryResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects low-quality extra key conclusions', () => {
@@ -405,6 +439,36 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const correctPatternResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+      'Takeaway: Use the correct pattern.',
+    ],
+    raw_payload: {
+      summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+  const maintenanceReliabilityResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+      'Takeaway: Reliability matters for future maintenance.',
+    ],
+    raw_payload: {
+      summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(genericTakeawayResult.accepted, false);
   assert.equal(genericTakeawayResult.reason, 'low-note-quality');
@@ -427,6 +491,12 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
   assert.equal(buildPassedResult.accepted, false);
   assert.equal(buildPassedResult.reason, 'low-note-quality');
   assert.ok(buildPassedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(correctPatternResult.accepted, false);
+  assert.equal(correctPatternResult.reason, 'low-note-quality');
+  assert.ok(correctPatternResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(maintenanceReliabilityResult.accepted, false);
+  assert.equal(maintenanceReliabilityResult.reason, 'low-note-quality');
+  assert.ok(maintenanceReliabilityResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects fix outcomes without visible fix conclusions', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -609,6 +609,28 @@ test('validateMaterializedNoteQuality accepts Chinese summaries with concrete ro
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts Chinese route ordering fixes', () => {
+  const summary = '在 request setup 前注册 /api/notes 路由，避免 API requests 返回 HTTP 404。';
+  const root_cause = '/api/notes 路由在 request setup 之后才注册，导致 API requests 返回 HTTP 404。';
+  const resolution = '在 request setup 前注册 /api/notes 路由，避免 API requests 返回 HTTP 404。';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'API 注册顺序导致 /api/notes HTTP 404',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    tags: ['api-route'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects low-quality extra key conclusions', () => {
   const genericTakeawayResult = validateMaterializedNoteQuality(note({
     title: 'Server readiness race returns ECONNREFUSED',
@@ -3021,6 +3043,24 @@ test('validateMaterializedNoteQuality rejects Chinese status-shell structured it
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects Chinese worklog structured items', () => {
+  const summary = '工作日志：使用 active request id gate /api/search result updates，避免 stale responses overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Decision: ${summary}`],
+    raw_payload: {
+      summary,
+      outcome_type: 'decision',
+      decisions: [summary],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality accepts route initialization HTTP failures', () => {
   const summary = 'POST /api/import returned HTTP 500 because the route handled requests before sql.js finished initialization; wait for db initialization before accepting import requests.';
   const root_cause = 'POST /api/import returned HTTP 500 because the route handled requests before sql.js finished initialization.';
@@ -3275,6 +3315,41 @@ test('validateMaterializedNoteQuality rejects generic orphan tag cleanup reliabi
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic Chinese route and worklog boilerplate', () => {
+  const routeResult = validateMaterializedNoteQuality(note({
+    title: '路由可靠性修复',
+    summary: '注册路由以提高可靠性。',
+    key_conclusions: [
+      'Root cause: 路由可靠性不稳定。',
+      'Resolution: 注册路由以提高可靠性。',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: '注册路由以提高可靠性。',
+      root_cause: '路由可靠性不稳定。',
+      resolution: '注册路由以提高可靠性。',
+    },
+  }), { mode: 'auto' });
+
+  const worklogResult = validateMaterializedNoteQuality(note({
+    title: '路由问题工作日志',
+    summary: '工作日志：已修复路由问题。',
+    key_conclusions: ['Decision: 工作日志：已修复路由问题。'],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary: '工作日志：已修复路由问题。',
+      decisions: ['工作日志：已修复路由问题。'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(routeResult.accepted, false);
+  assert.equal(routeResult.reason, 'low-note-quality');
+  assert.ok(routeResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(worklogResult.accepted, false);
+  assert.equal(worklogResult.reason, 'low-note-quality');
+  assert.ok(worklogResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects generic initialization reliability fixes', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1212,6 +1212,25 @@ test('validateMaterializedNoteQuality rejects visible status fixes with concrete
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
+
+  const verificationResult = validateMaterializedNoteQuality(note({
+    title: 'Search verification passed activeRequestId gates stale /api/search responses',
+    summary: 'Search verification passed activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.',
+    key_conclusions: [
+      'Root cause: Older /api/search responses overwrote current results because setResults did not check activeRequestId.',
+      'Resolution: Gate setResults with activeRequestId so stale responses cannot overwrite current results.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Search verification passed activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.',
+      root_cause: 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.',
+      resolution: 'Gate setResults with activeRequestId so stale responses cannot overwrite current results.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(verificationResult.accepted, false);
+  assert.equal(verificationResult.reason, 'low-note-quality');
+  assert.ok(verificationResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects first-person implementation diary fixes', () => {
@@ -3276,6 +3295,25 @@ test('validateMaterializedNoteQuality accepts SQL parameterized tag lookup fixes
   assert.equal(result.accepted, true);
   assert.equal(result.reason, 'note-quality-ok');
   assert.deepEqual(result.warnings, []);
+
+  const syntaxSummary = 'Bind tag names as SQL parameters so quotes stay data instead of altering WHERE clause syntax.';
+  const syntaxRootCause = 'Tag lookup interpolated user-controlled tag names into SQL WHERE clauses, so quotes in a tag altered SQL syntax.';
+  const syntaxResolution = 'Bind tag names as SQL parameters instead of interpolating them into WHERE clauses.';
+  const syntaxResult = validateMaterializedNoteQuality(note({
+    title: 'Parameterized tag queries prevent SQL syntax injection',
+    summary: syntaxSummary,
+    key_conclusions: [`Root cause: ${syntaxRootCause}`, `Resolution: ${syntaxResolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: syntaxSummary,
+      root_cause: syntaxRootCause,
+      resolution: syntaxResolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(syntaxResult.accepted, true);
+  assert.equal(syntaxResult.reason, 'note-quality-ok');
+  assert.deepEqual(syntaxResult.warnings, []);
 });
 
 test('validateMaterializedNoteQuality accepts SQLite migration backfill constraint fixes', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -5175,6 +5175,30 @@ test('validateMaterializedNoteQuality accepts stale Vectra index cleanup fixes',
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts structured SQL and Vectra deletion consistency patterns', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Note deletion E2E must verify SQL and Vectra together',
+    summary: 'Deleting a note must be verified across SQLite rows, writeback receipts, review links, and Vectra items in one E2E run.',
+    key_conclusions: [
+      'Pattern: When testing note deletion, assert SQL cleanup and Vectra cleanup in the same E2E run.',
+      'Decision: Keep vector cleanup idempotent because SQLite commits and Vectra commits can diverge.',
+      'Error signature: foreign_key_check reports orphan rows.',
+    ],
+    tags: ['deletion', 'vectra', 'sqlite'],
+    raw_payload: {
+      outcome_type: 'pattern',
+      summary: 'Deleting a note must be verified across SQLite rows, writeback receipts, review links, and Vectra items in one E2E run.',
+      reusable_patterns: ['When testing note deletion, assert SQL cleanup and Vectra cleanup in the same E2E run.'],
+      decisions: ['Keep vector cleanup idempotent because SQLite commits and Vectra commits can diverge.'],
+      error_signatures: ['foreign_key_check reports orphan rows'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects generic DB queue reliability fixes', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'DB queue reliability fix',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3293,6 +3293,29 @@ test('validateMaterializedNoteQuality accepts writeback receipt uniqueness fixes
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts unique note tag pair constraint fixes', () => {
+  const summary = 'Add a UNIQUE(note_id, tag_id) constraint so repeated summarization cannot create duplicate tag chips for one note.';
+  const root_cause = 'note_tags allowed duplicate note_id and tag_id pairs, so repeated summarization could show duplicate tag chips for one note.';
+  const resolution = 'Add a UNIQUE(note_id, tag_id) constraint and reuse the existing note_tags row when a tag is already attached.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'note_tags needs unique note-tag pairs',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+    tags: [],
+    embedding_text: '',
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality accepts queue conversation_id dedupe fixes', () => {
   const summary = 'Deduplicate queue jobs by conversation_id before enqueueing summarize work so retries reuse the pending job instead of writing duplicate notes.';
   const root_cause = 'summarize --all retries enqueued the same conversation_id more than once, so two queue jobs wrote duplicate notes for the same conversation.';
@@ -4225,6 +4248,38 @@ test('validateMaterializedNoteQuality rejects confirmation done and verified res
   }
 });
 
+test('validateMaterializedNoteQuality rejects shows and is result shells with concrete fix payloads', () => {
+  const root_cause = '/api/search returned HTTP 500 because route registration ran after request setup.';
+  const resolution = 'Register /api/search before request setup so API requests return JSON instead of HTTP 500.';
+  const shells = [
+    'Test shows /api/search registers before request setup so API requests do not return HTTP 500',
+    'Result is /api/search registers before request setup so API requests do not return HTTP 500',
+    'Progress is /api/search registers before request setup so API requests do not return HTTP 500',
+    'Validation shows /api/search registers before request setup so API requests do not return HTTP 500',
+    'QA shows /api/search registers before request setup so API requests do not return HTTP 500',
+  ];
+
+  for (const text of shells) {
+    const result = validateMaterializedNoteQuality(note({
+      title: text,
+      summary: text,
+      key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+      raw_payload: {
+        outcome_type: 'fix',
+        summary: text,
+        root_cause,
+        resolution,
+      },
+      tags: [],
+      embedding_text: '',
+    }), { mode: 'auto' });
+
+    assert.equal(result.accepted, false, text);
+    assert.equal(result.reason, 'low-note-quality', text);
+    assert.ok(result.warnings.includes('durable_reusable_lesson'), text);
+  }
+});
+
 test('validateMaterializedNoteQuality rejects English work record structured items', () => {
   const summary = 'Work record - use active request id gate for /api/search result updates, avoiding stale responses that overwrite current results.';
   const result = validateMaterializedNoteQuality(note({
@@ -4688,6 +4743,28 @@ test('validateMaterializedNoteQuality rejects generic duplicate constraint relia
       summary: 'Add constraints to prevent duplicates and improve database reliability.',
       root_cause: 'Duplicate records were unreliable.',
       resolution: 'Add constraints to prevent duplicates and improve database reliability.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic tag constraint reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Tag duplicate prevention fix',
+    summary: 'Add unique tag constraints to prevent duplicates and improve tag reliability.',
+    key_conclusions: [
+      'Root cause: Duplicate tag chips reduced reliability.',
+      'Resolution: Add unique tag constraints to prevent duplicates and improve tag reliability.',
+    ],
+    tags: ['tags', 'database'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Add unique tag constraints to prevent duplicates and improve tag reliability.',
+      root_cause: 'Duplicate tag chips reduced reliability.',
+      resolution: 'Add unique tag constraints to prevent duplicates and improve tag reliability.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -2870,6 +2870,28 @@ test('validateMaterializedNoteQuality accepts serialized DB persistence fixes', 
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts import transaction atomicity fixes', () => {
+  const summary = 'Wrap sql.js conversation imports in one transaction so a failed message insert rolls back partial conversation rows.';
+  const root_cause = 'Import inserted the conversation row before message rows, so a failed message insert left partial conversation rows in sql.js.';
+  const resolution = 'Wrap conversation and message inserts in one sql.js transaction so failed imports roll back the whole conversation.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Import batch transaction prevents partial conversation rows',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    tags: ['import', 'sql-js'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality accepts stale Vectra index cleanup fixes', () => {
   const root = 'Semantic search returned stale note_id hits because note deletion removed sql.js rows without removing Vectra index entries.';
   const resolution = 'Remove Vectra index entries after deleting sql.js note rows so semantic search cannot return deleted notes.';
@@ -2903,6 +2925,28 @@ test('validateMaterializedNoteQuality rejects generic DB queue reliability fixes
       summary: 'Queue chatcrystal.db writes so database reliability improves.',
       root_cause: 'DB writes were unreliable.',
       resolution: 'Queue chatcrystal.db writes so database reliability improves.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic transaction reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Database transaction reliability fix',
+    summary: 'Use transactions for database reliability.',
+    key_conclusions: [
+      'Root cause: Database writes were unreliable.',
+      'Resolution: Use transactions for database reliability.',
+    ],
+    tags: ['import', 'sql-js'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Use transactions for database reliability.',
+      root_cause: 'Database writes were unreliable.',
+      resolution: 'Use transactions for database reliability.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -366,6 +366,27 @@ test('validateMaterializedNoteQuality rejects active package artifact observatio
   assert.ok(foundResult.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects package metadata visible existence causes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Package metadata release checks',
+    summary: 'Normalize package metadata before comparing generated dist output during release checks.',
+    key_conclusions: [
+      'Root cause: Package metadata was visible because generated dist output diverged during release checks.',
+      'Resolution: Normalize package metadata before comparing generated dist output during release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package metadata before comparing generated dist output during release checks.',
+      outcome_type: 'fix',
+      root_cause: 'Package metadata was visible because generated dist output diverged during release checks.',
+      resolution: 'Normalize package metadata before comparing generated dist output during release checks.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality accepts API registration ordering HTTP failures', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'API registration ordering caused HTTP 404',
@@ -742,6 +763,23 @@ test('validateMaterializedNoteQuality rejects generic unreliable behavior conseq
       summary: 'Set DATA_DIR before importing the Electron server entrypoint to prevent unreliable behavior.',
       outcome_type: 'decision',
       decisions: ['Set DATA_DIR before importing the Electron server entrypoint to prevent unreliable behavior.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects bare fallback consequences', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'API fallback decision',
+    summary: 'Index /api/notes before request setup to prevent fallback.',
+    key_conclusions: ['Decision: Index /api/notes before request setup to prevent fallback.'],
+    raw_payload: {
+      summary: 'Index /api/notes before request setup to prevent fallback.',
+      outcome_type: 'decision',
+      decisions: ['Index /api/notes before request setup to prevent fallback.'],
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -4155,6 +4155,76 @@ test('validateMaterializedNoteQuality rejects validation regression and QA resul
   }
 });
 
+test('validateMaterializedNoteQuality rejects confirmation done and verified result shells', () => {
+  const root_cause = 'Older /api/search responses overwrote current results because setResults did not check activeRequestId before updating the React search view.';
+  const resolution = 'Ensure activeRequestId matches before setResults so stale /api/search responses cannot replace current results.';
+  const englishShells = [
+    [
+      'Search confirmed activeRequestId gates stale /api/search responses',
+      'Search confirmed activeRequestId gates stale /api/search responses from replacing current results.',
+    ],
+    [
+      'Search check confirmed activeRequestId gates stale /api/search responses',
+      'Search check confirmed activeRequestId gates stale /api/search responses from replacing current results.',
+    ],
+    [
+      'Search done activeRequestId gates stale /api/search responses',
+      'Search done activeRequestId gates stale /api/search responses from replacing current results.',
+    ],
+    [
+      'Search fix verified activeRequestId gates stale /api/search responses',
+      'Search fix verified activeRequestId gates stale /api/search responses from replacing current results.',
+    ],
+  ];
+
+  for (const [title, summary] of englishShells) {
+    const result = validateMaterializedNoteQuality(note({
+      title,
+      summary,
+      key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+      tags: ['react-search', 'api-search'],
+      raw_payload: {
+        outcome_type: 'fix',
+        summary,
+        root_cause,
+        resolution,
+      },
+      embedding_text: '',
+    }), { mode: 'auto' });
+
+    assert.equal(result.accepted, false, title);
+    assert.equal(result.reason, 'low-note-quality', title);
+    assert.ok(result.warnings.includes('durable_reusable_lesson'), title);
+  }
+
+  const chineseSummary = '在 setResults 前校验 activeRequestId，避免旧的 /api/search 响应覆盖当前查询结果。';
+  const chineseRootCause = '旧的 /api/search 响应覆盖当前查询结果，因为 setResults 前没有校验 activeRequestId。';
+  const chineseResolution = '在 setResults 前校验 activeRequestId，避免旧的 /api/search 响应覆盖当前查询结果。';
+  const chineseTitles = [
+    '语义搜索确认 activeRequestId 防止 /api/search 旧响应覆盖新结果',
+    '回归确认 activeRequestId 防止 /api/search 旧响应覆盖新结果',
+    '语义搜索检查确认 activeRequestId 防止 /api/search 旧响应覆盖新结果',
+  ];
+
+  for (const title of chineseTitles) {
+    const result = validateMaterializedNoteQuality(note({
+      title,
+      summary: chineseSummary,
+      key_conclusions: [`Root cause: ${chineseRootCause}`, `Resolution: ${chineseResolution}`],
+      raw_payload: {
+        outcome_type: 'fix',
+        summary: chineseSummary,
+        root_cause: chineseRootCause,
+        resolution: chineseResolution,
+      },
+    }), { mode: 'auto' });
+
+    assert.equal(result.accepted, false, title);
+    assert.equal(result.reason, 'low-note-quality', title);
+    assert.ok(result.warnings.includes('durable_reusable_lesson'), title);
+  }
+});
+
 test('validateMaterializedNoteQuality rejects English work record structured items', () => {
   const summary = 'Work record - use active request id gate for /api/search result updates, avoiding stale responses that overwrite current results.';
   const result = validateMaterializedNoteQuality(note({

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -471,6 +471,44 @@ test('validateMaterializedNoteQuality accepts concrete NODE_ENV HTTP failure fix
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality rejects generic HTTP root cause rationales', () => {
+  const correctnessResult = validateMaterializedNoteQuality(note({
+    title: 'NODE_ENV HTTP 500 fix',
+    summary: 'Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
+    key_conclusions: [
+      'Root cause: API returned HTTP 500 because correctness mattered.',
+      'Resolution: Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
+    ],
+    raw_payload: {
+      summary: 'Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
+      outcome_type: 'fix',
+      root_cause: 'API returned HTTP 500 because correctness mattered.',
+      resolution: 'Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
+    },
+  }), { mode: 'auto' });
+  const reliabilityResult = validateMaterializedNoteQuality(note({
+    title: 'NODE_ENV HTTP 500 fix',
+    summary: 'Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
+    key_conclusions: [
+      'Root cause: API returned HTTP 500 because reliability mattered.',
+      'Resolution: Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
+    ],
+    raw_payload: {
+      summary: 'Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
+      outcome_type: 'fix',
+      root_cause: 'API returned HTTP 500 because reliability mattered.',
+      resolution: 'Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(correctnessResult.accepted, false);
+  assert.equal(correctnessResult.reason, 'low-note-quality');
+  assert.ok(correctnessResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(reliabilityResult.accepted, false);
+  assert.equal(reliabilityResult.reason, 'low-note-quality');
+  assert.ok(reliabilityResult.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects weak not-correct HTTP root causes', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'API route weak HTTP fix',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1249,6 +1249,7 @@ test('validateMaterializedNoteQuality rejects first-person implementation decisi
     'I wait for Fastify readiness before issuing API requests because ECONNREFUSED happens when requests race startup.',
     'I block request setup until Fastify readiness resolves to prevent ECONNREFUSED.',
     'I place /api/notes registration before request setup so API requests do not return HTTP 404.',
+    '我把 DATA_DIR set before importing the Electron server entrypoint to prevent default data directory fallback.',
   ];
 
   for (const decision of decisions) {
@@ -1972,10 +1973,16 @@ test('validateMaterializedNoteQuality rejects generic fix tags', () => {
   const result = validateMaterializedNoteQuality(note({
     tags: ['fix'],
   }), { mode: 'auto' });
+  const statusResult = validateMaterializedNoteQuality(note({
+    tags: ['bug', 'reliability', '已修复'],
+  }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
   assert.ok(result.warnings.includes('tags'));
+  assert.equal(statusResult.accepted, false);
+  assert.equal(statusResult.reason, 'low-note-quality');
+  assert.ok(statusResult.warnings.includes('tags'));
 });
 
 test('validateMaterializedNoteQuality rejects identifier-only snippets', () => {
@@ -1992,10 +1999,26 @@ test('validateMaterializedNoteQuality rejects identifier-only snippets', () => {
       }],
     },
   }), { mode: 'auto' });
+  const wrappedResult = validateMaterializedNoteQuality(note({
+    raw_payload: {
+      summary: 'Requests must wait for server readiness before client calls.',
+      outcome_type: 'fix',
+      root_cause: 'Client calls raced server startup.',
+      resolution: 'Block request setup until readiness resolves.',
+      code_snippets: [{
+        language: 'ts',
+        code: '(DATA_DIR)',
+        description: 'Set DATA_DIR before importing the Electron server entrypoint.',
+      }],
+    },
+  }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
   assert.ok(result.warnings.includes('code_snippets'));
+  assert.equal(wrappedResult.accepted, false);
+  assert.equal(wrappedResult.reason, 'low-note-quality');
+  assert.ok(wrappedResult.warnings.includes('code_snippets'));
 });
 
 test('validateMaterializedNoteQuality accepts imported content sanitization fixes', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -209,6 +209,27 @@ test('validateMaterializedNoteQuality accepts causal package metadata inclusion 
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts package version bump dist regeneration fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Regenerate dist after package version bump',
+    summary: 'Regenerate generated dist output after bumping package metadata so release artifacts carry the new package version.',
+    key_conclusions: [
+      'Root cause: Generated dist output kept stale package metadata because the version bump ran after dist generation.',
+      'Resolution: Regenerate generated dist output after bumping package metadata so release artifacts carry the new package version.',
+    ],
+    raw_payload: {
+      summary: 'Regenerate generated dist output after bumping package metadata so release artifacts carry the new package version.',
+      outcome_type: 'fix',
+      root_cause: 'Generated dist output kept stale package metadata because the version bump ran after dist generation.',
+      resolution: 'Regenerate generated dist output after bumping package metadata so release artifacts carry the new package version.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects package parsing causes without dist consequence', () => {
   const wrongResult = validateMaterializedNoteQuality(note({
     title: 'Normalize package version parsing before dist output',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -450,6 +450,27 @@ test('validateMaterializedNoteQuality accepts register-based HTTP failure fixes'
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts natural HTTP registration ordering fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Register /api/notes before issuing API requests to prevent HTTP 404.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes was registered after request setup.',
+      'Resolution: Register /api/notes before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Register /api/notes before issuing API requests to prevent HTTP 404.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes was registered after request setup.',
+      resolution: 'Register /api/notes before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality accepts concrete NODE_ENV HTTP failure fixes', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Production API config import ordering caused HTTP 500',
@@ -462,6 +483,27 @@ test('validateMaterializedNoteQuality accepts concrete NODE_ENV HTTP failure fix
       summary: 'Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
       outcome_type: 'fix',
       root_cause: 'Production API requests returned HTTP 500 because config imported NODE_ENV after request setup.',
+      resolution: 'Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts natural NODE_ENV HTTP import ordering fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Production API config import ordering caused HTTP 500',
+    summary: 'Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
+    key_conclusions: [
+      'Root cause: Production API requests returned HTTP 500 because NODE_ENV config was imported after request setup.',
+      'Resolution: Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
+    ],
+    raw_payload: {
+      summary: 'Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
+      outcome_type: 'fix',
+      root_cause: 'Production API requests returned HTTP 500 because NODE_ENV config was imported after request setup.',
       resolution: 'Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
     },
   }), { mode: 'auto' });
@@ -507,6 +549,27 @@ test('validateMaterializedNoteQuality rejects generic HTTP root cause rationales
   assert.equal(reliabilityResult.accepted, false);
   assert.equal(reliabilityResult.reason, 'low-note-quality');
   assert.ok(reliabilityResult.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic HTTP rationales with route tokens', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'API HTTP 404 generic route fix',
+    summary: 'Register /api/notes before issuing API requests.',
+    key_conclusions: [
+      'Root cause: API returned HTTP 404 because correctness mattered; missing route.',
+      'Resolution: Register /api/notes before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Register /api/notes before issuing API requests.',
+      outcome_type: 'fix',
+      root_cause: 'API returned HTTP 404 because correctness mattered; missing route.',
+      resolution: 'Register /api/notes before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects weak not-correct HTTP root causes', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -231,6 +231,27 @@ test('validateMaterializedNoteQuality rejects package metadata existence even wi
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects package metadata was-there existence claims', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Package metadata release checks',
+    summary: 'Normalize package metadata before comparing generated dist output during release checks.',
+    key_conclusions: [
+      'Root cause: Package metadata was there because generated dist output diverged during release checks.',
+      'Resolution: Normalize package metadata before comparing generated dist output during release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package metadata before comparing generated dist output during release checks.',
+      outcome_type: 'fix',
+      root_cause: 'Package metadata was there because generated dist output diverged during release checks.',
+      resolution: 'Normalize package metadata before comparing generated dist output during release checks.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality accepts API registration ordering HTTP failures', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'API registration ordering caused HTTP 404',
@@ -265,6 +286,27 @@ test('validateMaterializedNoteQuality accepts register-based HTTP failure fixes'
       outcome_type: 'fix',
       root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
       resolution: 'Register /api/notes before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts concrete NODE_ENV HTTP failure fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Production API config import ordering caused HTTP 500',
+    summary: 'Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
+    key_conclusions: [
+      'Root cause: Production API requests returned HTTP 500 because config imported NODE_ENV after request setup.',
+      'Resolution: Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
+    ],
+    raw_payload: {
+      summary: 'Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
+      outcome_type: 'fix',
+      root_cause: 'Production API requests returned HTTP 500 because config imported NODE_ENV after request setup.',
+      resolution: 'Validate NODE_ENV before request setup to prevent HTTP 500 in production API requests.',
     },
   }), { mode: 'auto' });
 
@@ -531,6 +573,23 @@ test('validateMaterializedNoteQuality accepts fallback decisions with existence 
       summary: 'Set DATA_DIR before importing the Electron server entrypoint to prevent fallback to the default data directory when it exists.',
       outcome_type: 'decision',
       decisions: ['Set DATA_DIR before importing the Electron server entrypoint to prevent fallback to the default data directory when it exists.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts default data directory fallback wording', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'DATA_DIR prevents default fallback',
+    summary: 'Set DATA_DIR before importing the Electron server entrypoint to prevent default data directory fallback when it exists.',
+    key_conclusions: ['Decision: Set DATA_DIR before importing the Electron server entrypoint to prevent default data directory fallback when it exists.'],
+    raw_payload: {
+      summary: 'Set DATA_DIR before importing the Electron server entrypoint to prevent default data directory fallback when it exists.',
+      outcome_type: 'decision',
+      decisions: ['Set DATA_DIR before importing the Electron server entrypoint to prevent default data directory fallback when it exists.'],
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -334,6 +334,48 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
       resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
     },
   }), { mode: 'auto' });
+  const typecheckPassedResult = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Typecheck passed for /api/notes HTTP 404 after the route registration ran before request setup.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+    ],
+    raw_payload: {
+      summary: 'Typecheck passed for /api/notes HTTP 404 after the route registration ran before request setup.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
+  const lintPassedResult = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Lint passed for /api/notes HTTP 404 after the route registration ran before request setup.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+    ],
+    raw_payload: {
+      summary: 'Lint passed for /api/notes HTTP 404 after the route registration ran before request setup.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
+  const ciCompletedResult = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'CI completed successfully for /api/notes HTTP 404 after the route registration ran before request setup.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+    ],
+    raw_payload: {
+      summary: 'CI completed successfully for /api/notes HTTP 404 after the route registration ran before request setup.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(summaryResult.accepted, false);
   assert.equal(summaryResult.reason, 'low-note-quality');
@@ -365,6 +407,15 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
   assert.equal(localTestsSucceededResult.accepted, false);
   assert.equal(localTestsSucceededResult.reason, 'low-note-quality');
   assert.ok(localTestsSucceededResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(typecheckPassedResult.accepted, false);
+  assert.equal(typecheckPassedResult.reason, 'low-note-quality');
+  assert.ok(typecheckPassedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(lintPassedResult.accepted, false);
+  assert.equal(lintPassedResult.reason, 'low-note-quality');
+  assert.ok(lintPassedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(ciCompletedResult.accepted, false);
+  assert.equal(ciCompletedResult.reason, 'low-note-quality');
+  assert.ok(ciCompletedResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects low-quality extra key conclusions', () => {
@@ -640,6 +691,51 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
       resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
     },
   }), { mode: 'auto' });
+  const routeTypecheckPassedResult = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+      'Build: Typecheck passed for /api/notes HTTP 404.',
+    ],
+    raw_payload: {
+      summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
+  const routeLintPassedResult = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+      'Build: Lint passed for /api/notes HTTP 404.',
+    ],
+    raw_payload: {
+      summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
+  const routeCiCompletedResult = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+      'Build: CI completed successfully for /api/notes HTTP 404.',
+    ],
+    raw_payload: {
+      summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(genericTakeawayResult.accepted, false);
   assert.equal(genericTakeawayResult.reason, 'low-note-quality');
@@ -695,6 +791,15 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
   assert.equal(routeTestsSucceededResult.accepted, false);
   assert.equal(routeTestsSucceededResult.reason, 'low-note-quality');
   assert.ok(routeTestsSucceededResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(routeTypecheckPassedResult.accepted, false);
+  assert.equal(routeTypecheckPassedResult.reason, 'low-note-quality');
+  assert.ok(routeTypecheckPassedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(routeLintPassedResult.accepted, false);
+  assert.equal(routeLintPassedResult.reason, 'low-note-quality');
+  assert.ok(routeLintPassedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(routeCiCompletedResult.accepted, false);
+  assert.equal(routeCiCompletedResult.reason, 'low-note-quality');
+  assert.ok(routeCiCompletedResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects fix outcomes without visible fix conclusions', () => {
@@ -1840,6 +1945,26 @@ test('validateMaterializedNoteQuality accepts serialized DB persistence fixes', 
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts stale Vectra index cleanup fixes', () => {
+  const root = 'Semantic search returned stale note_id hits because note deletion removed sql.js rows without removing Vectra index entries.';
+  const resolution = 'Remove Vectra index entries after deleting sql.js note rows so semantic search cannot return deleted notes.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Note deletion leaves Vectra index entries stale',
+    summary: 'Remove Vectra index entries after deleting notes from sql.js so semantic search does not return stale note_id hits.',
+    key_conclusions: [`Root cause: ${root}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Remove Vectra index entries after deleting notes from sql.js so semantic search does not return stale note_id hits.',
+      root_cause: root,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality rejects generic DB queue reliability fixes', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'DB queue reliability fix',
@@ -1853,6 +1978,27 @@ test('validateMaterializedNoteQuality rejects generic DB queue reliability fixes
       summary: 'Queue chatcrystal.db writes so database reliability improves.',
       root_cause: 'DB writes were unreliable.',
       resolution: 'Queue chatcrystal.db writes so database reliability improves.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic search index cleanup reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search index cleanup reliability fix',
+    summary: 'Clean up semantic search index entries so search reliability improves.',
+    key_conclusions: [
+      'Root cause: Search index entries were unreliable.',
+      'Resolution: Clean up semantic search index entries so search reliability improves.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Clean up semantic search index entries so search reliability improves.',
+      root_cause: 'Search index entries were unreliable.',
+      resolution: 'Clean up semantic search index entries so search reliability improves.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -106,6 +106,26 @@ test('validateMaterializedNoteQuality rejects one-off status records disguised a
   assert.ok(result.warnings.includes('one_off_status'));
 });
 
+test('validateMaterializedNoteQuality rejects package version status comparisons disguised as prevention', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Package version status prevents dist mismatch',
+    summary: 'Compare current package version before generated dist output to prevent mismatch in local status checks.',
+    key_conclusions: ['Decision: Compare current package version before generated dist output to prevent mismatch in local status checks.'],
+    raw_payload: {
+      summary: 'Compare current package version before generated dist output to prevent mismatch in local status checks.',
+      outcome_type: 'decision',
+      decisions: ['Compare current package version before generated dist output to prevent mismatch in local status checks.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(
+    result.warnings.includes('one_off_status') ||
+    result.warnings.includes('durable_reusable_lesson'),
+  );
+});
+
 test('validateMaterializedNoteQuality accepts reusable package version fixes', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Normalize package version parsing before dist comparison',
@@ -543,6 +563,23 @@ test('validateMaterializedNoteQuality rejects identifier order decisions without
       summary: 'Set DATA_DIR before PORT when configuring /api/notes request setup.',
       outcome_type: 'decision',
       decisions: ['Set DATA_DIR before PORT when configuring /api/notes request setup.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic prevention wording without named consequences', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'DATA_DIR ordering prevents generic failure',
+    summary: 'Set DATA_DIR before server request setup to prevent failure in future runs.',
+    key_conclusions: ['Decision: Set DATA_DIR before server request setup to prevent failure in future runs.'],
+    raw_payload: {
+      summary: 'Set DATA_DIR before server request setup to prevent failure in future runs.',
+      outcome_type: 'decision',
+      decisions: ['Set DATA_DIR before server request setup to prevent failure in future runs.'],
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -1169,6 +1169,20 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const chineseDiaryResult = validateMaterializedNoteQuality(note({
+    title: 'Fastify readiness 竞态导致 ECONNREFUSED',
+    summary: '我添加了 Fastify readiness 等待，所以 API requests 不会在 server startup 前触发 ECONNREFUSED。',
+    key_conclusions: [
+      'Root cause: API requests hit ECONNREFUSED because they ran before Fastify readiness during server startup.',
+      'Resolution: 我添加了 Fastify readiness wait before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: '我添加了 Fastify readiness 等待，所以 API requests 不会在 server startup 前触发 ECONNREFUSED。',
+      outcome_type: 'fix',
+      root_cause: 'API requests hit ECONNREFUSED because they ran before Fastify readiness during server startup.',
+      resolution: '我添加了 Fastify readiness wait before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(foundResult.accepted, false);
   assert.equal(foundResult.reason, 'low-note-quality');
@@ -1188,6 +1202,9 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
   assert.equal(laterSentenceResult.accepted, false);
   assert.equal(laterSentenceResult.reason, 'low-note-quality');
   assert.ok(laterSentenceResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(chineseDiaryResult.accepted, false);
+  assert.equal(chineseDiaryResult.reason, 'low-note-quality');
+  assert.ok(chineseDiaryResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects #87-like one-off status records in auto mode', () => {
@@ -1961,6 +1978,26 @@ test('validateMaterializedNoteQuality rejects generic fix tags', () => {
   assert.ok(result.warnings.includes('tags'));
 });
 
+test('validateMaterializedNoteQuality rejects identifier-only snippets', () => {
+  const result = validateMaterializedNoteQuality(note({
+    raw_payload: {
+      summary: 'Requests must wait for server readiness before client calls.',
+      outcome_type: 'fix',
+      root_cause: 'Client calls raced server startup.',
+      resolution: 'Block request setup until readiness resolves.',
+      code_snippets: [{
+        language: 'ts',
+        code: 'DATA_DIR',
+        description: 'Set DATA_DIR before importing the Electron server entrypoint.',
+      }],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('code_snippets'));
+});
+
 test('validateMaterializedNoteQuality accepts imported content sanitization fixes', () => {
   const root = 'The Claude Code adapter saved raw JSONL message content, so <system-reminder> and <command-name> tags leaked into human-facing notes.';
   const resolution = 'Strip Claude system XML tags in sanitizeContent before saving imported conversation messages.';
@@ -1994,6 +2031,50 @@ test('validateMaterializedNoteQuality rejects generic import sanitization reliab
       summary: 'Sanitize imported content so notes are reliable.',
       root_cause: 'Imported content was unreliable.',
       resolution: 'Sanitize imported content so notes are reliable.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality accepts cross-platform DATA_DIR path normalization fixes', () => {
+  const summary = 'Normalize C:/Users fixture paths with path.win32 before comparing DATA_DIR output because POSIX path parsing prepends the repo path on Ubuntu runners.';
+  const root_cause = 'Ubuntu runner prepended the repository path to C:/Users/Rayner/.chatcrystal/data because Node POSIX path parsing treated the Windows DATA_DIR fixture as relative.';
+  const resolution = 'Normalize Windows DATA_DIR fixture expectations with path.win32 before comparing resolveDataDirForTest output on POSIX runners.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Ubuntu treats Windows DATA_DIR fixture paths as relative',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    tags: ['data_dir', 'windows'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects generic path reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Path reliability fix',
+    summary: 'Normalize paths for reliability.',
+    key_conclusions: [
+      'Root cause: Path handling was unreliable.',
+      'Resolution: Normalize paths for reliability.',
+    ],
+    tags: ['data_dir', 'windows'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Normalize paths for reliability.',
+      root_cause: 'Path handling was unreliable.',
+      resolution: 'Normalize paths for reliability.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3757,6 +3757,8 @@ test('validateMaterializedNoteQuality rejects descriptor-prefix status update sh
   const chineseSummary = '语义搜索状态更新：activeRequestId gates setResults so stale /api/search responses cannot overwrite current results.';
   const statusForSummary = 'Search status update for /api/search returned HTTP 500 because route registration ran after request setup.';
   const chineseStatusSummary = '语义搜索状态：/api/search 因为路由在 request setup 之后注册而返回 HTTP 500。';
+  const statusNoSeparatorSummary = 'Search status /api/search returned HTTP 500 because route registration ran after request setup.';
+  const chineseStatusNoSeparatorSummary = '语义搜索状态 /api/search 因为路由在 request setup 之后注册而返回 HTTP 500。';
   const root_cause = 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.';
   const resolution = 'Gate setResults with activeRequestId so stale responses cannot overwrite current results.';
   const result = validateMaterializedNoteQuality(note({
@@ -3820,6 +3822,34 @@ test('validateMaterializedNoteQuality rejects descriptor-prefix status update sh
       resolution: '在 request setup 前注册 /api/search 路由，避免 API 请求返回 HTTP 500。',
     },
   }), { mode: 'auto' });
+  const statusNoSeparatorResult = validateMaterializedNoteQuality(note({
+    title: 'Search status /api/search returned HTTP 500',
+    summary: statusNoSeparatorSummary,
+    key_conclusions: [
+      'Root cause: /api/search returned HTTP 500 because route registration ran after request setup.',
+      'Resolution: Register /api/search before request setup so API requests do not return HTTP 500.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: statusNoSeparatorSummary,
+      root_cause: '/api/search returned HTTP 500 because route registration ran after request setup.',
+      resolution: 'Register /api/search before request setup so API requests do not return HTTP 500.',
+    },
+  }), { mode: 'auto' });
+  const chineseStatusNoSeparatorResult = validateMaterializedNoteQuality(note({
+    title: '语义搜索状态 /api/search 返回 HTTP 500',
+    summary: chineseStatusNoSeparatorSummary,
+    key_conclusions: [
+      'Root cause: /api/search 路由在 request setup 之后注册，导致 API 请求返回 HTTP 500。',
+      'Resolution: 在 request setup 前注册 /api/search 路由，避免 API 请求返回 HTTP 500。',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: chineseStatusNoSeparatorSummary,
+      root_cause: '/api/search 路由在 request setup 之后注册，导致 API 请求返回 HTTP 500。',
+      resolution: '在 request setup 前注册 /api/search 路由，避免 API 请求返回 HTTP 500。',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
@@ -3836,6 +3866,12 @@ test('validateMaterializedNoteQuality rejects descriptor-prefix status update sh
   assert.equal(chineseStatusResult.accepted, false);
   assert.equal(chineseStatusResult.reason, 'low-note-quality');
   assert.ok(chineseStatusResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(statusNoSeparatorResult.accepted, false);
+  assert.equal(statusNoSeparatorResult.reason, 'low-note-quality');
+  assert.ok(statusNoSeparatorResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(chineseStatusNoSeparatorResult.accepted, false);
+  assert.equal(chineseStatusNoSeparatorResult.reason, 'low-note-quality');
+  assert.ok(chineseStatusNoSeparatorResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects English work record structured items', () => {
@@ -3910,6 +3946,41 @@ test('validateMaterializedNoteQuality rejects during-this-run implementation she
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects for-this-run implementation fix shells', () => {
+  const summary = 'For this run, gate setResults by activeRequestId so stale /api/search responses cannot overwrite current results.';
+  const taskSummary = 'For this task, gate setResults by activeRequestId so stale /api/search responses cannot overwrite current results.';
+  const root_cause = 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.';
+  const resolution = 'Gate setResults by activeRequestId so stale /api/search responses cannot overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+  const taskResult = validateMaterializedNoteQuality(note({
+    title: 'Search request id gate prevents stale responses',
+    summary: taskSummary,
+    key_conclusions: [`Decision: ${taskSummary}`],
+    raw_payload: {
+      outcome_type: 'decision',
+      summary: taskSummary,
+      decisions: [taskSummary],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+  assert.equal(taskResult.accepted, false);
+  assert.equal(taskResult.reason, 'low-note-quality');
+  assert.ok(taskResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects Chinese current-run implementation shells', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -358,6 +358,21 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const localTestingResult = validateMaterializedNoteQuality(note({
+    title: 'Server readiness race returns ECONNREFUSED',
+    summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+      'Takeaway: Local testing passed.',
+    ],
+    raw_payload: {
+      summary: 'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(genericTakeawayResult.accepted, false);
   assert.equal(genericTakeawayResult.reason, 'low-note-quality');
@@ -374,6 +389,9 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
   assert.equal(validateBehaviorResult.accepted, false);
   assert.equal(validateBehaviorResult.reason, 'low-note-quality');
   assert.ok(validateBehaviorResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(localTestingResult.accepted, false);
+  assert.equal(localTestingResult.reason, 'low-note-quality');
+  assert.ok(localTestingResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects diary or status summaries with concrete conclusions', () => {
@@ -448,6 +466,20 @@ test('validateMaterializedNoteQuality rejects diary or status summaries with con
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const testedResult = validateMaterializedNoteQuality(note({
+    title: 'Tested server readiness ECONNREFUSED fix',
+    summary: 'Tested server readiness fix locally after waiting for Fastify readiness before issuing API requests.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Tested server readiness fix locally after waiting for Fastify readiness before issuing API requests.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(diaryResult.accepted, false);
   assert.equal(diaryResult.reason, 'low-note-quality');
@@ -464,6 +496,9 @@ test('validateMaterializedNoteQuality rejects diary or status summaries with con
   assert.equal(observedResult.accepted, false);
   assert.equal(observedResult.reason, 'low-note-quality');
   assert.ok(observedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(testedResult.accepted, false);
+  assert.equal(testedResult.reason, 'low-note-quality');
+  assert.ok(testedResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects generic visible patterns with concrete raw payloads', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -252,6 +252,44 @@ test('validateMaterializedNoteQuality rejects package metadata was-there existen
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
+test('validateMaterializedNoteQuality rejects package metadata found or included existence claims', () => {
+  const foundResult = validateMaterializedNoteQuality(note({
+    title: 'Package metadata release checks',
+    summary: 'Normalize package metadata before comparing generated dist output during release checks.',
+    key_conclusions: [
+      'Root cause: Package metadata was found because generated dist output diverged during release checks.',
+      'Resolution: Normalize package metadata before comparing generated dist output during release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package metadata before comparing generated dist output during release checks.',
+      outcome_type: 'fix',
+      root_cause: 'Package metadata was found because generated dist output diverged during release checks.',
+      resolution: 'Normalize package metadata before comparing generated dist output during release checks.',
+    },
+  }), { mode: 'auto' });
+  const includedResult = validateMaterializedNoteQuality(note({
+    title: 'Package metadata release checks',
+    summary: 'Normalize package metadata before comparing generated dist output during release checks.',
+    key_conclusions: [
+      'Root cause: Package metadata was included because generated dist output diverged during release checks.',
+      'Resolution: Normalize package metadata before comparing generated dist output during release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package metadata before comparing generated dist output during release checks.',
+      outcome_type: 'fix',
+      root_cause: 'Package metadata was included because generated dist output diverged during release checks.',
+      resolution: 'Normalize package metadata before comparing generated dist output during release checks.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(foundResult.accepted, false);
+  assert.equal(foundResult.reason, 'low-note-quality');
+  assert.ok(foundResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(includedResult.accepted, false);
+  assert.equal(includedResult.reason, 'low-note-quality');
+  assert.ok(includedResult.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality accepts API registration ordering HTTP failures', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'API registration ordering caused HTTP 404',
@@ -313,6 +351,27 @@ test('validateMaterializedNoteQuality accepts concrete NODE_ENV HTTP failure fix
   assert.equal(result.accepted, true);
   assert.equal(result.reason, 'note-quality-ok');
   assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality rejects weak not-correct HTTP root causes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'API route weak HTTP fix',
+    summary: 'Register /api/notes before issuing API requests.',
+    key_conclusions: [
+      'Root cause: API route was not correct before request setup, so API requests returned HTTP 404.',
+      'Resolution: Register /api/notes before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Register /api/notes before issuing API requests.',
+      outcome_type: 'fix',
+      root_cause: 'API route was not correct before request setup, so API requests returned HTTP 404.',
+      resolution: 'Register /api/notes before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects generic environment decisions', () => {
@@ -641,6 +700,23 @@ test('validateMaterializedNoteQuality rejects default data directory on-disk dec
       summary: 'Set DATA_DIR before importing the Electron server entrypoint because the default data directory is on disk.',
       outcome_type: 'decision',
       decisions: ['Set DATA_DIR before importing the Electron server entrypoint because the default data directory is on disk.'],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects default data directory fallback existence decisions', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'DATA_DIR fallback existence decision',
+    summary: 'Set DATA_DIR before importing the Electron server entrypoint because default data directory fallback existed.',
+    key_conclusions: ['Decision: Set DATA_DIR before importing the Electron server entrypoint because default data directory fallback existed.'],
+    raw_payload: {
+      summary: 'Set DATA_DIR before importing the Electron server entrypoint because default data directory fallback existed.',
+      outcome_type: 'decision',
+      decisions: ['Set DATA_DIR before importing the Electron server entrypoint because default data directory fallback existed.'],
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -209,6 +209,27 @@ test('validateMaterializedNoteQuality accepts natural package metadata and dist 
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts caused package dist differences', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Normalize prerelease metadata before dist output',
+    summary: 'Normalize package version metadata before generating dist output during release checks.',
+    key_conclusions: [
+      'Root cause: Version normalization stripped prerelease tags and caused generated dist output to differ from package metadata.',
+      'Resolution: Normalize package version metadata before generating dist output during release checks.',
+    ],
+    raw_payload: {
+      summary: 'Normalize package version metadata before generating dist output during release checks.',
+      outcome_type: 'fix',
+      root_cause: 'Version normalization stripped prerelease tags and caused generated dist output to differ from package metadata.',
+      resolution: 'Normalize package version metadata before generating dist output during release checks.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality accepts causal package metadata inclusion fixes', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Normalize package metadata before dist generation',
@@ -602,6 +623,27 @@ test('validateMaterializedNoteQuality accepts natural HTTP registration ordering
       summary: 'Register /api/notes before issuing API requests to prevent HTTP 404.',
       outcome_type: 'fix',
       root_cause: 'API requests returned HTTP 404 because /api/notes was registered after request setup.',
+      resolution: 'Register /api/notes before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts not-registered HTTP route fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Register /api/notes before issuing API requests.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes route was not registered before request setup.',
+      'Resolution: Register /api/notes before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Register /api/notes before issuing API requests.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes route was not registered before request setup.',
       resolution: 'Register /api/notes before issuing API requests.',
     },
   }), { mode: 'auto' });

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -306,6 +306,20 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const allGoodRouteResult = validateMaterializedNoteQuality(note({
+    title: 'All good now for /api/notes HTTP 404',
+    summary: 'All good now for /api/notes HTTP 404 after the route fix.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+    ],
+    raw_payload: {
+      summary: 'All good now for /api/notes HTTP 404 after the route fix.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(summaryResult.accepted, false);
   assert.equal(summaryResult.reason, 'low-note-quality');
@@ -331,6 +345,9 @@ test('validateMaterializedNoteQuality rejects generic reliability visible fields
   assert.equal(genericSummaryResult.accepted, false);
   assert.equal(genericSummaryResult.reason, 'low-note-quality');
   assert.ok(genericSummaryResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(allGoodRouteResult.accepted, false);
+  assert.equal(allGoodRouteResult.reason, 'low-note-quality');
+  assert.ok(allGoodRouteResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects low-quality extra key conclusions', () => {
@@ -546,6 +563,36 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
       resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
     },
   }), { mode: 'auto' });
+  const routeInvestigationObservationResult = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+      'Observation: The issue was investigated for /api/notes HTTP 404.',
+    ],
+    raw_payload: {
+      summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
+  const routeAllGoodTakeawayResult = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+      'Takeaway: All good now for /api/notes HTTP 404.',
+    ],
+    raw_payload: {
+      summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(genericTakeawayResult.accepted, false);
   assert.equal(genericTakeawayResult.reason, 'low-note-quality');
@@ -589,6 +636,12 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
   assert.equal(genericRouteFixResult.accepted, false);
   assert.equal(genericRouteFixResult.reason, 'low-note-quality');
   assert.ok(genericRouteFixResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(routeInvestigationObservationResult.accepted, false);
+  assert.equal(routeInvestigationObservationResult.reason, 'low-note-quality');
+  assert.ok(routeInvestigationObservationResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(routeAllGoodTakeawayResult.accepted, false);
+  assert.equal(routeAllGoodTakeawayResult.reason, 'low-note-quality');
+  assert.ok(routeAllGoodTakeawayResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects fix outcomes without visible fix conclusions', () => {
@@ -1546,6 +1599,27 @@ test('validateMaterializedNoteQuality accepts concrete parser TypeError fixes', 
       outcome_type: 'fix',
       root_cause: 'Codex JSONL parsing threw TypeError because response_item.content was read before validating the partial event shape.',
       resolution: 'Validate response_item.content before reading parser fields and skip partial Codex events without content.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts concrete negative parser pitfalls', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Codex parser partial events throw TypeError',
+    summary: 'Validate response_item.content before reading parser fields so partial Codex events do not throw TypeError.',
+    key_conclusions: [
+      'Pitfall: Do not read response_item.content before validating parser fields because partial Codex events throw TypeError.',
+    ],
+    raw_payload: {
+      summary: 'Validate response_item.content before reading parser fields so partial Codex events do not throw TypeError.',
+      outcome_type: 'pitfall',
+      pitfalls: [
+        'Do not read response_item.content before validating parser fields because partial Codex events throw TypeError.',
+      ],
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -72,6 +72,27 @@ test('validateMaterializedNoteQuality accepts readiness fixes with reliable outc
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality rejects generic resolutions with concrete root causes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Server readiness generic validation',
+    summary: 'Add validation to prevent future failures.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Add validation to prevent future failures.',
+    ],
+    raw_payload: {
+      summary: 'Add validation to prevent future failures.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Add validation to prevent future failures.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality rejects #87-like one-off status records in auto mode', () => {
   const result = validateMaterializedNoteQuality(note({
     title: 'Check local dist and linked core',

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -3187,6 +3187,28 @@ test('validateMaterializedNoteQuality accepts SQL parameterized tag lookup fixes
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts SQLite migration backfill constraint fixes', () => {
+  const summary = 'Backfill existing SQLite note rows before enforcing a NOT NULL column so migration does not fail on old chatcrystal.db files.';
+  const root_cause = 'The migration added a NOT NULL notes column without a DEFAULT, so existing chatcrystal.db rows violated the constraint during startup.';
+  const resolution = 'Add the column nullable, backfill existing rows, then enforce NOT NULL after the data satisfies the constraint.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'SQLite migration NOT NULL default prevents existing row failures',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    tags: ['sqlite', 'migration'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality accepts stale async search response fixes', () => {
   const summary = 'Cancel older /api/search requests because slower previous responses overwrote the current query results in the React search view.';
   const root_cause = 'React search fired overlapping /api/search requests, so a slower previous response overwrote the current query results.';
@@ -3530,6 +3552,48 @@ test('validateMaterializedNoteQuality rejects English status report structured i
     },
     tags: ['search', 'frontend'],
     embedding_text: '',
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects technical-prefix status update shells', () => {
+  const summary = '/api/search status update: activeRequestId gates setResults so stale responses cannot overwrite current results.';
+  const root_cause = 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.';
+  const resolution = 'Gate setResults with activeRequestId so stale responses cannot overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: summary,
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects Chinese technical-prefix status update shells', () => {
+  const summary = '/api/search 状态更新：activeRequestId gates setResults，避免 stale responses overwrite current results.';
+  const root_cause = 'Older /api/search responses overwrote current results because setResults did not check activeRequestId.';
+  const resolution = 'Gate setResults with activeRequestId so stale responses cannot overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: summary,
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
   }), { mode: 'auto' });
 
   assert.equal(result.accepted, false);
@@ -3997,6 +4061,28 @@ test('validateMaterializedNoteQuality rejects generic SQL parameterization relia
       summary: 'Bind SQL parameters for reliability.',
       root_cause: 'SQL query reliability mattered.',
       resolution: 'Use parameterized queries to improve quality.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic migration backfill reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Migration backfill reliability fix',
+    summary: 'Backfill migrations for reliability.',
+    key_conclusions: [
+      'Root cause: Migration reliability mattered.',
+      'Resolution: Add defaults to improve quality.',
+    ],
+    tags: ['sqlite', 'migration'],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Backfill migrations for reliability.',
+      root_cause: 'Migration reliability mattered.',
+      resolution: 'Add defaults to improve quality.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -2999,6 +2999,28 @@ test('validateMaterializedNoteQuality accepts request-id gated stale response fi
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality rejects Chinese status-shell structured items', () => {
+  const summary = '状态记录：使用 active request id gate /api/search result updates，避免 stale responses overwrite current results.';
+  const result = validateMaterializedNoteQuality(note({
+    title: '状态记录 /api/search active request id stale response',
+    summary,
+    key_conclusions: [
+      `Decision: ${summary}`,
+    ],
+    raw_payload: {
+      summary,
+      outcome_type: 'decision',
+      decisions: [
+        summary,
+      ],
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
 test('validateMaterializedNoteQuality accepts route initialization HTTP failures', () => {
   const summary = 'POST /api/import returned HTTP 500 because the route handled requests before sql.js finished initialization; wait for db initialization before accepting import requests.';
   const root_cause = 'POST /api/import returned HTTP 500 because the route handled requests before sql.js finished initialization.';
@@ -3061,6 +3083,27 @@ test('validateMaterializedNoteQuality rejects recorded fix completion patterns',
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality accepts orphan note tag cleanup fixes', () => {
+  const summary = 'Filter tags through existing note_ids and prune orphan note_tags rows so WebUI filter chips do not show count 0 after note deletion.';
+  const root_cause = 'Deleting notes left orphan note_tags rows and unused tags because cleanup did not remove joins whose note_id no longer existed.';
+  const resolution = 'Filter tag counts through existing notes and prune orphan note_tags rows after deleteNoteWithReview removes a note.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Hide and prune orphan tags after note deletion',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
 });
 
 test('validateMaterializedNoteQuality accepts stale Vectra index cleanup fixes', () => {
@@ -3205,6 +3248,27 @@ test('validateMaterializedNoteQuality rejects generic request-id gating reliabil
       summary: 'Gate requests by request id to improve search reliability.',
       root_cause: 'Search requests were unreliable.',
       resolution: 'Gate requests by request id to improve search reliability.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic orphan tag cleanup reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Tag cleanup reliability fix',
+    summary: 'Prune orphan rows to improve tag cleanup quality.',
+    key_conclusions: [
+      'Root cause: Tag cleanup quality was unreliable.',
+      'Resolution: Prune orphan rows to improve tag cleanup quality.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Prune orphan rows to improve tag cleanup quality.',
+      root_cause: 'Tag cleanup quality was unreliable.',
+      resolution: 'Prune orphan rows to improve tag cleanup quality.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -514,6 +514,38 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
       resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
     },
   }), { mode: 'auto' });
+  const genericRootCauseResult = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+      'Root cause: Server configuration issue.',
+    ],
+    raw_payload: {
+      summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
+  const genericRouteFixResult = validateMaterializedNoteQuality(note({
+    title: 'API registration ordering caused HTTP 404',
+    summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    key_conclusions: [
+      'Root cause: API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      'Resolution: Register /api/notes before request setup so API requests do not return HTTP 404.',
+      'Root cause: API route misconfiguration.',
+      'Resolution: Update the API route configuration.',
+      'Resolution: Apply the route fix.',
+    ],
+    raw_payload: {
+      summary: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+      outcome_type: 'fix',
+      root_cause: 'API requests returned HTTP 404 because /api/notes registration ran after request setup.',
+      resolution: 'Register /api/notes before request setup so API requests do not return HTTP 404.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(genericTakeawayResult.accepted, false);
   assert.equal(genericTakeawayResult.reason, 'low-note-quality');
@@ -551,6 +583,12 @@ test('validateMaterializedNoteQuality rejects low-quality extra key conclusions'
   assert.equal(genericResolutionResult.accepted, false);
   assert.equal(genericResolutionResult.reason, 'low-note-quality');
   assert.ok(genericResolutionResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(genericRootCauseResult.accepted, false);
+  assert.equal(genericRootCauseResult.reason, 'low-note-quality');
+  assert.ok(genericRootCauseResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(genericRouteFixResult.accepted, false);
+  assert.equal(genericRouteFixResult.reason, 'low-note-quality');
+  assert.ok(genericRouteFixResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects fix outcomes without visible fix conclusions', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -2978,6 +2978,48 @@ test('validateMaterializedNoteQuality accepts stale async search response fixes'
   assert.deepEqual(result.warnings, []);
 });
 
+test('validateMaterializedNoteQuality accepts route initialization HTTP failures', () => {
+  const summary = 'POST /api/import returned HTTP 500 because the route handled requests before sql.js finished initialization; wait for db initialization before accepting import requests.';
+  const root_cause = 'POST /api/import returned HTTP 500 because the route handled requests before sql.js finished initialization.';
+  const resolution = 'Wait for db initialization before accepting /api/import requests.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'Import route returns HTTP 500 before sql.js initialization',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
+test('validateMaterializedNoteQuality accepts MCP stdio JSON-RPC transport fixes', () => {
+  const summary = 'Writing logs to process.stdout corrupts MCP JSON-RPC framing because stdout is the response transport; send diagnostics to process.stderr instead.';
+  const root_cause = 'Logs written to process.stdout interleaved with MCP JSON-RPC responses, so the client could not parse the stdio stream.';
+  const resolution = 'Send diagnostics to process.stderr and reserve process.stdout for JSON-RPC response frames.';
+  const result = validateMaterializedNoteQuality(note({
+    title: 'MCP stdout logging corrupts JSON-RPC responses',
+    summary,
+    key_conclusions: [`Root cause: ${root_cause}`, `Resolution: ${resolution}`],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary,
+      root_cause,
+      resolution,
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.reason, 'note-quality-ok');
+  assert.deepEqual(result.warnings, []);
+});
+
 test('validateMaterializedNoteQuality accepts stale Vectra index cleanup fixes', () => {
   const root = 'Semantic search returned stale note_id hits because note deletion removed sql.js rows without removing Vectra index entries.';
   const resolution = 'Remove Vectra index entries after deleting sql.js note rows so semantic search cannot return deleted notes.';
@@ -3098,6 +3140,48 @@ test('validateMaterializedNoteQuality rejects generic frontend cancel reliabilit
       summary: 'Cancel requests to improve frontend reliability.',
       root_cause: 'Frontend requests were unreliable.',
       resolution: 'Cancel requests to improve frontend reliability.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic initialization reliability fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'API initialization reliability fix',
+    summary: 'Wait for initialization to improve API reliability.',
+    key_conclusions: [
+      'Root cause: API initialization was unreliable.',
+      'Resolution: Wait for initialization to improve API reliability.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Wait for initialization to improve API reliability.',
+      root_cause: 'API initialization was unreliable.',
+      resolution: 'Wait for initialization to improve API reliability.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('durable_reusable_lesson'));
+});
+
+test('validateMaterializedNoteQuality rejects generic logging compatibility fixes', () => {
+  const result = validateMaterializedNoteQuality(note({
+    title: 'MCP logging compatibility fix',
+    summary: 'Send logs elsewhere to improve MCP compatibility.',
+    key_conclusions: [
+      'Root cause: MCP logging compatibility was unreliable.',
+      'Resolution: Send logs elsewhere to improve MCP compatibility.',
+    ],
+    raw_payload: {
+      outcome_type: 'fix',
+      summary: 'Send logs elsewhere to improve MCP compatibility.',
+      root_cause: 'MCP logging compatibility was unreliable.',
+      resolution: 'Send logs elsewhere to improve MCP compatibility.',
     },
   }), { mode: 'auto' });
 

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -249,6 +249,59 @@ test('validateMaterializedNoteQuality rejects first-person implementation diary 
   assert.equal(result.accepted, false);
   assert.equal(result.reason, 'low-note-quality');
   assert.ok(result.warnings.includes('durable_reusable_lesson'));
+
+  const foundResult = validateMaterializedNoteQuality(note({
+    title: 'Readiness implementation diary fix',
+    summary: 'Found readiness race and kept the wait.',
+    key_conclusions: [
+      'Root cause: I found client calls hit ECONNREFUSED because they ran before the local server was ready.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Found readiness race and kept the wait.',
+      outcome_type: 'fix',
+      root_cause: 'I found client calls hit ECONNREFUSED because they ran before the local server was ready.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+  const diagnosedResult = validateMaterializedNoteQuality(note({
+    title: 'Readiness implementation diary fix',
+    summary: 'Diagnosed readiness race and kept the wait.',
+    key_conclusions: [
+      'Root cause: We diagnosed client calls hit ECONNREFUSED because they ran before the local server was ready.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Diagnosed readiness race and kept the wait.',
+      outcome_type: 'fix',
+      root_cause: 'We diagnosed client calls hit ECONNREFUSED because they ran before the local server was ready.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+  const switchedResult = validateMaterializedNoteQuality(note({
+    title: 'Readiness implementation diary fix',
+    summary: 'Switched readiness handling and kept the wait.',
+    key_conclusions: [
+      'Root cause: Client calls hit ECONNREFUSED because they ran before the local server was ready.',
+      'Resolution: We switched request setup to wait for the Fastify readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Switched readiness handling and kept the wait.',
+      outcome_type: 'fix',
+      root_cause: 'Client calls hit ECONNREFUSED because they ran before the local server was ready.',
+      resolution: 'We switched request setup to wait for the Fastify readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+
+  assert.equal(foundResult.accepted, false);
+  assert.equal(foundResult.reason, 'low-note-quality');
+  assert.ok(foundResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(diagnosedResult.accepted, false);
+  assert.equal(diagnosedResult.reason, 'low-note-quality');
+  assert.ok(diagnosedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(switchedResult.accepted, false);
+  assert.equal(switchedResult.reason, 'low-note-quality');
+  assert.ok(switchedResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects #87-like one-off status records in auto mode', () => {

--- a/server/src/services/memory/quality.test.ts
+++ b/server/src/services/memory/quality.test.ts
@@ -221,6 +221,34 @@ test('validateMaterializedNoteQuality rejects diary or status summaries with con
       resolution: 'Regenerate generated dist output after bumping package metadata so release artifacts carry the new package version.',
     },
   }), { mode: 'auto' });
+  const addedResult = validateMaterializedNoteQuality(note({
+    title: 'Added server readiness wait after ECONNREFUSED',
+    summary: 'Added Fastify readiness wait after checking API request setup.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Added Fastify readiness wait after checking API request setup.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
+  const foundResult = validateMaterializedNoteQuality(note({
+    title: 'Found readiness race before Fastify startup',
+    summary: 'Found client API requests hit ECONNREFUSED before Fastify readiness.',
+    key_conclusions: [
+      'Root cause: Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      'Resolution: Wait for the Fastify server readiness promise before issuing API requests.',
+    ],
+    raw_payload: {
+      summary: 'Found client API requests hit ECONNREFUSED before Fastify readiness.',
+      outcome_type: 'fix',
+      root_cause: 'Client API requests hit ECONNREFUSED because request setup ran before Fastify readiness.',
+      resolution: 'Wait for the Fastify server readiness promise before issuing API requests.',
+    },
+  }), { mode: 'auto' });
 
   assert.equal(diaryResult.accepted, false);
   assert.equal(diaryResult.reason, 'low-note-quality');
@@ -228,6 +256,12 @@ test('validateMaterializedNoteQuality rejects diary or status summaries with con
   assert.equal(statusResult.accepted, false);
   assert.equal(statusResult.reason, 'low-note-quality');
   assert.ok(statusResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(addedResult.accepted, false);
+  assert.equal(addedResult.reason, 'low-note-quality');
+  assert.ok(addedResult.warnings.includes('durable_reusable_lesson'));
+  assert.equal(foundResult.accepted, false);
+  assert.equal(foundResult.reason, 'low-note-quality');
+  assert.ok(foundResult.warnings.includes('durable_reusable_lesson'));
 });
 
 test('validateMaterializedNoteQuality rejects generic visible patterns with concrete raw payloads', () => {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -824,6 +824,9 @@ function hasConcreteTransferableText(value: string) {
     hasConcreteConsequence &&
     !isExistenceOnlyClaim(value) &&
     !isFirstPersonDiaryClaim(value) &&
+    !isVisibleWorkLogClaim(value) &&
+    !isLowValueOutcomeStatusClaim(value) &&
+    !isVisibleStatusSnapshotText(value) &&
     !isGenericReleaseValidationClaim(value) &&
     !isGenericStatusAction(value) &&
     !isVagueGenericLesson(value)
@@ -1018,7 +1021,7 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
     /\b(writeback|receipt|source_agent|source_run_key)\b.+\b(unique key|unique constraint)\b/i
       .test(text);
   const hasNamedAsyncObject =
-    /\b(abortcontroller|react search|search view|\/api\/search|stale search requests?|stale responses?|previous responses?|current query results?|current results|overlapping requests?|overlapping \/api\/search requests?)\b/i
+    /\b(abortcontroller|react search|search view|\/api\/search|search request sequence|stale search requests?|stale responses?|stale results?|previous responses?|current query results?|current results|overlapping requests?|overlapping \/api\/search requests?)\b/i
       .test(text);
   const hasNamedTransportObject =
     /\b(mcp|json-rpc|json rpc|stdio|stdout|stderr|process\.stdout|process\.stderr|response frames?|response transport|stdio stream)\b/i
@@ -1050,6 +1053,10 @@ function hasStrictStructuralEngineeringAction(value: string) {
       .test(text);
   const hasConcreteAsyncAction =
     /\b(use\b.+\babortcontroller|abortcontroller\b.+\bcancel|cancel(?: older| previous| prior)?\b.+\b(?:\/api\/search|requests?|responses?))\b/i
+      .test(text) ||
+    /\b(gate)\b.+\b(result updates?|responses?|requests?)\b.+\b(active|latest|request id|query)\b/i
+      .test(text) ||
+    /\b(ignore)\b.+\b(responses?)\b.+\b(not from the latest query|older|previous|stale|latest query)\b/i
       .test(text);
   const hasConcreteLifecycleAction =
     /\b(wait)\b.+\b(db initialization|database initialization|sql\.js initialization|initialized|finished initialization)\b.+\b(before accepting|before handling|requests?)\b/i
@@ -1095,6 +1102,14 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
     /\b(cancel|abortcontroller)\b.+\b(before starting the next query|before updating results|next query)\b/i
       .test(text) ||
     /\bstale responses?\b.+\b(cannot|do not|does not)\b.+\b(replace|overwrite)\b.+\bcurrent results\b/i
+      .test(text) ||
+    /\b(gate)\b.+\b(result updates?|search result updates?|current results)\b.+\b(active|latest|request id|\/api\/search|query)\b/i
+      .test(text) ||
+    /\b(active|latest)\b.+\b(\/api\/search\s+)?request id\b.+\b(older responses?|stale responses?|current results|overwrite)\b/i
+      .test(text) ||
+    /\b(ignore)\b.+\bresponses?\b.+\b(not from the latest query|older|previous|stale|latest query)\b/i
+      .test(text) ||
+    /\bolder\b.+\b\/api\/search responses?\b.+\b(after a newer query|newer query)\b.+\boverwrite\b.+\bcurrent results\b/i
       .test(text);
   const hasInitializationOrderFlow =
     /\b(route|\/api\/[\w/-]+)\b.+\b(handled|handles?|accept(?:ed|ing)?|requests?)\b.+\bbefore\b.+\b(sql\.js|db|database)\b.+\b(finished initialization|initialization|initialized)\b/i
@@ -1115,7 +1130,7 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
     /\b(reserve)\b.+\b(process\.stdout|stdout)\b.+\b(json-rpc|json rpc|response frames?|stdio)\b/i
       .test(text);
   const hasCausalFlow =
-    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve)\b/i
+    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gate|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve)\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) &&
     hasCausalFlow &&
@@ -1133,7 +1148,7 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
 function hasStrictStructuralEngineeringFailureSignal(value: string) {
   const text = value.toLowerCase();
   const hasNamedConsequence =
-    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|stale responses?|overwrote the current query results?|overwrote current results?|replace current results?|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream))\b/i
+    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream))\b/i
       .test(text);
   const hasCausalFlow =
     /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?)\b/i
@@ -1397,7 +1412,7 @@ function hasVisibleConcreteContent(value: string) {
 }
 
 function isVisibleWorkLogClaim(value: string) {
-  return /^(added|changed|checked|confirmed|diagnosed|discovered|fixed|found|implemented|noted|observed|reviewed|resolved|switched|tested|testing|updated|verified)\b/i
+  return /^(added|changed|checked|confirmed|diagnosed|discovered|fixed|found|implemented|noted|observed|recorded|reviewed|resolved|switched|tested|testing|updated|verified)\b/i
     .test(value.trim());
 }
 
@@ -1405,6 +1420,11 @@ function isLowValueOutcomeStatusClaim(value: string) {
   const text = value.toLowerCase();
   return (
     /\ball good(?: now)?\b/i.test(text) ||
+    /\brecorded that\b/i.test(text) ||
+    /\bis now fixed\b/i.test(text) ||
+    /\bfix completed\b/i.test(text) ||
+    /\b(?:completed|recovered|fixed)\b.+\b(?:after|for|http|api|route|request|requests?|initialization|issue|fix)\b/i
+      .test(text) ||
     /\b(issue|task|fix|route fix|route|request|requests?)\b.+\b(investigated|investigation)\b/i
       .test(text) ||
     /\b(investigated|investigation)\b.+\b(issue|task|fix|route|request|requests?)\b/i

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -417,8 +417,10 @@ function hasDurableFixSignal(note: MaterializedTaskMemoryNote) {
 function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
   const payload = note.raw_payload;
   const hasVisibleSignal = hasVisibleQualitySignal(note);
+  const hasVisibleTitleSummarySignal = hasVisibleTitleSummaryQuality(note);
   const hasVisibleFixSignal = hasVisibleConcreteFixSignal(note);
   const hasFixSignal = hasDurableFixSignal(note);
+  if (!hasVisibleTitleSummarySignal) return false;
   if (hasFixSignal) return hasVisibleFixSignal;
   if (isMostlyOneOffStatus(note)) return false;
 
@@ -427,6 +429,37 @@ function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
     Boolean(payload.pitfalls?.some((item) => hasConcreteTransferableText(item))) ||
     Boolean(payload.decisions?.some((item) => hasConcreteTransferableText(item)));
   return hasStructuredSignal && hasVisibleStructuredSignal(note) && hasVisibleSignal;
+}
+
+function hasVisibleTitleSummaryQuality(note: MaterializedTaskMemoryNote) {
+  return hasVisibleTitleQuality(note.title) && hasVisibleSummaryQuality(note.summary);
+}
+
+function hasVisibleTitleQuality(title: string) {
+  return (
+    hasNonPlaceholderMeaningfulText(title, 10, 6) &&
+    !isGenericTitle(title) &&
+    !isFirstPersonDiaryClaim(title) &&
+    !isVagueGenericFixClaim(title) &&
+    !isVisibleStatusSnapshotText(title)
+  );
+}
+
+function hasVisibleSummaryQuality(summary: string) {
+  return (
+    hasNonPlaceholderMeaningfulText(summary) &&
+    !isFirstPersonDiaryClaim(summary) &&
+    !isVagueGenericFixClaim(summary) &&
+    !isVisibleStatusSnapshotText(summary)
+  );
+}
+
+function isVisibleStatusSnapshotText(value: string) {
+  const hasStatusVerb = /\b(checked|verified|verification|current|status)\b/i.test(value);
+  const hasStatusObject =
+    /\b(node_env|env|environment|production|local|package version|version|generated dist output|dist output)\b/i
+      .test(value);
+  return hasStatusVerb && hasStatusObject && !hasStrongReusableMechanism(value);
 }
 
 function conclusionText(
@@ -520,7 +553,10 @@ export function validateMaterializedNoteQuality(
   options: { mode: ValidationMode },
 ): NoteQualityDecision {
   const warnings: string[] = [];
-  const acceptedDurableFix = hasDurableFixSignal(note) && hasVisibleConcreteFixSignal(note);
+  const acceptedDurableFix =
+    hasDurableFixSignal(note) &&
+    hasVisibleConcreteFixSignal(note) &&
+    hasVisibleTitleSummaryQuality(note);
 
   if (!hasMeaningfulText(note.title, 10, 6) || isGenericTitle(note.title)) {
     warnings.push('title');

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -8,6 +8,52 @@ export type NoteQualityDecision = {
   warnings: string[];
 };
 
+const concreteActionWords = [
+  'add',
+  'block',
+  'cache',
+  'collapse',
+  'configure',
+  'compare',
+  'comparing',
+  'debounce',
+  'deduplicate',
+  'defer',
+  'enqueue',
+  'extract',
+  'filter',
+  'gate',
+  'group',
+  'import',
+  'index',
+  'initialize',
+  'load',
+  'migrate',
+  'move',
+  'normalize',
+  'parse',
+  'place',
+  'pin',
+  'prune',
+  'rebuild',
+  'regenerate',
+  'register',
+  'remove',
+  'replace',
+  'retry',
+  'sanitize',
+  'set',
+  'strip',
+  'truncate',
+  'validate',
+  'wait',
+  'wait for',
+  'wrap',
+  '避免',
+  '防止',
+  '复用',
+] as const;
+
 function compactLength(value: string) {
   return value.replace(/\s+/g, '').length;
 }
@@ -40,11 +86,15 @@ function joined(note: MaterializedTaskMemoryNote) {
   ].join('\n').toLowerCase();
 }
 
+function regexEscape(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function hasWord(text: string, word: string) {
   if (/[\u3400-\u9fff]/.test(word)) {
     return text.includes(word);
   }
-  return new RegExp(`\\b${word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i').test(text);
+  return new RegExp(`\\b${regexEscape(word)}\\b`, 'i').test(text);
 }
 
 function hasConcreteTransferableAction(value: string) {
@@ -58,51 +108,6 @@ function hasConcreteTransferableAction(value: string) {
   if (hasCrossPlatformPathAction(text)) return true;
   if (hasFrontendCacheInvalidationAction(text)) return true;
   if (hasSqliteWalSidecarAction(text)) return true;
-  const concreteActionWords = [
-    'add',
-    'block',
-    'cache',
-    'collapse',
-    'configure',
-    'compare',
-    'comparing',
-    'debounce',
-    'deduplicate',
-    'defer',
-    'enqueue',
-    'extract',
-    'filter',
-    'gate',
-    'group',
-    'import',
-    'index',
-    'initialize',
-    'load',
-    'migrate',
-    'move',
-    'normalize',
-    'parse',
-    'place',
-    'pin',
-    'prune',
-    'rebuild',
-    'regenerate',
-    'register',
-    'remove',
-    'replace',
-    'retry',
-    'sanitize',
-    'set',
-    'strip',
-    'truncate',
-    'validate',
-    'wait',
-    'wait for',
-    'wrap',
-    '避免',
-    '防止',
-    '复用',
-  ];
   return concreteActionWords.some((word) => hasWord(text, word));
 }
 
@@ -723,29 +728,35 @@ function hasConcreteTransferableText(value: string) {
 
 function isFirstPersonDiaryClaim(value: string) {
   if (hasChineseFirstPersonDiaryClaim(value)) return true;
-  const diaryVerbs = [
+  const diaryVerbs = Array.from(new Set([
+    ...concreteActionWords.filter((word) => !/[\u3400-\u9fff]/.test(word)),
     'added',
     'changed',
     'checked',
     'confirmed',
+    'configured',
     'diagnosed',
     'discovered',
     'fixed',
     'found',
     'implemented',
-    'block',
-    'configure',
+    'imported',
+    'loaded',
+    'moved',
+    'normalized',
+    'parsed',
+    'pruned',
     'reviewed',
     'resolved',
-    'place',
-    'register',
-    'set',
+    'sanitized',
+    'stripped',
     'switched',
     'tested',
     'updated',
     'verified',
-    'wait',
-  ].join('|');
+  ]))
+    .map(regexEscape)
+    .join('|');
   return new RegExp(
     `(?:^|[:.!?,;]\\s*|\\b(?:and|then|but|so)\\s+)\\b(?:i|we)\\s+(?:${diaryVerbs})\\b`,
     'i',
@@ -754,9 +765,24 @@ function isFirstPersonDiaryClaim(value: string) {
 }
 
 function hasChineseFirstPersonDiaryClaim(value: string) {
-  const chineseAction = '(?:添加|修复|设置|配置|注册|等待|发现|验证|检查|确认|诊断|切换|更新|实现|改动|修改|处理|解决)';
-  const englishAction = '(?:add|added|block|configure|configured|fix|fixed|import|importing|place|placed|register|registered|set|switch|switched|update|updated|validate|validated|verify|verified|wait)';
-  return new RegExp(`(?:我|我们)(?:已经|已)?${chineseAction}|(?:我|我们)(?:已经|已)?(?:把|将).{0,80}(?:${chineseAction}|\\b${englishAction}\\b)`, 'i')
+  const chineseAction = '(?:添加|修复|设置|配置|注册|等待|发现|验证|检查|确认|诊断|切换|更新|实现|改动|修改|处理|解决|去掉|剥离|规范化|清理|解析|移除|删除|过滤|截断|剪枝)';
+  const englishAction = Array.from(new Set([
+    ...concreteActionWords.filter((word) => !/[\u3400-\u9fff]/.test(word)),
+    'added',
+    'configured',
+    'fixed',
+    'imported',
+    'importing',
+    'placed',
+    'registered',
+    'switched',
+    'updated',
+    'validated',
+    'verified',
+  ]))
+    .map(regexEscape)
+    .join('|');
+  return new RegExp(`(?:我|我们)(?:已经|已)?${chineseAction}|(?:我|我们)(?:已经|已)?(?:把|将).{0,80}(?:${chineseAction}|\\b(?:${englishAction})\\b)`, 'i')
     .test(value);
 }
 
@@ -1310,8 +1336,21 @@ function hasLowQualityTags(note: MaterializedTaskMemoryNote) {
   return note.tags.some((tag) => isLowQualityTag(tag));
 }
 
+function normalizeTagForQuality(tag: string) {
+  let normalized = tag.trim().toLowerCase();
+  for (let i = 0; i < 3; i += 1) {
+    normalized = normalized
+      .replace(/^#+\s*/, '')
+      .replace(/^[\[\]()（）【】]+/, '')
+      .replace(/[\[\]()（）【】]+$/, '')
+      .replace(/[.。!！,，;；:：]+$/, '')
+      .trim();
+  }
+  return normalized;
+}
+
 function isLowQualityTag(tag: string) {
-  const normalized = tag.trim().toLowerCase();
+  const normalized = normalizeTagForQuality(tag);
   if (!normalized || isPlaceholderText(normalized)) return true;
   return /^(fix|bug|issue|bugfix|bug[-_\s]?fix|success|fixed|reliable|reliability|quality|done|verified|test[-_\s]?passed|passed|ok|okay|resolved|working|complete|completed|all[-_\s]?good|status|checked|reviewed|tested|修复|已修复|修复完成|已完成|完成|已验证|验证|测试通过|测试|通过|可靠性|成功|状态|检查|问题|质量)$/i
     .test(normalized);

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -224,8 +224,9 @@ function hasConcreteTransferableText(value: string) {
 
 function hasFailureOrConsequenceSignal(value: string) {
   return (
-    /\b(race|raced|orphan|dedupe|deduplicate|stale dist|dist diverge|dist diverged|diverge|diverged|fallback|fell back|default data directory|econrefused|readiness issue|startup race|invalid note_tags|foreign_keys|cascade|nulling|source_run_key collision)\b/i
+    /\b(race|raced|orphan|dedupe|deduplicate|stale dist|dist diverge|dist diverged|diverge|diverged|fallback|fell back|econrefused|readiness issue|startup race|invalid note_tags|foreign_keys|cascade|nulling|source_run_key collision)\b/i
       .test(value) ||
+    hasDefaultDataDirectoryConsequence(value) ||
     hasHttpFailureSignal(value)
   );
 }
@@ -240,16 +241,26 @@ function hasStrongRootCauseSignal(value: string) {
       .test(value) ||
     /\b(dist comparison|dist comparisons|generated dist output|dist output)\b.+\b(inconsistent|mismatch|wrong comparison|stale|diverged|diverge)\b.+\b(version parsing|package metadata|package version)\b/i
       .test(value) ||
-    /\b(because|so)\b.+\b(ran before|ran after|returned http [45]\d\d|returned [45]\d\d|http [45]\d\d|imported.+before|used the default data directory|version parsing.+(inconsistent|mismatch|wrong|stale|diverged|diverge)|default data directory|fell back|fallback|diverged|raced|race|econrefused)\b/i
+    /\b(because|so)\b.+\b(ran before|ran after|returned http [45]\d\d|returned [45]\d\d|http [45]\d\d|imported.+before|used the default data directory|version parsing.+(inconsistent|mismatch|wrong|stale|diverged|diverge)|fell back|fallback|diverged|raced|race|econrefused)\b/i
       .test(value) ||
-    /\b(ran before|ran after|returned http [45]\d\d|returned [45]\d\d|http [45]\d\d|imported.+before|used the default data directory|version parsing.+(inconsistent|mismatch|wrong|stale|diverged|diverge)|default data directory|fell back|fallback|diverged|raced|race|econrefused)\b.+\b(because|so)\b/i
+    /\b(ran before|ran after|returned http [45]\d\d|returned [45]\d\d|http [45]\d\d|imported.+before|used the default data directory|version parsing.+(inconsistent|mismatch|wrong|stale|diverged|diverge)|fell back|fallback|diverged|raced|race|econrefused)\b.+\b(because|so)\b/i
       .test(value)
   );
 }
 
 function isExistenceOnlyClaim(value: string) {
   const text = value.toLowerCase();
-  return /\b(existed|exists|was present|were present|available|present during)\b/.test(text);
+  const hasExistencePhrase =
+    /\b(existed|exists|was present|were present|present during|is available|was available|on disk|is on disk|was on disk)\b/
+      .test(text);
+  return hasExistencePhrase && !hasDefaultDataDirectoryConsequence(text);
+}
+
+function hasDefaultDataDirectoryConsequence(value: string) {
+  return /\b(prevents?|preventing|avoid|avoids|avoiding)\b.+\bfallback\b.+\bdefault data directory\b/i
+    .test(value) ||
+    /\b(fallback|fell back)\b.+\bdefault data directory\b/i.test(value) ||
+    /\bused the default data directory\b/i.test(value);
 }
 
 function hasHttpFailureSignal(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -186,8 +186,7 @@ function hasConcreteMechanism(value: string) {
       .test(text) ||
     /\b(package metadata|package version|generated dist|dist output)\b.+\b(diverged|diverge|parse|parsing|normalize|normalizing|compare|comparing)\b/i
       .test(text);
-  const hasDataDirFallback =
-    /\b(default data directory|data directory fallback|fell back|fallback)\b/i.test(text);
+  const hasDataDirFallback = hasDefaultDataDirectoryConsequence(text);
   const hasRelationalCleanup =
     /\b(foreign_keys|orphan rows|cascade|nulling|resets foreign_keys)\b/i.test(text);
   const hasDedupeKey =
@@ -224,7 +223,7 @@ function hasConcreteTransferableText(value: string) {
 
 function hasFailureOrConsequenceSignal(value: string) {
   return (
-    /\b(race|raced|orphan|dedupe|deduplicate|stale dist|dist diverge|dist diverged|diverge|diverged|fallback|fell back|econrefused|readiness issue|startup race|invalid note_tags|foreign_keys|cascade|nulling|source_run_key collision)\b/i
+    /\b(race|raced|orphan|dedupe|deduplicate|stale dist|dist diverge|dist diverged|diverge|diverged|econrefused|readiness issue|startup race|invalid note_tags|foreign_keys|cascade|nulling|source_run_key collision)\b/i
       .test(value) ||
     hasDefaultDataDirectoryConsequence(value) ||
     hasHttpFailureSignal(value)
@@ -235,18 +234,33 @@ function hasStrongRootCauseSignal(value: string) {
   if (isExistenceOnlyClaim(value)) return false;
   if (isPackageArtifactObservationClaim(value)) return false;
   if (isWeakRootCauseClaim(value)) return false;
+  if (hasPackageDistRootCauseShape(value)) return hasPackageDistRootCauseSignal(value);
   return (
     hasFailureOrConsequenceSignal(value) ||
-    /\b(version parsing|package metadata|package version)\b.+\b(inconsistent|mismatch|wrong comparison|stale|diverged|diverge)\b.+\b(dist comparison|dist comparisons|generated dist output|dist output)\b/i
+    /\b(because|so)\b.+\b(ran before|ran after|returned http [45]\d\d|returned [45]\d\d|http [45]\d\d|imported.+before|used the default data directory|version parsing.+(inconsistent|mismatch|wrong|stale|diverged|diverge)|raced|race|econrefused)\b/i
       .test(value) ||
-    /\b(inconsistent|mismatch|wrong comparison|stale|diverged|diverge)\b.+\b(version parsing|package metadata|package version)\b.+\b(dist comparison|dist comparisons|generated dist output|dist output)\b/i
-      .test(value) ||
-    /\b(dist comparison|dist comparisons|generated dist output|dist output)\b.+\b(inconsistent|mismatch|wrong comparison|stale|diverged|diverge)\b.+\b(version parsing|package metadata|package version)\b/i
-      .test(value) ||
-    /\b(because|so)\b.+\b(ran before|ran after|returned http [45]\d\d|returned [45]\d\d|http [45]\d\d|imported.+before|used the default data directory|version parsing.+(inconsistent|mismatch|wrong|stale|diverged|diverge)|fell back|fallback|diverged|raced|race|econrefused)\b/i
-      .test(value) ||
-    /\b(ran before|ran after|returned http [45]\d\d|returned [45]\d\d|http [45]\d\d|imported.+before|used the default data directory|version parsing.+(inconsistent|mismatch|wrong|stale|diverged|diverge)|fell back|fallback|diverged|raced|race|econrefused)\b.+\b(because|so)\b/i
+    /\b(ran before|ran after|returned http [45]\d\d|returned [45]\d\d|http [45]\d\d|imported.+before|used the default data directory|version parsing.+(inconsistent|mismatch|wrong|stale|diverged|diverge)|raced|race|econrefused)\b.+\b(because|so)\b/i
       .test(value)
+  );
+}
+
+function hasPackageDistRootCauseShape(value: string) {
+  return /\b(package metadata|package version|version parsing|package version parsing|package normalization|version normalization)\b/i
+    .test(value) &&
+    /\b(generated dist output|dist output|dist comparison|dist comparisons|dist)\b/i
+      .test(value);
+}
+
+function hasPackageDistRootCauseSignal(value: string) {
+  const text = value.toLowerCase();
+  if (isPackageArtifactObservationClaim(text) || isExistenceOnlyClaim(text)) return false;
+  return (
+    /\b(package metadata|package version|generated dist output|dist output)\b.+\b(diverged|diverge|mismatch|stale|wrong)\b.+\bbecause\b.+\b(version parsing|parsing|normalization|normalize|normalized)\b.+\b(inconsistent|different formats|mismatch|wrong|stale)\b/i
+      .test(text) ||
+    /\b(generated dist output|dist output)\b.+\b(diverged|diverge|mismatch|stale|wrong)\b.+\b(package metadata|package version)\b.+\bbecause\b.+\b(version parsing|parsing|normalization|normalize|normalized)\b.+\b(inconsistent|different formats|mismatch|wrong|stale)\b/i
+      .test(text) ||
+    /\b(inconsistent|mismatch|wrong comparison|wrong|stale|different formats)\b.+\b(version parsing|package version parsing|package metadata|package version|version normalization|package normalization)\b.+\b(generated dist output|dist output|dist comparisons?|dist)\b/i
+      .test(text)
   );
 }
 
@@ -382,7 +396,7 @@ function isStatusShapedSelfContainedItem(note: MaterializedTaskMemoryNote) {
 }
 
 function hasStrongReusableMechanism(value: string) {
-  return /\b(normalize|normalizing|parse|parsing|diverge|diverged|default data directory|fallback|fell back|race|raced|orphan|dedupe|deduplicate|foreign_keys|cascade|nulling|source_run_key)\b/i
+  return /\b(normalize|normalizing|parse|parsing|diverge|diverged|default data directory|race|raced|orphan|dedupe|deduplicate|foreign_keys|cascade|nulling|source_run_key)\b/i
     .test(value);
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -162,6 +162,7 @@ function hasSpecificEvidence(value: string) {
   return (
     /\b(data_dir|node_env|econrefused|note_tags|chatcrystal\.db|port|source_run_key|foreign_keys)\b|\/api\/[\w/-]+|\b[a-z0-9]+_[a-z0-9_]+\b|[a-z]:\\|\/[\w.-]+|[\u3400-\u9fff]/i
       .test(text) ||
+    hasHttpFailureSignal(text) ||
     /\b(api requests?|fastify readiness|server readiness|request setup|package metadata|package version|dist output|generated dist output|data directory|electron server|server entrypoint|client calls?)\b/i
       .test(text)
   );
@@ -190,13 +191,20 @@ function hasConcreteMechanism(value: string) {
     /\b(foreign_keys|orphan rows|cascade|nulling|resets foreign_keys)\b/i.test(text);
   const hasDedupeKey =
     /\b(dedupe|deduplicate)\b.+\b(source_run_key|key)\b/i.test(text);
+  const hasRequestFailureOrdering =
+    hasHttpFailureSignal(text) &&
+    (
+      /\b(ran after|after request setup|before issuing|before request setup|registration ran after)\b/i.test(text) ||
+      hasTimingOrder
+    );
   return (
     hasTimingOrder ||
     hasRaceReadiness ||
     hasPackageDistFlow ||
     hasDataDirFallback ||
     hasRelationalCleanup ||
-    hasDedupeKey
+    hasDedupeKey ||
+    hasRequestFailureOrdering
   );
 }
 
@@ -213,22 +221,34 @@ function hasConcreteTransferableText(value: string) {
 }
 
 function hasFailureOrConsequenceSignal(value: string) {
-  return /\b(race|raced|orphan|dedupe|deduplicate|stale dist|dist diverge|dist diverged|diverge|diverged|fallback|fell back|default data directory|econrefused|readiness issue|startup race|invalid note_tags|foreign_keys|cascade|nulling|source_run_key collision)\b/i
-    .test(value);
+  return (
+    /\b(race|raced|orphan|dedupe|deduplicate|stale dist|dist diverge|dist diverged|diverge|diverged|fallback|fell back|default data directory|econrefused|readiness issue|startup race|invalid note_tags|foreign_keys|cascade|nulling|source_run_key collision)\b/i
+      .test(value) ||
+    hasHttpFailureSignal(value)
+  );
 }
 
 function hasStrongRootCauseSignal(value: string) {
   return (
     hasFailureOrConsequenceSignal(value) ||
-    /\b(version parsing|package metadata|package version)\b.+\b(dist comparison|dist comparisons|generated dist output|dist output)\b/i
+    /\b(version parsing|package metadata|package version)\b.+\b(inconsistent|mismatch|wrong comparison|stale|diverged|diverge)\b.+\b(dist comparison|dist comparisons|generated dist output|dist output)\b/i
       .test(value) ||
-    /\b(dist comparison|dist comparisons|generated dist output|dist output)\b.+\b(version parsing|package metadata|package version)\b/i
+    /\b(inconsistent|mismatch|wrong comparison|stale|diverged|diverge)\b.+\b(version parsing|package metadata|package version)\b.+\b(dist comparison|dist comparisons|generated dist output|dist output)\b/i
       .test(value) ||
-    /\b(because|so)\b.+\b(ran before|imported.+before|used the default data directory|version parsing|generated dist output|default data directory|fell back|fallback|diverged|raced|race|econrefused)\b/i
+    /\b(dist comparison|dist comparisons|generated dist output|dist output)\b.+\b(inconsistent|mismatch|wrong comparison|stale|diverged|diverge)\b.+\b(version parsing|package metadata|package version)\b/i
       .test(value) ||
-    /\b(ran before|imported.+before|used the default data directory|version parsing|generated dist output|default data directory|fell back|fallback|diverged|raced|race|econrefused)\b.+\b(because|so)\b/i
+    /\b(because|so)\b.+\b(ran before|ran after|returned http [45]\d\d|returned [45]\d\d|http [45]\d\d|imported.+before|used the default data directory|version parsing|generated dist output|default data directory|fell back|fallback|diverged|raced|race|econrefused)\b/i
+      .test(value) ||
+    /\b(ran before|ran after|returned http [45]\d\d|returned [45]\d\d|http [45]\d\d|imported.+before|used the default data directory|version parsing|generated dist output|default data directory|fell back|fallback|diverged|raced|race|econrefused)\b.+\b(because|so)\b/i
       .test(value)
   );
+}
+
+function hasHttpFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasHttpError = /\b(http\s*)?[45]\d\d\b/.test(text);
+  const hasFailureContext = /\b(api|request|requests|route|http|returned|failed|threw|error)\b/.test(text);
+  return hasHttpError && hasFailureContext && !/\b(status\s*)?2\d\d\b/.test(text);
 }
 
 function hasActionableResolution(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -650,7 +650,9 @@ function isFirstPersonDiaryClaim(value: string) {
 }
 
 function hasChineseFirstPersonDiaryClaim(value: string) {
-  return /(?:我|我们)(?:已经|已)?(?:添加|修复|设置|配置|注册|等待|发现|验证|检查|确认|诊断|切换|更新|实现|改动|修改|处理|解决)/i
+  const chineseAction = '(?:添加|修复|设置|配置|注册|等待|发现|验证|检查|确认|诊断|切换|更新|实现|改动|修改|处理|解决)';
+  const englishAction = '(?:add|added|block|configure|configured|fix|fixed|import|importing|place|placed|register|registered|set|switch|switched|update|updated|validate|validated|verify|verified|wait)';
+  return new RegExp(`(?:我|我们)(?:已经|已)?${chineseAction}|(?:我|我们)(?:把|将).{0,80}(?:${chineseAction}|\\b${englishAction}\\b)`, 'i')
     .test(value);
 }
 
@@ -1177,8 +1179,12 @@ function hasUsefulCodeSnippet(
 
   const combined = `${language}\n${code}\n${description}`;
   const hasConcreteCodeShape =
-    /[{}()[\];:=<>]/.test(code) ||
-    /\b(pragma|select|insert|update|delete|create table|json\.parse|z\.object|z\.array|const|let|function|return|import|export|class)\b/i
+    /\b(pragma|select|insert|update|delete|create table)\b/i.test(code) ||
+    /\b(const|let|var|function|return|import|export|class)\b/i.test(code) ||
+    /\b[\w.]+\s*\([^)]*\S[^)]*\)/.test(code) ||
+    /\{[^}]+[:=][^}]+\}/.test(code) ||
+    /"[^"]+"\s*:/.test(code) ||
+    /\b[\w.]+\s*[:=]\s*(?:"[^"]+"|'[^']+'|`[^`]+`|\d+|true|false|\/[\w./-]+|\w+\([^)]*\))/
       .test(code);
   const hasConcreteEvidence =
     /\b(pragma\s+foreign_keys|foreign_keys|json\.parse|z\.object|z\.array|response_item\.content|data_dir|node_env|source_run_key|note_tags)\b/i
@@ -1201,7 +1207,7 @@ function hasLowQualityTags(note: MaterializedTaskMemoryNote) {
 function isLowQualityTag(tag: string) {
   const normalized = tag.trim().toLowerCase();
   if (!normalized || isPlaceholderText(normalized)) return true;
-  return /^(fix|bugfix|bug[-_\s]?fix|success|fixed|reliable|done|verified|test[-_\s]?passed|passed|ok|okay|resolved|working|complete|completed|all[-_\s]?good|status|checked|reviewed|tested)$/i
+  return /^(fix|bug|issue|bugfix|bug[-_\s]?fix|success|fixed|reliable|reliability|quality|done|verified|test[-_\s]?passed|passed|ok|okay|resolved|working|complete|completed|all[-_\s]?good|status|checked|reviewed|tested|修复|已修复|已验证|测试通过|可靠性|成功|问题|质量)$/i
     .test(normalized);
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -228,7 +228,7 @@ function hasConcreteTransferableText(value: string) {
 }
 
 function isFirstPersonDiaryClaim(value: string) {
-  return /\b(i|we)\s+(added|checked|verified|fixed|implemented|updated|changed|found|diagnosed|switched|then)\b/i
+  return /\b(i|we)\s+(added|checked|verified|fixed|implemented|updated|changed|found|diagnosed|discovered|switched|then)\b/i
     .test(value);
 }
 
@@ -392,6 +392,8 @@ function isGenericResolutionClaim(value: string) {
   return /\b(add|use|apply)\b.+\bvalidation\b.+\b(prevent|avoid)\b.+\b(future failures?|failures?|issues?)\b/i
     .test(value) ||
     /\bvalidate\b.+\b(?:to\s+)?(?:prevent|avoid)\b.+\b(future failures?|failures?|issues?)\b/i
+    .test(value) ||
+    /\badd\b.+\b(readiness|guard)\b.+\b(prevent|avoid)\b.+\b(future failures?|failures?|issues?)\b/i
     .test(value);
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1020,16 +1020,28 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
   const hasNamedAsyncObject =
     /\b(abortcontroller|react search|search view|\/api\/search|stale search requests?|stale responses?|previous responses?|current query results?|current results|overlapping requests?|overlapping \/api\/search requests?)\b/i
       .test(text);
-  const hasEngineeringContext =
-    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?)\b/i
+  const hasNamedTransportObject =
+    /\b(mcp|json-rpc|json rpc|stdio|stdout|stderr|process\.stdout|process\.stderr|response frames?|response transport|stdio stream)\b/i
       .test(text);
-  return (hasConcreteToken || hasNamedDbObject || hasNamedAsyncObject) && hasEngineeringContext;
+  const hasNamedLifecycleObject =
+    /\b(db initialization|database initialization|sql\.js initialization|sql\.js finished initialization|finished initialization|accepting import requests?|accepting \/api\/[\w/-]+ requests?|route handled requests?)\b/i
+      .test(text);
+  const hasEngineeringContext =
+    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?|initialization|initialized|route|mcp|json-rpc|stdio|stdout|stderr|framing|transport|logs?|diagnostics?)\b/i
+      .test(text);
+  return (
+    hasConcreteToken ||
+    hasNamedDbObject ||
+    hasNamedAsyncObject ||
+    hasNamedTransportObject ||
+    hasNamedLifecycleObject
+  ) && hasEngineeringContext;
 }
 
 function hasStrictStructuralEngineeringAction(value: string) {
   const text = value.toLowerCase();
   const hasAction =
-    /\b(add|create|remove|wrap|validate|normalize|configure|set|index|return|reuse|cancel|use)\b/i
+    /\b(add|create|remove|wrap|validate|normalize|configure|set|index|return|reuse|cancel|use|wait|send|reserve)\b/i
       .test(text);
   const hasConcreteDbAction =
     /\b(add|create)\b.+\b(unique\s*\([^)]*\)|unique key|unique constraint|constraint|index|idx_[a-z0-9_]+)\b/i
@@ -1039,8 +1051,16 @@ function hasStrictStructuralEngineeringAction(value: string) {
   const hasConcreteAsyncAction =
     /\b(use\b.+\babortcontroller|abortcontroller\b.+\bcancel|cancel(?: older| previous| prior)?\b.+\b(?:\/api\/search|requests?|responses?))\b/i
       .test(text);
+  const hasConcreteLifecycleAction =
+    /\b(wait)\b.+\b(db initialization|database initialization|sql\.js initialization|initialized|finished initialization)\b.+\b(before accepting|before handling|requests?)\b/i
+      .test(text);
+  const hasConcreteTransportAction =
+    /\b(send)\b.+\b(diagnostics?|logs?)\b.+\b(process\.stderr|stderr)\b/i
+      .test(text) ||
+    /\b(reserve)\b.+\b(process\.stdout|stdout)\b.+\b(json-rpc|json rpc|response frames?|stdio)\b/i
+      .test(text);
   return hasStrictStructuralEngineeringEvidence(text) &&
-    (hasAction || hasConcreteDbAction || hasConcreteAsyncAction);
+    (hasAction || hasConcreteDbAction || hasConcreteAsyncAction || hasConcreteLifecycleAction || hasConcreteTransportAction);
 }
 
 function hasStrictStructuralEngineeringMechanism(value: string) {
@@ -1076,8 +1096,26 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       .test(text) ||
     /\bstale responses?\b.+\b(cannot|do not|does not)\b.+\b(replace|overwrite)\b.+\bcurrent results\b/i
       .test(text);
+  const hasInitializationOrderFlow =
+    /\b(route|\/api\/[\w/-]+)\b.+\b(handled|handles?|accept(?:ed|ing)?|requests?)\b.+\bbefore\b.+\b(sql\.js|db|database)\b.+\b(finished initialization|initialization|initialized)\b/i
+      .test(text) ||
+    /\b(wait)\b.+\b(sql\.js|db|database)\b.+\b(initialization|initialized)\b.+\bbefore\b.+\b(accept(?:ing)?|handl(?:e|ing)?)\b.+\b(?:\/api\/[\w/-]+|requests?)\b/i
+      .test(text) ||
+    /\b(?:http\s*)?[45]\d\d\b.+\bbecause\b.+\b(route|\/api\/[\w/-]+)\b.+\bbefore\b.+\b(sql\.js|db|database)\b.+\b(initialization|initialized)\b/i
+      .test(text);
+  const hasTransportFramingFlow =
+    /\b(logs?|logging|diagnostics?)\b.+\b(process\.stdout|stdout)\b.+\b(interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|json-rpc|json rpc|responses?|frames?)\b/i
+      .test(text) ||
+    /\b(process\.stdout|stdout)\b.+\b(response transport|json-rpc|json rpc|response frames?|stdio stream)\b/i
+      .test(text) ||
+    /\b(process\.stdout|stdout)\b.+\b(corrupt(?:s|ed|ing)?|interleav(?:e|ed|es|ing))\b.+\b(json-rpc|json rpc|responses?|frames?|stdio)\b/i
+      .test(text) ||
+    /\b(send)\b.+\b(diagnostics?|logs?)\b.+\b(process\.stderr|stderr)\b.+\b(reserve|instead|process\.stdout|stdout|json-rpc|json rpc)\b/i
+      .test(text) ||
+    /\b(reserve)\b.+\b(process\.stdout|stdout)\b.+\b(json-rpc|json rpc|response frames?|stdio)\b/i
+      .test(text);
   const hasCausalFlow =
-    /\b(because|so|but|caused|without|instead of|before|after|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing)\b/i
+    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve)\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) &&
     hasCausalFlow &&
@@ -1086,17 +1124,19 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       hasFilterWithoutIndex ||
       hasLookupScanFlow ||
       hasUniquenessConstraintFlow ||
-      hasStaleAsyncResponseFlow
+      hasStaleAsyncResponseFlow ||
+      hasInitializationOrderFlow ||
+      hasTransportFramingFlow
     );
 }
 
 function hasStrictStructuralEngineeringFailureSignal(value: string) {
   const text = value.toLowerCase();
   const hasNamedConsequence =
-    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|stale responses?|overwrote the current query results?|overwrote current results?|replace current results?)\b/i
+    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|stale responses?|overwrote the current query results?|overwrote current results?|replace current results?|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream))\b/i
       .test(text);
   const hasCausalFlow =
-    /\b(because|so|but|caused|without|instead of|before|after|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing)\b/i
+    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?)\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) && hasNamedConsequence && hasCausalFlow;
 }
@@ -1225,7 +1265,11 @@ function hasGenericRootCauseRationale(value: string) {
 function hasConcreteHttpRootCauseSignal(value: string) {
   return hasConcreteRootCauseMechanism(value) ||
     hasRateLimitRetryRootCauseSignal(value) ||
-    hasProviderBaseUrlFailureSignal(value);
+    hasProviderBaseUrlFailureSignal(value) ||
+    (
+      hasStrictStructuralEngineeringMechanism(value) &&
+      hasStrictStructuralEngineeringFailureSignal(value)
+    );
 }
 
 function hasRateLimitRetryRootCauseSignal(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -511,7 +511,7 @@ function isGenericVisibleBoilerplateClaim(value: string) {
     hasGenericReliabilityFix ||
     hasGenericFutureFailure ||
     hasGenericReleaseValidation
-  ) && !hasSpecificEvidence(text) && !hasConcreteMechanism(text);
+  ) && !hasConcreteMechanism(text);
 }
 
 function isVisibleStatusSnapshotText(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -265,12 +265,14 @@ function hasPackageDistRootCauseShape(value: string) {
 
 function hasPackageDistRootCauseSignal(value: string) {
   const text = value.toLowerCase();
+  const packageMechanism = '(?:version parsing|parsing|version normalization|normalization|normalize|normalized|different formats|inconsistent normalization|comparison|comparing)';
+  const packageOutcome = '(?:diverged|divergence|mismatch|stale(?: package metadata| output| dist)?|wrong comparison|comparison failure|differed from package metadata|differed from package version)';
   const hasPositiveSignal =
-    /\b(package metadata|package version|generated dist output|dist output)\b.+\b(diverged|diverge|mismatch|stale|wrong)\b.+\bbecause\b.+\b(version parsing|parsing|normalization|normalize|normalized)\b.+\b(inconsistent|different formats|mismatch|wrong|stale)\b/i
+    new RegExp(`\\b(package metadata|package version|generated dist output|dist output)\\b.+\\b${packageOutcome}\\b.+\\bbecause\\b.+\\b${packageMechanism}\\b.+\\b(inconsistent|different formats|mismatch|wrong|stale)\\b`, 'i')
       .test(text) ||
-    /\b(generated dist output|dist output)\b.+\b(diverged|diverge|mismatch|stale|wrong)\b.+\b(package metadata|package version)\b.+\bbecause\b.+\b(version parsing|parsing|normalization|normalize|normalized)\b.+\b(inconsistent|different formats|mismatch|wrong|stale)\b/i
+    new RegExp(`\\b(generated dist output|dist output)\\b.+\\b${packageOutcome}\\b.+\\b(package metadata|package version)\\b.+\\bbecause\\b.+\\b${packageMechanism}\\b.+\\b(inconsistent|different formats|mismatch|wrong|stale)\\b`, 'i')
       .test(text) ||
-    /\b(inconsistent|mismatch|wrong comparison|wrong|stale|different formats)\b.+\b(version parsing|package version parsing|package metadata|package version|version normalization|package normalization)\b.+\b(generated dist output|dist output|dist comparisons?|dist)\b/i
+    new RegExp(`\\b(inconsistent|mismatch|wrong comparison|comparison failure|stale|different formats)\\b.+\\b(version parsing|package version parsing|package metadata|package version|version normalization|package normalization)\\b.+\\b(generated dist output|dist output|dist comparisons?|dist)\\b`, 'i')
       .test(text);
   if (hasPositiveSignal) return true;
   if (isPackageArtifactObservationClaim(text) || isExistenceOnlyClaim(text)) return false;

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -40,6 +40,13 @@ function joined(note: MaterializedTaskMemoryNote) {
   ].join('\n').toLowerCase();
 }
 
+function hasWord(text: string, word: string) {
+  if (/[\u3400-\u9fff]/.test(word)) {
+    return text.includes(word);
+  }
+  return new RegExp(`\\b${word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i').test(text);
+}
+
 function hasConcreteTransferableAction(value: string) {
   const text = value.toLowerCase();
   const concreteActionWords = [
@@ -73,7 +80,7 @@ function hasConcreteTransferableAction(value: string) {
     '防止',
     '复用',
   ];
-  return concreteActionWords.some((word) => text.includes(word));
+  return concreteActionWords.some((word) => hasWord(text, word));
 }
 
 function isVagueGenericLesson(value: string) {
@@ -82,6 +89,17 @@ function isVagueGenericLesson(value: string) {
     /\b(the task|this task|the pattern|the implementation|implementation behavior|expected behavior|expected pattern|values?|input|correctness|going forward)\b/.test(text) &&
     !hasSpecificObject(text)
   );
+}
+
+function isGenericStatusAction(value: string) {
+  const text = value.toLowerCase();
+  const hasGenericAction = ['validate', 'investigate', 'check', 'checked']
+    .some((word) => hasWord(text, word));
+  const hasStatusSubject =
+    /\b(node_env|env|environment|deployment|production|status|local|package version|version)\b/i
+      .test(text);
+  const hasGenericRationale = /\b(expected|should|because|pattern)\b/i.test(text);
+  return hasGenericAction && hasStatusSubject && hasGenericRationale;
 }
 
 function hasSpecificObject(value: string) {
@@ -94,6 +112,7 @@ function hasConcreteTransferableText(value: string) {
     hasNonPlaceholderMeaningfulText(value) &&
     hasConcreteTransferableAction(value) &&
     hasSpecificObject(value) &&
+    !isGenericStatusAction(value) &&
     !isVagueGenericLesson(value)
   );
 }
@@ -105,11 +124,13 @@ function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
   const hasMeaningfulRootCause = Boolean(
     payload.root_cause &&
     hasNonPlaceholderMeaningfulText(payload.root_cause) &&
+    !isGenericStatusAction(payload.root_cause) &&
     !isVagueGenericLesson(payload.root_cause),
   );
   const hasMeaningfulResolution = Boolean(
     payload.resolution &&
     hasNonPlaceholderMeaningfulText(payload.resolution) &&
+    !isGenericStatusAction(payload.resolution) &&
     !isVagueGenericLesson(payload.resolution),
   );
   const hasStructuredSignal =
@@ -145,7 +166,7 @@ function isMostlyOneOffStatus(note: MaterializedTaskMemoryNote) {
     '状态',
   ];
   const statusHits = statusWords.filter((word) => text.includes(word)).length;
-  return statusHits >= 3 && !hasConcreteTransferableAction(text);
+  return statusHits >= 3 && (!hasConcreteTransferableAction(text) || isGenericStatusAction(text));
 }
 
 export function validateMaterializedNoteQuality(

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -101,6 +101,10 @@ function isVagueGenericLesson(value: string) {
     /\bthe (pattern|task) should\b/.test(text) ||
     /\bshould validate\b.+\bbecause\b/.test(text) ||
     /\bbecause it should work\b/.test(text) ||
+    /\bit should work correctly\b/.test(text) ||
+    /\bshould work\b/.test(text) ||
+    /\bshould work correctly\b/.test(text) ||
+    /\bso\b.+\bworks?\b/.test(text) ||
     /\bso the server works\b/.test(text) ||
     /\badd api config\b/.test(text) ||
     /\bcache server config\b/.test(text) ||

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1327,6 +1327,57 @@ function hasSqlParameterizationFailureSignal(value: string) {
   return hasSqlParameterizationEvidence(text) && hasQueryBreakage && hasCausalFlow;
 }
 
+function hasGeneralUniqueConstraintEvidence(value: string) {
+  const text = value.toLowerCase();
+  const hasUniqueConstraint =
+    /\bunique\s*\([^)]*,[^)]*\)|\bunique (?:key|constraint)\b/i.test(text);
+  const hasUniquePairDescriptor = /\bunique\b.+\bpairs?\b/i.test(text);
+  const hasNamedDbPair =
+    /\b[a-z0-9]+_[a-z0-9_]+\b|\b[a-z_]+_id\b.+\b[a-z_]+_id\b|\bnote-[a-z]+\s+pairs?\b/i
+      .test(text);
+  const hasDbContext =
+    /\b(table|rows?|constraint|pairs?|tags?|chips?|database|db|sqlite|sql\.js)\b/i
+      .test(text);
+  return (hasUniqueConstraint || hasUniquePairDescriptor) && hasNamedDbPair && hasDbContext;
+}
+
+function hasGeneralUniqueConstraintAction(value: string) {
+  const text = value.toLowerCase();
+  return hasGeneralUniqueConstraintEvidence(text) &&
+    (
+      /\b(add|create)\b.+\b(unique\s*\([^)]*\)|unique key|unique constraint|constraint)\b/i
+        .test(text) ||
+      /\breuse\b.+\bexisting\b.+\b[a-z0-9_]+ row\b/i.test(text)
+    );
+}
+
+function hasGeneralUniqueConstraintMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasUniquePrevention =
+    /\bunique\s*\([^)]*,[^)]*\).+\b(?:duplicate|repeated|reuse|existing|pairs?|chips?|rows?)\b/i
+      .test(text);
+  const hasDuplicatePairFlow =
+    /\b(?:allowed|allows?|without|no|missing|lacked|lacks)\b.+\bduplicate\b.+\b[a-z_]+_id\b.+\b(?:[a-z_]+_id\b|pairs?)\b/i
+      .test(text) ||
+    /\bduplicate\b.+\b[a-z_]+_id\b.+\b(?:[a-z_]+_id\b|pairs?)\b.+\b(?:chips?|rows?|notes?)\b/i
+      .test(text);
+  const hasReuseExistingRow =
+    /\breuse\b.+\bexisting\b.+\b[a-z0-9_]+ row\b.+\b(?:tag|duplicate|attached)\b/i
+      .test(text);
+  return hasUniquePrevention || hasDuplicatePairFlow || (hasGeneralUniqueConstraintEvidence(text) && hasReuseExistingRow);
+}
+
+function hasGeneralUniqueConstraintFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasDuplicateConsequence =
+    /\bduplicate (?:tag chips?|rows?|notes?|pairs?)\b/i.test(text) ||
+    /\bduplicate\b.+\bfor one\b/i.test(text);
+  const hasCausalFlow =
+    /\b(so|because|cannot create|could show|allowed|allows?|reuse|existing|repeated)\b/i
+      .test(text);
+  return hasDuplicateConsequence && hasCausalFlow;
+}
+
 function hasStrictStructuralEngineeringEvidence(value: string) {
   const text = value.toLowerCase();
   const hasConcreteToken =
@@ -1335,6 +1386,7 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
   const hasNamedDbObject =
     /\b(unique\s*\([^)]*\)|writeback receipts?|writeback_receipts|receipt rows?|source_agent|source_run_key|write_task_memory)\b/i
       .test(text) ||
+    hasGeneralUniqueConstraintEvidence(text) ||
     /\b(unique key|unique constraint)\b.+\b(writeback|receipt|source_agent|source_run_key)\b/i
       .test(text) ||
     /\b(writeback|receipt|source_agent|source_run_key)\b.+\b(unique key|unique constraint)\b/i
@@ -1410,7 +1462,8 @@ function hasStrictStructuralEngineeringAction(value: string) {
     /\b(add|create)\b.+\b(unique\s*\([^)]*\)|unique key|unique constraint|constraint|index|idx_[a-z0-9_]+)\b/i
       .test(text) ||
     /\b(return|reuse)\b.+\b(existing receipt row|first note|existing row)\b/i
-      .test(text);
+      .test(text) ||
+    hasGeneralUniqueConstraintAction(text);
   const hasConcreteAsyncAction =
     /\b(use\b.+\babortcontroller|abortcontroller\b.+\bcancel|cancel(?: older| previous| prior)?\b.+\b(?:\/api\/search|requests?|responses?))\b/i
       .test(text) ||
@@ -1507,7 +1560,8 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
     /\b(return|reuse)\b.+\b(existing receipt row|existing row|first note)\b.+\b(retries|reuse|instead of inserting duplicate rows?)\b/i
       .test(text) ||
     /\b(source_run_key|writeback_receipts|receipt rows?)\b.+\b(unique\s*\([^)]*\)|unique key|unique constraint|duplicate receipt rows?|duplicate notes?)\b/i
-      .test(text);
+      .test(text) ||
+    hasGeneralUniqueConstraintMechanism(text);
   const hasStaleAsyncResponseFlow =
     /\b(overlapping|slower previous|previous|older|stale)\b.+\b(\/api\/search|search requests?|responses?)\b.+\b(overwrote|overwrite|replace|current query results?|current results)\b/i
       .test(text) ||
@@ -1669,6 +1723,7 @@ function hasStrictStructuralEngineeringFailureSignal(value: string) {
   const hasNamedConsequence =
     /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|duplicate conversation jobs?|duplicate messages?|duplicate websocket messages?|appended twice|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|orphan note_tags rows?|orphan tags?|unused tags?|count 0|joins? whose note_id no longer existed|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream)|false serve success|dead server|looked like a running server|running server|nonzero exit codes?|non-zero exit codes?|exit code\s*\d+|migration (?:does not )?fail(?:s|ed)?|migration failures?|existing row failures?|constraint violation|violated the constraint|fell through to the spa fallback|clients? received index\.html instead of json|return json instead of index\.html|returns? html for api json)\b/i
       .test(text) ||
+    hasGeneralUniqueConstraintFailureSignal(text) ||
     /(?:旧(?:的)?\s*)?(?:\/api\/search\s*)?响应.{0,20}覆盖.{0,12}(?:当前查询结果|新结果)/i
       .test(text);
   const hasCausalFlow =
@@ -1945,6 +2000,7 @@ function hasVisibleConcreteContent(value: string) {
   if (isLowValueOutcomeStatusClaim(text)) return false;
   if (isChineseVisibleStatusShell(text)) return false;
   if (isGenericReleaseValidationClaim(text)) return false;
+  if (hasGeneralUniqueConstraintEvidence(text)) return true;
   if (hasSpecificEvidence(text) && hasConcreteMechanism(text)) return true;
   if (hasSpecificEvidence(text) && hasFailureOrConsequenceSignal(text)) return true;
   if (hasPackageDistRootCauseSignal(text)) return true;
@@ -1963,6 +2019,7 @@ function isExplicitEnglishStatusShell(value: string) {
       .test(value.trim()) ||
     isValidationResultStatusShell(value) ||
     isConfirmationResultStatusShell(value) ||
+    isPredicateResultStatusShell(value) ||
     isCurrentRunImplementationShell(value) ||
     isCurrentRunStatusObservationClaim(value);
 }
@@ -1985,6 +2042,13 @@ function isConfirmationResultStatusShell(value: string) {
         .test(text)
     ) ||
     isChineseConfirmationResultStatusShell(text);
+}
+
+function isPredicateResultStatusShell(value: string) {
+  const text = value.trim();
+  return hasSpecificEvidence(text) &&
+    /^\s*(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,2}\s+)?(?:(?:smoke\s+)?test|result|progress|validation|qa)\s+(?:shows?|is)\b/i
+      .test(text);
 }
 
 function hasTechnicalPrefixStatusShell(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -104,6 +104,7 @@ function hasConcreteTransferableAction(value: string) {
   if (hasDurableEngineeringPreventionAction(text)) return true;
   if (hasImportDedupeAction(text)) return true;
   if (hasPersistenceSerializationAction(text)) return true;
+  if (hasDbTransactionAtomicityAction(text)) return true;
   if (hasElectronResourceAction(text)) return true;
   if (hasCrossPlatformPathAction(text)) return true;
   if (hasFrontendCacheInvalidationAction(text)) return true;
@@ -217,6 +218,7 @@ function hasSpecificEvidence(value: string) {
     hasImportDedupeEvidence(text) ||
     hasContentSanitizationEvidence(text) ||
     hasPersistenceSnapshotEvidence(text) ||
+    hasDbTransactionAtomicityEvidence(text) ||
     hasIndexConsistencyEvidence(text) ||
     hasElectronResourceEvidence(text) ||
     hasCrossPlatformPathEvidence(text) ||
@@ -772,6 +774,7 @@ function hasConcreteMechanism(value: string) {
   const hasImportDedupeFlow = hasImportDedupeMechanism(text);
   const hasContentSanitizationFlow = hasContentSanitizationMechanism(text);
   const hasPersistenceSerializationFlow = hasPersistenceSerializationMechanism(text);
+  const hasDbTransactionAtomicityFlow = hasDbTransactionAtomicityMechanism(text);
   const hasIndexConsistencyFlow = hasIndexConsistencyMechanism(text);
   const hasElectronResourceFlow = hasElectronResourceMechanism(text);
   const hasCrossPlatformPathFlow = hasCrossPlatformPathMechanism(text);
@@ -795,6 +798,7 @@ function hasConcreteMechanism(value: string) {
     hasImportDedupeFlow ||
     hasContentSanitizationFlow ||
     hasPersistenceSerializationFlow ||
+    hasDbTransactionAtomicityFlow ||
     hasIndexConsistencyFlow ||
     hasElectronResourceFlow ||
     hasCrossPlatformPathFlow ||
@@ -907,6 +911,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     hasImportDedupeFailureSignal(value) ||
     hasContentSanitizationFailureSignal(value) ||
     hasPersistenceSnapshotFailureSignal(value) ||
+    hasDbTransactionAtomicityFailureSignal(value) ||
     hasIndexConsistencyFailureSignal(value) ||
     hasElectronResourceFailureSignal(value) ||
     hasCrossPlatformPathFailureSignal(value) ||
@@ -936,6 +941,58 @@ function hasPersistenceSnapshotFailureSignal(value: string) {
     /\b(because|while|so|concurrent|concurrently|same in-memory connection|mutat(?:e|ed|es|ing|ion)|auto-save|later save|overwrite|transaction)\b/i
       .test(text);
   return hasPersistenceSnapshotEvidence(text) && hasSnapshotFailure && hasCausalFlow;
+}
+
+function hasDbTransactionAtomicityEvidence(value: string) {
+  const text = value.toLowerCase();
+  const hasDbImportContext = /\b(sql\.js|database|db|import|imports?|conversation imports?)\b/i
+    .test(text);
+  const hasAtomicityTarget =
+    /\b(conversation rows?|message rows?|conversation row|message insert|message inserts?|conversation inserts?|transaction|rollback|roll back|partial conversation rows?|partial rows?)\b/i
+      .test(text);
+  return hasDbImportContext && hasAtomicityTarget;
+}
+
+function hasDbTransactionAtomicityAction(value: string) {
+  const text = value.toLowerCase();
+  const hasTransactionAction =
+    /\b(wrap|begin|commit|rollback|roll back|use)\b/i.test(text);
+  const hasRelatedInsertTarget =
+    /\b(transaction|conversation and message inserts?|conversation rows?|message rows?|message inserts?|failed imports?|whole conversation)\b/i
+      .test(text);
+  return hasDbTransactionAtomicityEvidence(text) && hasTransactionAction && hasRelatedInsertTarget;
+}
+
+function hasDbTransactionAtomicityMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasTransactionWrapFlow =
+    /\b(wrap|begin|use)\b.+\b(conversation|message|insert|imports?)\b.+\btransaction\b/i
+      .test(text) ||
+    /\btransaction\b.+\b(conversation|message|insert|imports?)\b/i
+      .test(text);
+  const hasRollbackFlow =
+    /\b(failed imports?|failed message insert|failure)\b.+\b(rollback|roll back|partial|whole conversation)\b/i
+      .test(text) ||
+    /\b(rollback|roll back)\b.+\b(failed imports?|failed message insert|whole conversation)\b/i
+      .test(text);
+  const hasPartialInsertFlow =
+    /\binserted\b.+\bconversation row\b.+\bbefore\b.+\bmessage rows?\b/i
+      .test(text) ||
+    /\bfailed message insert\b.+\bleft\b.+\bpartial conversation rows?\b/i
+      .test(text);
+  return hasDbTransactionAtomicityEvidence(text) &&
+    ((hasTransactionWrapFlow && hasRollbackFlow) || hasPartialInsertFlow);
+}
+
+function hasDbTransactionAtomicityFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasPartialImportConsequence =
+    /\b(partial conversation rows?|partial rows?|failed message insert left|incomplete import|inconsistent data)\b/i
+      .test(text);
+  const hasCausalFlow =
+    /\b(because|so|failed|left|prevents?|rolls? back|rollback|roll back|before)\b/i
+      .test(text);
+  return hasDbTransactionAtomicityEvidence(text) && hasPartialImportConsequence && hasCausalFlow;
 }
 
 function hasStrongRootCauseSignal(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -70,8 +70,10 @@ function hasConcreteTransferableAction(value: string) {
     'initialize',
     'load',
     'migrate',
+    'move',
     'normalize',
     'parse',
+    'place',
     'pin',
     'prune',
     'rebuild',
@@ -437,6 +439,7 @@ function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
   const hasVisibleFixSignal = hasVisibleConcreteFixSignal(note);
   const hasFixSignal = hasDurableFixSignal(note);
   if (!hasVisibleTitleSummarySignal) return false;
+  if (hasVisibleConclusionBoilerplate(note)) return false;
   if (hasFixSignal) return hasVisibleFixSignal;
   if (isMostlyOneOffStatus(note)) return false;
 
@@ -459,6 +462,7 @@ function hasVisibleTitleQuality(title: string) {
     !isVisibleWorkLogClaim(title) &&
     !isVagueGenericFixClaim(title) &&
     !isMetaReusableClaim(title) &&
+    !isGenericVisibleBoilerplateClaim(title) &&
     !isVisibleStatusSnapshotText(title)
   );
 }
@@ -470,6 +474,7 @@ function hasVisibleSummaryQuality(summary: string) {
     !isVisibleWorkLogClaim(summary) &&
     !isVagueGenericFixClaim(summary) &&
     !isMetaReusableClaim(summary) &&
+    !isGenericVisibleBoilerplateClaim(summary) &&
     !isVisibleStatusSnapshotText(summary)
   );
 }
@@ -482,9 +487,17 @@ function isVisibleWorkLogClaim(value: string) {
 function isMetaReusableClaim(value: string) {
   const text = value.toLowerCase();
   const hasMetaClaim =
-    /\b(reusable lesson|reusable note|future tasks?|this note captures|captures a reusable|for future tasks?)\b/i
+    /\b(reusable lesson|reusable note|reusable fix|future work|future tasks?|this note captures|captures a reusable|for future work|for future tasks?)\b/i
       .test(text);
   return hasMetaClaim && !hasConcreteMechanism(text);
+}
+
+function isGenericVisibleBoilerplateClaim(value: string) {
+  const text = value.toLowerCase();
+  const hasGenericReliabilityFix =
+    /\b(?:backend|api|server)?\s*reliability\s+fix\b/i.test(text) ||
+    /\bfix\b.+\breliability\b/i.test(text);
+  return hasGenericReliabilityFix && !hasSpecificEvidence(text) && !hasConcreteMechanism(text);
 }
 
 function isVisibleStatusSnapshotText(value: string) {
@@ -525,6 +538,11 @@ function hasVisibleStructuredSignal(note: MaterializedTaskMemoryNote) {
     ...conclusionText(note, 'decision'),
     ...conclusionText(note, 'pitfall'),
   ].some((item) => hasConcreteTransferableText(item));
+}
+
+function hasVisibleConclusionBoilerplate(note: MaterializedTaskMemoryNote) {
+  return note.key_conclusions.some((item) =>
+    isMetaReusableClaim(item) || isGenericVisibleBoilerplateClaim(item));
 }
 
 function hasVisibleQualitySignal(note: MaterializedTaskMemoryNote) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1754,6 +1754,8 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
   const hasStaleAsyncResponseFlow =
     /\b(overlapping|slower previous|previous|older|stale)\b.+\b(\/api\/search|search requests?|responses?)\b.+\b(overwrote|overwrite|replace|current query results?|current results)\b/i
       .test(text) ||
+    /\b(older|previous|stale)\b.+\b\/api\/search responses?\b.+\boverwrote\b.+\b(?:progress (?:indicator|bar) )?loading state\b/i
+      .test(text) ||
     /\b(overwrote|overwrite|replace)\b.+\b(current query results?|current results)\b/i
       .test(text) ||
     /\b(cancel|abortcontroller)\b.+\b(previous|older|prior|stale)\b.+\b(\/api\/search|requests?|responses?)\b/i
@@ -1765,6 +1767,8 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
     /\bgat(?:e|es|ed|ing)\b.+\b(result updates?|search result updates?|current results)\b.+\b(active|activerequestid|latest|request id|\/api\/search|query)\b/i
       .test(text) ||
     /\b(gate)\b.+\bsetresults\b.+\bactiverequestid\b/i
+      .test(text) ||
+    /\bgat(?:e|es|ed|ing)\b.+\bactiverequestid\b.+\bbefore\b.+\bsetresults\b.+\bstale loading state\b/i
       .test(text) ||
     /\bactiverequestid\b.+\bgat(?:e|es|ed|ing)\b.+\bstale\b.+\b(?:\/api\/search|responses?)\b/i
       .test(text) ||
@@ -1920,7 +1924,7 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
 function hasStrictStructuralEngineeringFailureSignal(value: string) {
   const text = value.toLowerCase();
   const hasNamedConsequence =
-    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|duplicate conversation jobs?|duplicate messages?|duplicate websocket messages?|appended twice|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|invert user and assistant turns?|inverted user and assistant turns?|out-of-order writes?|file-order parsing can invert|orphan note_tags rows?|orphan tags?|unused tags?|count 0|joins? whose note_id no longer existed|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream)|false serve success|dead server|looked like a running server|running server|nonzero exit codes?|non-zero exit codes?|exit code\s*\d+|migration (?:does not )?fail(?:s|ed)?|migration failures?|existing row failures?|constraint violation|violated the constraint|fell through to the spa fallback|clients? received index\.html instead of json|return json instead of index\.html|returns? html for api json)\b/i
+    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|duplicate conversation jobs?|duplicate messages?|duplicate websocket messages?|appended twice|stale responses?|stale results?|stale loading state|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|overwrote (?:the )?(?:progress (?:indicator|bar) )?loading state|replace current results?|invert user and assistant turns?|inverted user and assistant turns?|out-of-order writes?|file-order parsing can invert|orphan note_tags rows?|orphan tags?|unused tags?|count 0|joins? whose note_id no longer existed|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream)|false serve success|dead server|looked like a running server|running server|nonzero exit codes?|non-zero exit codes?|exit code\s*\d+|migration (?:does not )?fail(?:s|ed)?|migration failures?|existing row failures?|constraint violation|violated the constraint|fell through to the spa fallback|clients? received index\.html instead of json|return json instead of index\.html|returns? html for api json)\b/i
       .test(text) ||
     hasGeneralUniqueConstraintFailureSignal(text) ||
     /(?:旧(?:的)?\s*)?(?:\/api\/search\s*)?响应.{0,20}覆盖.{0,12}(?:当前查询结果|新结果)/i
@@ -2261,7 +2265,7 @@ function isPredicateResultStatusShell(value: string) {
 function isUndelimitedStatusPrefixShell(value: string) {
   const text = value.trim();
   return hasSpecificEvidence(text) &&
-    /^\s*(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,2}\s+)?(?:status check|progress|verification note|completion check|result check)\s+(?:[a-z][a-z0-9-]*\s+){0,4}(?=(?:activeRequestId|setResults|\/api\/|stale\b|http\b|api\b|[a-z0-9_]+\.[a-z_]))/i
+    /^\s*(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,2}\s+)?(?:status check|progress(?!\s+(?:indicator|bar)\b)|verification note|completion check|result check)\s+(?:[a-z][a-z0-9-]*\s+){0,4}(?=(?:activeRequestId|setResults|\/api\/|stale\b|http\b|api\b|[a-z0-9_]+\.[a-z_]))/i
       .test(text);
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -20,7 +20,7 @@ function hasMeaningfulText(value: string, minLatin = 24, minCjk = 18) {
 }
 
 function isPlaceholderText(value: string) {
-  return /\b(unknown|n\/a|not sure|todo|tbd|appropriate change|fix the issue|task needed investigation|expected behavior|task works correctly|expected pattern)\b/i
+  return /\b(unknown|n\/a|not sure|todo|tbd|appropriate change|fix the issue|task needed investigation|expected behavior|task works correctly|expected pattern|was wrong)\b/i
     .test(value);
 }
 
@@ -100,6 +100,10 @@ function isVagueGenericLesson(value: string) {
     /\bshould\b.+\bcorrect pattern\b/.test(text) ||
     /\bthe (pattern|task) should\b/.test(text) ||
     /\bshould validate\b.+\bbecause\b/.test(text) ||
+    /\bbecause it should work\b/.test(text) ||
+    /\bso the server works\b/.test(text) ||
+    /\badd api config\b/.test(text) ||
+    /\bcache server config\b/.test(text) ||
     /\bexpected pattern\b/.test(text);
   const hasGenericTerms =
     /\b(the task|this task|the pattern|the implementation|implementation behavior|expected behavior|expected pattern|values?|input|correctness|going forward)\b/.test(text);
@@ -118,8 +122,14 @@ function isGenericStatusAction(value: string) {
 }
 
 function hasSpecificObject(value: string) {
-  return /\b(server|readiness|client calls?|request setup|package version|dist output|release checks?|node_env|data_dir|data directory|entrypoint|startup|npm link|sqlite|database|tags?|note_tags|embedding|jsonl|cursor|codex|claude|mcp|api|url|port|path|config|environment|schema|queue|watcher|electron|window state)\b|\b[a-z0-9]+_[a-z0-9_]+\b|[a-z]:\\|\/[\w.-]+|[\u3400-\u9fff]/i
-    .test(value.toLowerCase());
+  const text = value.toLowerCase();
+  const hasSpecificIdentifier =
+    /\b(data_dir|node_env|econrefused|note_tags|chatcrystal\.db|port|source_run_key|foreign_keys)\b|\/api\/[\w/-]+|\b[a-z0-9]+_[a-z0-9_]+\b|[a-z]:\\|\/[\w.-]+|[\u3400-\u9fff]/i
+      .test(text);
+  const hasConcreteMechanism =
+    /\b(before importing|raced server startup|raced startup|resets foreign_keys|orphan rows|commits can diverge|used the default data directory|stale dist|dedupe by source_run_key|client calls raced|request setup|package version parsing|dist comparisons?|generated dist output|release checks?|startup used the default data directory|imported the server before)\b/i
+      .test(text);
+  return hasSpecificIdentifier || hasConcreteMechanism;
 }
 
 function hasConcreteTransferableText(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1018,6 +1018,9 @@ function isFirstPersonDiaryClaim(value: string) {
     'configures',
     'diagnosed',
     'discovered',
+    'ensure',
+    'ensured',
+    'ensures',
     'fixed',
     'found',
     'gates',
@@ -1212,10 +1215,10 @@ function hasSqlParameterizationEvidence(value: string) {
   const hasQueryContext =
     /\b(sql|sql\.js|where clauses?|queries?|query|lookups?|lookup)\b/i.test(text);
   const hasParameterOrTagContext =
-    /\b(sql parameters?|parameters?|parameterized|parameterised|tag names?|tags?|interpolated tag strings?|interpolated tag text)\b/i
+    /\b(sql parameters?|parameters?|parameterized|parameterised|tag names?|tag values?|tag filters?|tag payload|user-controlled tag text|tags?|interpolated tag strings?|interpolated tag text)\b/i
       .test(text);
   const hasInterpolationBoundary =
-    /\b(quotes?|quote breakage|sql syntax|where clauses?|interpolat(?:e|ed|ing)|bind(?:ing)?|parameteriz(?:e|ed|ing)|parameteris(?:e|ed|ing))\b/i
+    /\b(quotes?|quote breakage|sql syntax|executable sql|where clauses?|interpolat(?:e|ed|ing)|bind(?:ing)?|parameteriz(?:e|ed|ing)|parameteris(?:e|ed|ing))\b/i
       .test(text);
   return hasQueryContext && hasParameterOrTagContext && hasInterpolationBoundary;
 }
@@ -1225,6 +1228,8 @@ function hasSqlParameterizationAction(value: string) {
   return hasSqlParameterizationEvidence(text) &&
     (
       /\b(bind|binding|parameteriz(?:e|es|ed|ing)|parameteris(?:e|es|ed|ing))\b.+\b(tag names?|tags?|sql parameters?|parameters?|queries?|lookups?)\b/i
+        .test(text) ||
+      /\b(bind|binding)\b.+\b(tag values?|tag filters?|tag payload|tag text)\b.+\b(sql\.js\s+)?parameters?\b/i
         .test(text) ||
       /\b(use)\b.+\b(parameterized queries?|parameterised queries?|sql parameters?)\b/i
         .test(text)
@@ -1242,10 +1247,16 @@ function hasSqlParameterizationMechanism(value: string) {
       .test(text) ||
     /\binterpolat(?:e|ed|ing)\b.+\buser-controlled tag names?\b.+\b(?:sql\s+)?where clauses?\b/i
       .test(text) ||
+    /\binterpolat(?:e|ed|ing)\b.+\btag text\b.+\bcrafted tag payload\b.+\bchang(?:e|ed|es|ing)\b.+\b(?:sql\s+)?where clause syntax\b/i
+      .test(text) ||
     /\bquotes?\b.+\btag\b.+\b(?:alter(?:ed|s|ing)|chang(?:ed|es|ing))\b.+\bsql syntax\b/i
       .test(text);
   const hasParameterizationFix =
     /\bbind\b.+\btag names?\b.+\b(sql\.js\s+)?parameters?\b.+\bquotes?\b.+\bdata\b.+\binstead of sql syntax\b/i
+      .test(text) ||
+    /\bbind\b.+\btag values?\b.+\b(sql\.js\s+)?parameters?\b.+\binstead of\b.+\binterpolat(?:e|ing)\b.+\btag text\b.+\bwhere clauses?\b/i
+      .test(text) ||
+    /\bsql parameters?\b.+\btag filters?\b.+\buser-controlled tag text\b.+\bstays?\b.+\bdata\b.+\binstead of executable sql\b/i
       .test(text) ||
     /\bquotes?\b.+\bstay\b.+\bdata\b.+\binstead of sql syntax\b/i
       .test(text) ||
@@ -1274,6 +1285,8 @@ function hasSqlParameterizationFailureSignal(value: string) {
     /\bsql syntax injection\b/i
       .test(text) ||
     /\bquotes?\b.+\btag\b.+\b(?:alter(?:ed|s|ing)|chang(?:ed|es|ing))\b.+\bsql syntax\b/i
+      .test(text) ||
+    /\bcrafted tag payload\b.+\bchang(?:e|ed|es|ing)\b.+\b(?:sql\s+)?where clause syntax\b/i
       .test(text) ||
     /\balter(?:ed|s|ing)\b.+\bwhere clause syntax\b/i
       .test(text);
@@ -2066,6 +2079,8 @@ function isVisibleStatusSnapshotText(value: string) {
     /\b(ci green|ci completed successfully|tests? succeeded|testing succeeded|verification succeeded|build succeeded|typecheck succeeded|lint succeeded)\b/i
       .test(value) ||
     /\b(typecheck|lint|ci|build|tests?|testing|verification)\b.+\bcompleted successfully\b/i
+      .test(value) ||
+    /\bverification\b.+\bconfirmed\b/i
       .test(value);
   const hasHttpSuccessStatus =
     /\b(?:now\s+)?(?:returns?|responds?)(?:\s+with)?\s+(?:http\s*)?2\d\d\b/i

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -50,6 +50,7 @@ function hasWord(text: string, word: string) {
 function hasConcreteTransferableAction(value: string) {
   const text = value.toLowerCase();
   if (hasNegativeTransferableAction(text)) return true;
+  if (hasSchemaDefaultArrayAction(text)) return true;
   const concreteActionWords = [
     'add',
     'block',
@@ -100,6 +101,15 @@ function hasConcreteTransferableAction(value: string) {
 function hasNegativeTransferableAction(text: string) {
   return /\bdo not\b.+\b(read|write|call|use|access|parse)\b.+\bbefore\b.+\b(validat(?:e|ing)|check(?:ing)?|parse|parsing)\b/i
     .test(text);
+}
+
+function hasSchemaDefaultArrayAction(text: string) {
+  return (
+    /\b(use|change|set|default|materializ(?:e|ed)|configure)\b.+\b(schema|z\.array|default\(\[\]\)|empty array|omitted items?)\b/i
+      .test(text) ||
+    /\b(schema|z\.array|default\(\[\]\)|empty array|omitted items?)\b.+\b(default|materializ(?:e|ed)|empty array)\b/i
+      .test(text)
+  );
 }
 
 function isVagueGenericLesson(value: string) {
@@ -175,10 +185,31 @@ function hasSpecificEvidence(value: string) {
   return (
     /\b(data_dir|node_env|econrefused|typeerror|note_tags|chatcrystal\.db|port|source_run_key|foreign_keys)\b|\/api\/[\w/-]+|\b[a-z0-9]+_[a-z0-9_]+\b|[a-z]:\\|\/[\w.-]+|[\u3400-\u9fff]/i
       .test(text) ||
+    hasSchemaArrayEvidence(text) ||
     hasHttpFailureSignal(text) ||
     /\b(api requests?|fastify readiness|server readiness|request setup|package metadata|package version|dist output|generated dist output|data directory|electron server|server entrypoint|client calls?)\b/i
       .test(text)
   );
+}
+
+function hasSchemaArrayEvidence(value: string) {
+  const text = value.toLowerCase();
+  return (
+    /\b(zod|z\.array|z\.object|request\.\w+|\w+schema)\b/i.test(text) ||
+    /\.(?:optional|default)\(/i.test(text) ||
+    /\bdefault\(\[\]\)\b/i.test(text)
+  );
+}
+
+function hasSchemaDefaultArrayMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasOptionalOrDefaultArray =
+    /\b(optional arrays?|omitted arrays?|omitted items?|undefined|empty array)\b/i.test(text) ||
+    /\.(?:optional|default)\(/i.test(text) ||
+    /\bdefault\(\[\]\)\b/i.test(text);
+  const hasIterationOrHandler =
+    /\b(iterat(?:e|ed|es|ing|ion)|handler|handler logic)\b/i.test(text);
+  return hasSchemaArrayEvidence(text) && hasOptionalOrDefaultArray && hasIterationOrHandler;
 }
 
 function hasConcreteMechanism(value: string) {
@@ -223,6 +254,7 @@ function hasConcreteMechanism(value: string) {
       .test(text) ||
     /\b(rate[- ]limit|http 429|429|retry-after|backoff|delay)\b.+\b(retry|retried|retries|queue|queued|provider requests?)\b/i
       .test(text);
+  const hasSchemaDefaultArrayFlow = hasSchemaDefaultArrayMechanism(text);
   return (
     hasTimingOrder ||
     hasRaceReadiness ||
@@ -232,7 +264,8 @@ function hasConcreteMechanism(value: string) {
     hasDedupeKey ||
     hasRequestFailureOrdering ||
     hasParserFieldValidation ||
-    hasRetryBackoffFlow
+    hasRetryBackoffFlow ||
+    hasSchemaDefaultArrayFlow
   );
 }
 
@@ -266,12 +299,18 @@ function isFirstPersonDiaryClaim(value: string) {
     'fixed',
     'found',
     'implemented',
+    'block',
+    'configure',
     'reviewed',
     'resolved',
+    'place',
+    'register',
+    'set',
     'switched',
     'tested',
     'updated',
     'verified',
+    'wait',
   ].join('|');
   return new RegExp(
     `(?:^|[:.!?,;]\\s*|\\b(?:and|then|but|so)\\s+)\\b(?:i|we)\\s+(?:${diaryVerbs})\\b`,
@@ -290,9 +329,20 @@ function hasFailureOrConsequenceSignal(value: string) {
   return (
     /\b(race|raced|orphan|dedupe|deduplicate|stale dist|dist diverge|dist diverged|diverge|diverged|econrefused|typeerror|threw|throws?|readiness issue|startup race|invalid note_tags|foreign_keys|cascade|nulling|source_run_key collision)\b/i
       .test(value) ||
+    hasSchemaArrayFailureSignal(value) ||
     hasDefaultDataDirectoryConsequence(value) ||
     hasHttpFailureSignal(value)
   );
+}
+
+function hasSchemaArrayFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasArrayFailure =
+    /\b(undefined|throws?|throw|omitted arrays?|omitted items?|optional arrays?)\b/i.test(text) ||
+    /\.optional\(\)/i.test(text);
+  const hasIterationOrHandler =
+    /\b(iterat(?:e|ed|es|ing|ion)|handler|handler logic)\b/i.test(text);
+  return hasSchemaArrayEvidence(text) && hasArrayFailure && hasIterationOrHandler;
 }
 
 function hasStrongRootCauseSignal(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1534,7 +1534,7 @@ function isVisibleWorkLogClaim(value: string) {
 }
 
 function isExplicitEnglishStatusShell(value: string) {
-  return /^\s*(?:work\s*log|worklog|status\s+record|status|record)\s*(?:[:\-\u2013\u2014])/i
+  return /^\s*(?:work\s*log|worklog|status\s+record|status\s+update|status|record|execution\s+record|completion\s+record|fix\s+record|this\s+fix|this\s+run|run\s+log)\s*(?:[:\-\u2013\u2014])/i
     .test(value.trim());
 }
 
@@ -1571,6 +1571,8 @@ function hasChineseVisibleMechanism(value: string) {
 function isChineseVisibleStatusShell(value: string) {
   if (!/[\u3400-\u9fff]/.test(value)) return false;
   const hasStatusRecordShell =
+    /^\s*(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|本次修复|本次执行|修复记录)\s*(?:[：:\-\u2013\u2014]|$)/i
+      .test(value) ||
     /(?:^|[\s：:])(?:状态记录|记录状态|工作日志|日志记录|工作记录)(?:[\s：:]|$)|^(?:状态|记录)\s*[：:]/i
       .test(value) ||
     /(?:已记录|记录了).{0,80}(?:已修复|修复完成|已完成|完成|处理完成|解决完成)/i

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1306,13 +1306,18 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
       .test(text) &&
     /\b(\/api\/[\w/-]+|\/search|proxy|route|fastify|http\s*404)\b/i
       .test(text);
+  const hasNamedSpaFallbackObject =
+    /\b(spa fallback|fallback handler|index\.html|json|api route|clients?|registered after the fallback handler)\b/i
+      .test(text) &&
+    /\b(\/api\/[\w/-]+|api route|requests?|route|fallback handler)\b/i
+      .test(text);
   const hasNamedMigrationObject =
     /\b(sqlite|chatcrystal\.db|migration|migrations?|not null|default|existing rows?|existing \w+ rows?|notes column|column nullable|backfill|constraint)\b/i
       .test(text) &&
     /\b(migration|migrations?|not null|backfill|chatcrystal\.db|constraint)\b/i
       .test(text);
   const hasEngineeringContext =
-    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?|initialization|initialized|route|mcp|json-rpc|stdio|stdout|stderr|framing|transport|logs?|diagnostics?|tags?|joins?|deletion|cleanup|filter chips?|webui|websocket|listeners?|useeffect|remounts?|unmount|child_process|child process|daemon|pid|spawn|exit code|serve|status|dead server|migration|not null|default|backfill|column|startup|vite|proxy|fastify|rewrite|registered route)\b/i
+    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?|initialization|initialized|route|mcp|json-rpc|stdio|stdout|stderr|framing|transport|logs?|diagnostics?|tags?|joins?|deletion|cleanup|filter chips?|webui|websocket|listeners?|useeffect|remounts?|unmount|child_process|child process|daemon|pid|spawn|exit code|serve|status|dead server|migration|not null|default|backfill|column|startup|vite|proxy|fastify|rewrite|registered route|spa fallback|fallback handler|index\.html|conversation_id|queue jobs?|enqueue|enqueueing|summarize)\b/i
       .test(text);
   return (
     hasConcreteToken ||
@@ -1324,6 +1329,7 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
     hasNamedListenerObject ||
     hasNamedProcessLifecycleObject ||
     hasNamedProxyRoutingObject ||
+    hasNamedSpaFallbackObject ||
     hasNamedMigrationObject
   ) && hasEngineeringContext;
 }
@@ -1331,7 +1337,7 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
 function hasStrictStructuralEngineeringAction(value: string) {
   const text = value.toLowerCase();
   const hasAction =
-    /\b(add|create|remove|wrap|validate|normalize|configure|set|index|return|reuse|cancel|use|wait|send|reserve|filter|prune|clean up|cleanup)\b/i
+    /\b(add|create|remove|wrap|validate|normalize|configure|set|index|return|reuse|cancel|use|wait|send|reserve|filter|prune|clean up|cleanup|register|deduplicate|dedupe|enqueue|enqueueing|ensure)\b/i
       .test(text);
   const hasConcreteDbAction =
     /\b(add|create)\b.+\b(unique\s*\([^)]*\)|unique key|unique constraint|constraint|index|idx_[a-z0-9_]+)\b/i
@@ -1341,9 +1347,16 @@ function hasStrictStructuralEngineeringAction(value: string) {
   const hasConcreteAsyncAction =
     /\b(use\b.+\babortcontroller|abortcontroller\b.+\bcancel|cancel(?: older| previous| prior)?\b.+\b(?:\/api\/search|requests?|responses?))\b/i
       .test(text) ||
+    /\bensure\b.+\bactiverequestid\b.+\bmatches\b.+\bbefore\b.+\bsetresults\b/i
+      .test(text) ||
     /\b(gate)\b.+\b(result updates?|responses?|requests?|setresults)\b.+\b(active|activerequestid|latest|request id|query)\b/i
       .test(text) ||
     /\b(ignore)\b.+\b(responses?)\b.+\b(not from the latest query|older|previous|stale|latest query)\b/i
+      .test(text);
+  const hasConcreteQueueDedupeAction =
+    /\b(deduplicate|dedupe)\b.+\bqueue jobs?\b.+\bconversation_id\b/i
+      .test(text) ||
+    /\b(reuse|reuses?)\b.+\bpending job\b.+\bduplicate notes?\b/i
       .test(text);
   const hasConcreteRelationAction =
     /\b(filter|filtered)\b.+\b(tag counts?|tags?)\b.+\b(existing notes?|existing note_ids?|note_ids?)\b/i
@@ -1377,6 +1390,11 @@ function hasStrictStructuralEngineeringAction(value: string) {
       .test(text) ||
     /\b(disable|disabled)\b.+\bproxy\b.+\brewrite\b.+\b(route|\/api\/[\w/-]+|fastify)\b/i
       .test(text);
+  const hasConcreteSpaFallbackAction =
+    /\bregister\b.+(?:\/api\/[\w/-]+|\bapi route\b).+\bbefore\b.+\b(?:spa fallback|fallback handler)\b/i
+      .test(text) ||
+    /\breturn\b.+\bjson\b.+\binstead of\b.+\bindex\.html\b/i
+      .test(text);
   const hasConcreteMigrationAction =
     /\bbackfill\b.+\b(existing rows?|existing \w+ rows?|rows?)\b/i
       .test(text) ||
@@ -1389,12 +1407,14 @@ function hasStrictStructuralEngineeringAction(value: string) {
       hasAction ||
       hasConcreteDbAction ||
       hasConcreteAsyncAction ||
+      hasConcreteQueueDedupeAction ||
       hasConcreteRelationAction ||
       hasConcreteLifecycleAction ||
       hasConcreteTransportAction ||
       hasConcreteListenerAction ||
       hasConcreteProcessLifecycleAction ||
       hasConcreteProxyRoutingAction ||
+      hasConcreteSpaFallbackAction ||
       hasConcreteMigrationAction
     );
 }
@@ -1442,9 +1462,22 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       .test(text) ||
     /\bactiverequestid\b.+\b(?:was\s+)?not checked\b.+\bbefore\b.+\bsetresults\b/i
       .test(text) ||
+    /\bsetresults\b.+\b(?:did not|without)\b.+\bcheck(?:ing)?\b.+\bactiverequestid\b/i
+      .test(text) ||
+    /\bensure\b.+\bactiverequestid\b.+\bmatches\b.+\bbefore\b.+\bsetresults\b.+\bstale\b.+\b(?:\/api\/search|responses?)\b/i
+      .test(text) ||
     /\b(ignore)\b.+\bresponses?\b.+\b(not from the latest query|older|previous|stale|latest query)\b/i
       .test(text) ||
     /\bolder\b.+\b\/api\/search responses?\b.+\b(after a newer query|newer query)\b.+\boverwrite\b.+\bcurrent results\b/i
+      .test(text);
+  const hasQueueDedupeFlow =
+    /\b(?:summarize --all|retries|retry)\b.+\benqueued\b.+\bsame conversation_id\b.+\bduplicate notes?\b/i
+      .test(text) ||
+    /\bqueue jobs?\b.+\bduplicate notes?\b.+\bsame conversation\b/i
+      .test(text) ||
+    /\bdeduplicate\b.+\bqueue jobs?\b.+\bconversation_id\b.+\b(retries|pending job|duplicate notes?|enqueueing)\b/i
+      .test(text) ||
+    /\bconversation_id\b.+\b(?:more than once|duplicate notes?|pending job|enqueueing|queue jobs?)\b/i
       .test(text);
   const hasRelationCleanupFlow =
     /\b(filter|filtered)\b.+\b(tag counts?|tags?)\b.+\b(existing notes?|existing note_ids?|note_ids?)\b/i
@@ -1506,6 +1539,17 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       .test(text) ||
     /\b(disable|disabled|preserv(?:e|es|ed|ing))\b.+\bproxy\b.+\b(path rewrite|rewrite|\/api\/[\w/-]+)\b.+\b(registered fastify route|registered route|fastify|route)\b/i
       .test(text);
+  const hasSpaFallbackRouteFlow =
+    /(?:\/api\/[\w/-]+|\bapi route\b).+\bfell through\b.+\bspa fallback\b.+\bbecause\b.+\bregistered after\b.+\bfallback handler\b/i
+      .test(text) ||
+    /\bapi route\b.+\bbefore\b.+\bspa fallback\b.+\breturns?\b.+\bjson\b/i
+      .test(text) ||
+    /\bapi route\b.+\bregistered after\b.+\bfallback handler\b.+\bindex\.html\b.+\bjson\b/i
+      .test(text) ||
+    /\bregister\b.+\b(?:\/api\/[\w/-]+|api route)\b.+\bbefore\b.+\bspa fallback\b.+\bjson\b.+\bindex\.html\b/i
+      .test(text) ||
+    /\bclients?\b.+\breceived\b.+\bindex\.html\b.+\binstead of\b.+\bjson\b/i
+      .test(text);
   const hasMigrationConstraintFlow =
     /\bmigration\b.+\badd(?:ed)?\b.+\bnot null\b.+\bwithout a default\b/i
       .test(text) ||
@@ -1518,7 +1562,7 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
     /\badd\b.+\bcolumn\b.+\bnullable\b.+\bbackfill\b.+\benforce\b.+\bnot null\b/i
       .test(text);
   const hasCausalFlow =
-    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gat(?:e|es|ed|ing)|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve|left|no longer existed|deleting notes?|note deletion|cleanup|prune|filter|duplicate|appended twice|remounts?|unmount|spawn handshake|exit event|exit code|dead server|nonzero|non-zero|backfill|not null|default|constraint|violat(?:e|ed|es|ing)|rewrote|rewrite|proxy|preserv(?:e|es|ed|ing)|registered route)\b/i
+    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gat(?:e|es|ed|ing)|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve|left|no longer existed|deleting notes?|note deletion|cleanup|prune|filter|duplicate|deduplicate|dedupe|enqueued|enqueue|pending job|appended twice|remounts?|unmount|spawn handshake|exit event|exit code|dead server|nonzero|non-zero|backfill|not null|default|constraint|violat(?:e|ed|es|ing)|rewrote|rewrite|proxy|preserv(?:e|es|ed|ing)|registered route|fell through|spa fallback|fallback handler|index\.html)\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) &&
     hasCausalFlow &&
@@ -1528,12 +1572,14 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       hasLookupScanFlow ||
       hasUniquenessConstraintFlow ||
       hasStaleAsyncResponseFlow ||
+      hasQueueDedupeFlow ||
       hasRelationCleanupFlow ||
       hasInitializationOrderFlow ||
       hasTransportFramingFlow ||
       hasListenerCleanupFlow ||
       hasProcessLifecycleFlow ||
       hasProxyPathRewriteFlow ||
+      hasSpaFallbackRouteFlow ||
       hasMigrationConstraintFlow
     );
 }
@@ -1541,10 +1587,10 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
 function hasStrictStructuralEngineeringFailureSignal(value: string) {
   const text = value.toLowerCase();
   const hasNamedConsequence =
-    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|duplicate messages?|duplicate websocket messages?|appended twice|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|orphan note_tags rows?|orphan tags?|unused tags?|count 0|joins? whose note_id no longer existed|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream)|false serve success|dead server|looked like a running server|running server|nonzero exit codes?|non-zero exit codes?|exit code\s*\d+|migration (?:does not )?fail(?:s|ed)?|migration failures?|existing row failures?|constraint violation|violated the constraint)\b/i
+    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|duplicate messages?|duplicate websocket messages?|appended twice|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|orphan note_tags rows?|orphan tags?|unused tags?|count 0|joins? whose note_id no longer existed|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream)|false serve success|dead server|looked like a running server|running server|nonzero exit codes?|non-zero exit codes?|exit code\s*\d+|migration (?:does not )?fail(?:s|ed)?|migration failures?|existing row failures?|constraint violation|violated the constraint|fell through to the spa fallback|clients? received index\.html instead of json|return json instead of index\.html)\b/i
       .test(text);
   const hasCausalFlow =
-    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|left|no longer existed|deleting notes?|note deletion|cleanup|filter|prune|remounts?|unmount|duplicate|appended twice|spawn handshake|exit event|exit code|nonzero|non-zero|dead server|backfill|not null|default|constraint|violat(?:e|ed|es|ing)|migration)\b/i
+    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|left|no longer existed|deleting notes?|note deletion|cleanup|filter|prune|remounts?|unmount|duplicate|deduplicate|dedupe|enqueued|enqueue|pending job|appended twice|spawn handshake|exit event|exit code|nonzero|non-zero|dead server|backfill|not null|default|constraint|violat(?:e|ed|es|ing)|migration|fell through|spa fallback|fallback handler|index\.html)\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) && hasNamedConsequence && hasCausalFlow;
 }
@@ -1831,15 +1877,18 @@ function isVisibleWorkLogClaim(value: string) {
 function isExplicitEnglishStatusShell(value: string) {
   return hasTechnicalPrefixStatusShell(value) ||
     /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task)\s+(?:record|report|note|summary|update|log|entry)|(?:implementation|task|fix|execution|run|work|status)\s+results?|run\s+results?|work\s*log(?:\s+entry)?|worklog(?:\s+entry)?|status|record|update|implementation|result|outcome|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
-    .test(value.trim()) ||
-    isCurrentRunImplementationShell(value);
+      .test(value.trim()) ||
+    isCurrentRunImplementationShell(value) ||
+    isCurrentRunStatusObservationClaim(value);
 }
 
 function hasTechnicalPrefixStatusShell(value: string) {
   const text = value.trim();
   const descriptorWord = String.raw`(?:api|search|vite|proxy|fastify|react|sqlite|database|mcp|websocket|codex|claude|import|jsonl|electron|daemon|embedding|llm|route)`;
   const chineseDescriptorWord = String.raw`(?:搜索|接口|代理|路由|导入|数据库|前端|后端)`;
-  const technicalPrefix = String.raw`(?:\/api\/[\w/-]+|[a-z0-9]+_[a-z0-9_]+|[a-z][a-z0-9_]*\.[a-z_][a-z0-9_]*|activerequestid|setresults|data_dir|node_env|child_process|jsonl|sqlite|sql\.js|websocket|mcp|json-rpc|${descriptorWord}(?:\s+${descriptorWord}){0,2}|${chineseDescriptorWord}(?:\s+${chineseDescriptorWord}){0,2})`;
+  const englishDescriptorPrefix = String.raw`(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,3})`;
+  const chineseDescriptorPrefix = String.raw`(?:[\u3400-\u9fff]{2,16})`;
+  const technicalPrefix = String.raw`(?:\/api\/[\w/-]+|[a-z0-9]+_[a-z0-9_]+|[a-z][a-z0-9_]*\.[a-z_][a-z0-9_]*|activerequestid|setresults|data_dir|node_env|child_process|jsonl|sqlite|sql\.js|websocket|mcp|json-rpc|${descriptorWord}(?:\s+${descriptorWord}){0,2}|${chineseDescriptorWord}(?:\s+${chineseDescriptorWord}){0,2}|${englishDescriptorPrefix}|${chineseDescriptorPrefix})`;
   const englishShell = String.raw`(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task)\s+(?:record|report|note|summary|update|log|entry)|(?:status|record|update|implementation|result|outcome|completion(?:\s+(?:note|record))?|completed|done))`;
   const chineseShell = String.raw`(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|运行结果|执行结果|结果记录|结果报告|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|结果|完成|已完成|完成说明)`;
   return new RegExp(`^\\s*${technicalPrefix}\\s+${englishShell}\\s*(?:[:\\-\\u2013\\u2014])`, 'i')
@@ -1851,7 +1900,7 @@ function hasTechnicalPrefixStatusShell(value: string) {
 function isCurrentRunImplementationShell(value: string) {
   const text = value.trim();
   const currentRunSubject = '(?:run|execution|fix|task|change)';
-  const currentRunPrefix = `(?:(?:in\\s+(?:this|the\\s+current)\\s+${currentRunSubject})|(?:(?:the\\s+)?current|this)\\s+${currentRunSubject})`;
+  const currentRunPrefix = `(?:(?:(?:in|during)\\s+(?:this|the\\s+current)\\s+${currentRunSubject})|(?:(?:the\\s+)?current|this)\\s+${currentRunSubject})`;
   const implementationVerb = '(?:use|uses|used|did|add|adds|added|set|sets|configured?|register(?:s|ed)?|wait(?:s|ed)?|block(?:s|ed)?|gate(?:s|d)?|ignore(?:s|d)?|cancel(?:s|ed|led)?|move(?:s|d)?|place(?:s|d)?|import(?:s|ed)?|update(?:s|d)?|fix(?:es|ed)?|change(?:s|d)?|validat(?:e|es|ed)|normaliz(?:e|es|ed)|parse(?:s|d)?|strip(?:s|ped)?|debounce(?:s|d)?|route(?:s|d)?|return(?:s|ed)?|prune(?:s|d)?|remove(?:s|d)?|wrap(?:s|ped)?)';
   const hasCurrentRunPrefix =
     new RegExp(`^\\s*${currentRunPrefix}\\b`, 'i').test(text);
@@ -1859,6 +1908,16 @@ function isCurrentRunImplementationShell(value: string) {
     new RegExp(`^\\s*${currentRunPrefix}\\b.{0,80}\\b${implementationVerb}\\b`, 'i')
       .test(text);
   return hasCurrentRunPrefix && hasImplementationAction && hasSpecificEvidence(text);
+}
+
+function isCurrentRunStatusObservationClaim(value: string) {
+  const text = value.trim();
+  return (
+    /\b(?:during|in)\s+this\s+run\b/i.test(text) &&
+    hasSpecificEvidence(text) &&
+    /\b(returned|returns?|http\s*[45]\d\d|observed|recorded|checked|verified|passed|completed|fixed|status)\b/i
+      .test(text)
+  );
 }
 
 function isLowValueOutcomeStatusClaim(value: string) {
@@ -2054,6 +2113,8 @@ function isLowQualityVisibleConclusion(value: string) {
     isFirstPersonDiaryClaim(body) ||
     isExplicitEnglishStatusShell(value) ||
     isExplicitEnglishStatusShell(body) ||
+    isCurrentRunStatusObservationClaim(value) ||
+    isCurrentRunStatusObservationClaim(body) ||
     isVisibleWorkLogClaim(body) ||
     isVisibleStatusSnapshotText(body) ||
     isLowValueOutcomeStatusClaim(value) ||

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -276,9 +276,22 @@ function hasPackageDistRootCauseSignal(value: string) {
       .test(text) ||
     /\b(inconsistent|different formats)\b.+\b(version parsing|package version parsing|version normalization|package normalization)\b.+\bdist comparisons?\b.+\bunreliable\b/i
       .test(text);
+  if ((isPackageArtifactObservationClaim(text) || isExistenceOnlyClaim(text)) && !hasExplicitPackageCausality(text)) {
+    return false;
+  }
   if (hasPositiveSignal) return true;
   if (isPackageArtifactObservationClaim(text) || isExistenceOnlyClaim(text)) return false;
   return false;
+}
+
+function hasExplicitPackageCausality(value: string) {
+  const text = value.toLowerCase();
+  return (
+    /\b(diverged|divergence|mismatch|stale(?: package metadata| output| dist)?|wrong comparison|comparison failure|dist comparisons? unreliable|differed from package metadata|differed from package version)\b.+\bbecause\b.+\b(version parsing|parsing|version normalization|normalization|normalize|normalized|different formats|inconsistent normalization|comparison|comparing)\b/i
+      .test(text) ||
+    /\b(version parsing|parsing|version normalization|normalization|normalize|normalized|different formats|inconsistent normalization|comparison|comparing)\b.+\b(caused|produced|led to|made)\b.+\b(diverged|divergence|mismatch|stale(?: package metadata| output| dist)?|wrong comparison|comparison failure|dist comparisons? unreliable|differed from package metadata|differed from package version)\b/i
+      .test(text)
+  );
 }
 
 function isExistenceOnlyClaim(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -456,6 +456,7 @@ function hasVisibleTitleQuality(title: string) {
     hasNonPlaceholderMeaningfulText(title, 10, 6) &&
     !isGenericTitle(title) &&
     !isFirstPersonDiaryClaim(title) &&
+    !isVisibleWorkLogClaim(title) &&
     !isVagueGenericFixClaim(title) &&
     !isMetaReusableClaim(title) &&
     !isVisibleStatusSnapshotText(title)
@@ -466,10 +467,16 @@ function hasVisibleSummaryQuality(summary: string) {
   return (
     hasNonPlaceholderMeaningfulText(summary) &&
     !isFirstPersonDiaryClaim(summary) &&
+    !isVisibleWorkLogClaim(summary) &&
     !isVagueGenericFixClaim(summary) &&
     !isMetaReusableClaim(summary) &&
     !isVisibleStatusSnapshotText(summary)
   );
+}
+
+function isVisibleWorkLogClaim(value: string) {
+  return /^(added|changed|checked|confirmed|diagnosed|discovered|fixed|found|implemented|switched|updated|verified)\b/i
+    .test(value.trim());
 }
 
 function isMetaReusableClaim(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -216,12 +216,15 @@ function hasConcreteMechanism(value: string) {
 
 function hasConcreteTransferableText(value: string) {
   if (hasPackageDistRootCauseShape(value) && !hasPackageItemSignal(value)) return false;
+  const hasConcreteConsequence =
+    hasFailureOrConsequenceSignal(value) ||
+    (hasPackageDistRootCauseShape(value) && hasPackageDistRootCauseSignal(value));
   return (
     hasNonPlaceholderMeaningfulText(value) &&
     hasConcreteTransferableAction(value) &&
     hasSpecificEvidence(value) &&
     hasConcreteMechanism(value) &&
-    hasFailureOrConsequenceSignal(value) &&
+    hasConcreteConsequence &&
     !isExistenceOnlyClaim(value) &&
     !isFirstPersonDiaryClaim(value) &&
     !isGenericStatusAction(value) &&
@@ -497,7 +500,18 @@ function isGenericVisibleBoilerplateClaim(value: string) {
   const hasGenericReliabilityFix =
     /\b(?:backend|api|server)?\s*reliability\s+fix\b/i.test(text) ||
     /\bfix\b.+\breliability\b/i.test(text);
-  return hasGenericReliabilityFix && !hasSpecificEvidence(text) && !hasConcreteMechanism(text);
+  const hasGenericFutureFailure =
+    /\bfuture failure prevention\b/i.test(text) ||
+    /\b(?:avoid|prevent|prevents?|prevention)\b.+\bfuture failures?\b/i.test(text) ||
+    /\bfuture failures?\b.+\bexpected workflow\b/i.test(text);
+  const hasGenericReleaseValidation =
+    /\balways validate behavior before release\b/i.test(text) ||
+    /\bvalidate behavior\b.+\bbefore release\b/i.test(text);
+  return (
+    hasGenericReliabilityFix ||
+    hasGenericFutureFailure ||
+    hasGenericReleaseValidation
+  ) && !hasSpecificEvidence(text) && !hasConcreteMechanism(text);
 }
 
 function isVisibleStatusSnapshotText(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -52,6 +52,7 @@ function hasConcreteTransferableAction(value: string) {
   if (hasNegativeTransferableAction(text)) return true;
   if (hasSchemaDefaultArrayAction(text)) return true;
   if (hasDurableEngineeringPreventionAction(text)) return true;
+  if (hasImportDedupeAction(text)) return true;
   if (hasPersistenceSerializationAction(text)) return true;
   const concreteActionWords = [
     'add',
@@ -194,10 +195,12 @@ function hasSpecificObject(value: string) {
 function hasSpecificEvidence(value: string) {
   const text = value.toLowerCase();
   return (
-    /\b(data_dir|node_env|econrefused|typeerror|note_tags|chatcrystal\.db|port|source_run_key|foreign_keys)\b|\/api\/[\w/-]+|\b[a-z0-9]+_[a-z0-9_]+\b|[a-z]:\\|\/[\w.-]+|[\u3400-\u9fff]/i
+    /\b(data_dir|node_env|econrefused|typeerror|note_tags|chatcrystal\.db|port|source_run_key|foreign_keys)\b|\/api\/[\w/-]+|\b[a-z0-9]+_[a-z0-9_]+\b|[a-z]:\\|\/[\w.-]+/i
       .test(text) ||
+    hasChineseTechnicalEvidence(text) ||
     hasSchemaArrayEvidence(text) ||
     hasDurableEngineeringEvidence(text) ||
+    hasImportDedupeEvidence(text) ||
     hasContentSanitizationEvidence(text) ||
     hasPersistenceSnapshotEvidence(text) ||
     hasIndexConsistencyEvidence(text) ||
@@ -205,6 +208,11 @@ function hasSpecificEvidence(value: string) {
     /\b(api requests?|fastify readiness|server readiness|request setup|package metadata|package version|dist output|generated dist output|data directory|electron server|server entrypoint|client calls?)\b/i
       .test(text)
   );
+}
+
+function hasChineseTechnicalEvidence(value: string) {
+  return /接口|请求|路由|注册|配置|数据库|索引|语义搜索|向量|笔记|导入|解析|去重|文件|目录|环境变量|凭据|私钥|内网|脱敏|校准|样本|夹具|数据集|元数据|来源|隐私|构建|编译/
+    .test(value);
 }
 
 function hasSchemaArrayEvidence(value: string) {
@@ -267,6 +275,41 @@ function hasDurableEngineeringFailureSignal(value: string) {
     /\b(because|so|caused|led to|hid whether|could commit|cannot silently include|without review context|leak(?:ed|s|ing)?|returned|overwrote|threw)\b/i
       .test(text);
   return hasDurableEngineeringEvidence(text) && hasConcreteConsequence && hasFailureFlow;
+}
+
+function hasImportDedupeEvidence(value: string) {
+  const text = value.toLowerCase();
+  return /\b(chokidar|jsonl|mtime|file size|source file size|file revision|import scan|adapter|import dedupe key|dedupe key|duplicate inserts?|unchanged [\w -]*files?|reparsed|reparse|same file revision)\b/i
+    .test(text);
+}
+
+function hasImportDedupeAction(value: string) {
+  const text = value.toLowerCase();
+  const hasDedupeAction = /\b(use|skip|dedupe|deduplicate|key|compare|track)\b/i.test(text);
+  const hasRevisionKey =
+    /\b(file size|source file size|mtime|dedupe key|file revision|skip parsing|same file revision)\b/i
+      .test(text);
+  return hasImportDedupeEvidence(text) && hasDedupeAction && hasRevisionKey;
+}
+
+function hasImportDedupeMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasDedupeFlow =
+    /\b(import dedupe|dedupe key|dedupe|deduplicate|skip parsing|same file revision)\b/i
+      .test(text);
+  const hasRevisionOrWatcherEvidence =
+    /\b(file size|source file size|mtime|file revision|same file revision|chokidar|unchanged [\w -]*files?|jsonl|reparsed|reparse|repeated)\b/i
+      .test(text);
+  return hasImportDedupeEvidence(text) && hasDedupeFlow && hasRevisionOrWatcherEvidence;
+}
+
+function hasImportDedupeFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasRepeatedImportConsequence =
+    /\b(repeated events?|repeated jsonl parsing|reparsed|reparse|duplicate inserts?|same conversation|every chokidar event)\b/i
+      .test(text);
+  const hasCausalFlow = /\b(because|so|otherwise|attempted|prevents?|preventing)\b/i.test(text);
+  return hasImportDedupeEvidence(text) && hasRepeatedImportConsequence && hasCausalFlow;
 }
 
 function hasContentSanitizationEvidence(value: string) {
@@ -409,6 +452,7 @@ function hasConcreteMechanism(value: string) {
       .test(text);
   const hasSchemaDefaultArrayFlow = hasSchemaDefaultArrayMechanism(text);
   const hasDurableEngineeringFlow = hasDurableEngineeringMechanism(text);
+  const hasImportDedupeFlow = hasImportDedupeMechanism(text);
   const hasContentSanitizationFlow = hasContentSanitizationMechanism(text);
   const hasPersistenceSerializationFlow = hasPersistenceSerializationMechanism(text);
   const hasIndexConsistencyFlow = hasIndexConsistencyMechanism(text);
@@ -424,6 +468,7 @@ function hasConcreteMechanism(value: string) {
     hasRetryBackoffFlow ||
     hasSchemaDefaultArrayFlow ||
     hasDurableEngineeringFlow ||
+    hasImportDedupeFlow ||
     hasContentSanitizationFlow ||
     hasPersistenceSerializationFlow ||
     hasIndexConsistencyFlow
@@ -492,6 +537,7 @@ function hasFailureOrConsequenceSignal(value: string) {
       .test(value) ||
     hasSchemaArrayFailureSignal(value) ||
     hasDurableEngineeringFailureSignal(value) ||
+    hasImportDedupeFailureSignal(value) ||
     hasContentSanitizationFailureSignal(value) ||
     hasPersistenceSnapshotFailureSignal(value) ||
     hasIndexConsistencyFailureSignal(value) ||
@@ -834,10 +880,15 @@ function isVisibleStatusSnapshotText(value: string) {
       .test(value);
   const hasStatusVerb = /\b(checked|noted|observed|reviewed|resolved|tested|testing passed|verified|verification|current|status)\b/i
     .test(value);
+  const hasChineseStatus =
+    /已验证|验证通过|测试通过|构建通过|编译通过|类型检查通过|检查通过|已修复|修复已验证|ci\s*通过|持续集成通过/i
+      .test(value) ||
+    /(?:提高|提升).{0,12}(?:可靠性|正确性)|(?:可靠性|正确性).{0,12}(?:提高|提升)/
+      .test(value);
   const hasStatusObject =
     /\b(node_env|env|environment|production|local|testing|server readiness|fastify readiness|api requests?|package version|version|generated dist output|dist output)\b/i
       .test(value);
-  return (hasPassStatus || hasSuccessStatus || (hasStatusVerb && hasStatusObject)) &&
+  return (hasPassStatus || hasSuccessStatus || hasChineseStatus || (hasStatusVerb && hasStatusObject)) &&
     !hasStrongReusableMechanism(value);
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -475,7 +475,7 @@ function hasVisibleSummaryQuality(summary: string) {
 }
 
 function isVisibleWorkLogClaim(value: string) {
-  return /^(added|changed|checked|confirmed|diagnosed|discovered|fixed|found|implemented|switched|updated|verified)\b/i
+  return /^(added|changed|checked|confirmed|diagnosed|discovered|fixed|found|implemented|noted|observed|switched|updated|verified)\b/i
     .test(value.trim());
 }
 
@@ -488,7 +488,7 @@ function isMetaReusableClaim(value: string) {
 }
 
 function isVisibleStatusSnapshotText(value: string) {
-  const hasStatusVerb = /\b(checked|verified|verification|current|status)\b/i.test(value);
+  const hasStatusVerb = /\b(checked|noted|observed|verified|verification|current|status)\b/i.test(value);
   const hasStatusObject =
     /\b(node_env|env|environment|production|local|package version|version|generated dist output|dist output)\b/i
       .test(value);

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -124,14 +124,13 @@ function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
   const hasMeaningfulRootCause = Boolean(
     payload.root_cause &&
     hasNonPlaceholderMeaningfulText(payload.root_cause) &&
+    hasSpecificObject(payload.root_cause) &&
     !isGenericStatusAction(payload.root_cause) &&
     !isVagueGenericLesson(payload.root_cause),
   );
   const hasMeaningfulResolution = Boolean(
     payload.resolution &&
-    hasNonPlaceholderMeaningfulText(payload.resolution) &&
-    !isGenericStatusAction(payload.resolution) &&
-    !isVagueGenericLesson(payload.resolution),
+    hasConcreteTransferableText(payload.resolution),
   );
   const hasStructuredSignal =
     (hasMeaningfulRootCause && hasMeaningfulResolution) ||

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -120,6 +120,7 @@ function hasConcreteTransferableAction(value: string) {
   if (hasImportContentArrayAction(text)) return true;
   if (hasSignatureRawBodyAction(text)) return true;
   if (hasAdvisoryLockTransactionAction(text)) return true;
+  if (hasOffsetCommitAfterProcessingAction(text)) return true;
   return concreteActionWords.some((word) => hasWord(text, word));
 }
 
@@ -228,6 +229,7 @@ function hasSpecificEvidence(value: string) {
     hasImportContentArrayEvidence(text) ||
     hasSignatureRawBodyEvidence(text) ||
     hasAdvisoryLockTransactionEvidence(text) ||
+    hasOffsetCommitAfterProcessingEvidence(text) ||
     hasDurableEngineeringEvidence(text) ||
     hasImportDedupeEvidence(text) ||
     hasContentSanitizationEvidence(text) ||
@@ -623,6 +625,52 @@ function hasAdvisoryLockTransactionFailureSignal(value: string) {
     /\b(because|so|after|before|rollback|rollbacks?|failed jobs?|surviv(?:e|ed|es)|block(?:ed)?|retries|releases?)\b/i
       .test(text);
   return hasAdvisoryLockTransactionEvidence(text) && hasLockFailure && hasCausalFlow;
+}
+
+function hasOffsetCommitAfterProcessingEvidence(value: string) {
+  const text = value.toLowerCase();
+  return /\b(kafka|consumer offsets?|offset commits?|commit(?:ted)? offsets?|partition offset|acknowledg(?:e|ed|es|ing)? messages?|unprocessed messages?)\b/i
+    .test(text) &&
+    /\b(offsets?|commit(?:ted|s)?|database transaction|transaction commits?|persist(?:ed|s|ence)?|messages?)\b/i
+      .test(text);
+}
+
+function hasOffsetCommitAfterProcessingAction(value: string) {
+  const text = value.toLowerCase();
+  const hasCommitAfterProcessingAction =
+    /\bcommit\b.+\boffsets?\b.+\b(only after|after)\b.+\b(database transaction|transaction commits?|persist(?:ed|s|ence)?)\b/i
+      .test(text) ||
+    /\bretry\b.+\b(same partition offset|partition offset|same .*offset)\b.+\b(persistence fails?|persist(?:ence)? fails?|fails?)\b/i
+      .test(text);
+  return hasOffsetCommitAfterProcessingEvidence(text) && hasCommitAfterProcessingAction;
+}
+
+function hasOffsetCommitAfterProcessingMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasEarlyCommitCrashFlow =
+    /\bcommit(?:ted)?\b.+\boffsets?\b.+\bbefore\b.+\b(database transaction|transaction commits?|persist(?:ed|s|ence)?)\b/i
+      .test(text) ||
+    /\bcrash\b.+\backnowledg(?:e|ed|es|ing)\b.+\b(unprocessed messages?|messages whose rows were never persisted)\b/i
+      .test(text) ||
+    /\backnowledg(?:e|ed|es|ing)\b.+\bmessages?\b.+\b(rows? (?:were )?never persisted|unprocessed|message loss)\b/i
+      .test(text);
+  const hasPostCommitRetryFlow =
+    /\bcommit\b.+\boffsets?\b.+\b(after|only after)\b.+\b(database transaction|transaction commits?)\b/i
+      .test(text) ||
+    /\bretry\b.+\b(same partition offset|partition offset|same .*offset)\b.+\b(persistence fails?|fails?)\b/i
+      .test(text);
+  return hasOffsetCommitAfterProcessingEvidence(text) && (hasEarlyCommitCrashFlow || hasPostCommitRetryFlow);
+}
+
+function hasOffsetCommitAfterProcessingFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasOffsetFailure =
+    /\b(message loss|acknowledg(?:e|ed|es|ing) unprocessed messages?|unprocessed messages?|rows? (?:were )?never persisted|persistence fails?|crash)\b/i
+      .test(text);
+  const hasCausalFlow =
+    /\b(because|so|before|after|crash|acknowledg(?:e|ed|es|ing)|never persisted|persistence fails?|retry|commit(?:ted)?|transaction commits?)\b/i
+      .test(text);
+  return hasOffsetCommitAfterProcessingEvidence(text) && hasOffsetFailure && hasCausalFlow;
 }
 
 function hasDurableEngineeringEvidence(value: string) {
@@ -1066,6 +1114,7 @@ function hasConcreteMechanism(value: string) {
   const hasImportContentArrayFlow = hasImportContentArrayMechanism(text);
   const hasSignatureRawBodyFlow = hasSignatureRawBodyMechanism(text);
   const hasAdvisoryLockTransactionFlow = hasAdvisoryLockTransactionMechanism(text);
+  const hasOffsetCommitAfterProcessingFlow = hasOffsetCommitAfterProcessingMechanism(text);
   const hasDurableEngineeringFlow = hasDurableEngineeringMechanism(text);
   const hasImportDedupeFlow = hasImportDedupeMechanism(text);
   const hasContentSanitizationFlow = hasContentSanitizationMechanism(text);
@@ -1098,6 +1147,7 @@ function hasConcreteMechanism(value: string) {
     hasImportContentArrayFlow ||
     hasSignatureRawBodyFlow ||
     hasAdvisoryLockTransactionFlow ||
+    hasOffsetCommitAfterProcessingFlow ||
     hasDurableEngineeringFlow ||
     hasImportDedupeFlow ||
     hasContentSanitizationFlow ||
@@ -1236,6 +1286,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     hasImportContentArrayFailureSignal(value) ||
     hasSignatureRawBodyFailureSignal(value) ||
     hasAdvisoryLockTransactionFailureSignal(value) ||
+    hasOffsetCommitAfterProcessingFailureSignal(value) ||
     hasDurableEngineeringFailureSignal(value) ||
     hasImportDedupeFailureSignal(value) ||
     hasContentSanitizationFailureSignal(value) ||
@@ -2366,7 +2417,7 @@ function isGenericReleaseValidationClaim(value: string) {
 }
 
 function isVisibleStatusSnapshotText(value: string) {
-  const hasPassStatus = /\b(build|npm test|tests?|testing|typecheck|lint|ci|verification|checks?|smoke(?: tests?)?)\b.+\bpassed\b/i
+  const hasPassStatus = /\b(build|npm test|tests?|testing|typecheck|lint|ci|verification|checks?|smoke(?: tests?)?|acceptance|e2e|scenario)\b.+\bpassed\b/i
     .test(value);
   const hasSuccessStatus =
     /\b(ci green|ci completed successfully|tests? succeeded|testing succeeded|verification succeeded|build succeeded|typecheck succeeded|lint succeeded)\b/i

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1433,8 +1433,13 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
       .test(text) &&
     /\b(migration|migrations?|not null|backfill|chatcrystal\.db|constraint)\b/i
       .test(text);
+  const hasNamedEventOrderObject =
+    /\b(jsonl|events?|event order|file-order parsing|timestamp|transcript|out-of-order writes?|user and assistant turns?|conversation (?:order|sequence))\b/i
+      .test(text) &&
+    /\b(jsonl|event order|timestamp|transcript|file-order|conversation|turns?)\b/i
+      .test(text);
   const hasEngineeringContext =
-    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?|initialization|initialized|route|mcp|json-rpc|stdio|stdout|stderr|framing|transport|logs?|diagnostics?|tags?|joins?|deletion|cleanup|filter chips?|webui|websocket|listeners?|useeffect|remounts?|unmount|child_process|child process|daemon|pid|spawn|exit code|serve|status|dead server|migration|not null|default|backfill|column|startup|vite|proxy|fastify|rewrite|registered route|spa fallback|fallback handler|index\.html|conversation_id|queue jobs?|enqueue|enqueueing|summarize|activerequestid|setresults)\b/i
+    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|event order|file-order parsing|out-of-order|timestamp|transcript|conversation sequence|user and assistant turns?|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?|initialization|initialized|route|mcp|json-rpc|stdio|stdout|stderr|framing|transport|logs?|diagnostics?|tags?|joins?|deletion|cleanup|filter chips?|webui|websocket|listeners?|useeffect|remounts?|unmount|child_process|child process|daemon|pid|spawn|exit code|serve|status|dead server|migration|not null|default|backfill|column|startup|vite|proxy|fastify|rewrite|registered route|spa fallback|fallback handler|index\.html|conversation_id|queue jobs?|enqueue|enqueueing|summarize|activerequestid|setresults)\b/i
       .test(text) ||
     /(?:语义搜索|响应|查询结果|旧响应|旧的.*响应|覆盖.*结果)/i.test(text);
   return (
@@ -1449,7 +1454,8 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
     hasNamedProxyRoutingObject ||
     hasNamedSpaFallbackObject ||
     hasNamedQueueDedupeObject ||
-    hasNamedMigrationObject
+    hasNamedMigrationObject ||
+    hasNamedEventOrderObject
   ) && hasEngineeringContext;
 }
 
@@ -1694,8 +1700,17 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       .test(text) ||
     /\badd\b.+\bcolumn\b.+\bnullable\b.+\bbackfill\b.+\benforce\b.+\bnot null\b/i
       .test(text);
+  const hasEventOrderFlow =
+    /\b(jsonl|events?|event order|file-order parsing|timestamp|transcript|turns?|conversation (?:order|sequence))\b.+\b(out[- ]of[- ]order|file-order|invert|normaliz(?:e|es|ed|ing|ation)|timestamp|real conversation sequence|preserv(?:e|es|ed|ing) conversation order)\b/i
+      .test(text) ||
+    /\bnormaliz(?:e|es|ed|ing|ation)\b.+\bevent order\b.+\btimestamp\b.+\b(before|transcript|sequence)\b/i
+      .test(text) ||
+    /\bfile-order parsing\b.+\binvert\b.+\buser\b.+\bassistant turns?\b/i
+      .test(text) ||
+    /\bout-of-order writes?\b.+\binvert\b.+\buser\b.+\bassistant turns?\b/i
+      .test(text);
   const hasCausalFlow =
-    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gat(?:e|es|ed|ing)|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve|left|no longer existed|deleting notes?|note deletion|cleanup|prune|filter|duplicate|deduplicate|dedupe|enqueued|enqueue|pending job|appended twice|remounts?|unmount|spawn handshake|exit event|exit code|dead server|nonzero|non-zero|backfill|not null|default|constraint|violat(?:e|ed|es|ing)|rewrote|rewrite|proxy|preserv(?:e|es|ed|ing)|registered route|fell through|spa fallback|fallback handler|index\.html)\b/i
+    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gat(?:e|es|ed|ing)|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve|left|no longer existed|deleting notes?|note deletion|cleanup|prune|filter|duplicate|deduplicate|dedupe|enqueued|enqueue|pending job|appended twice|remounts?|unmount|spawn handshake|exit event|exit code|dead server|nonzero|non-zero|backfill|not null|default|constraint|violat(?:e|ed|es|ing)|rewrote|rewrite|proxy|preserv(?:e|es|ed|ing)|registered route|fell through|spa fallback|fallback handler|index\.html|out-of-order|file-order|invert|timestamp|conversation sequence)\b/i
       .test(text) ||
     /(?:因为|所以|导致|避免|防止|覆盖|校验|没有|未)/i.test(text);
   return hasStrictStructuralEngineeringEvidence(text) &&
@@ -1714,20 +1729,21 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       hasProcessLifecycleFlow ||
       hasProxyPathRewriteFlow ||
       hasSpaFallbackRouteFlow ||
-      hasMigrationConstraintFlow
+      hasMigrationConstraintFlow ||
+      hasEventOrderFlow
     );
 }
 
 function hasStrictStructuralEngineeringFailureSignal(value: string) {
   const text = value.toLowerCase();
   const hasNamedConsequence =
-    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|duplicate conversation jobs?|duplicate messages?|duplicate websocket messages?|appended twice|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|orphan note_tags rows?|orphan tags?|unused tags?|count 0|joins? whose note_id no longer existed|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream)|false serve success|dead server|looked like a running server|running server|nonzero exit codes?|non-zero exit codes?|exit code\s*\d+|migration (?:does not )?fail(?:s|ed)?|migration failures?|existing row failures?|constraint violation|violated the constraint|fell through to the spa fallback|clients? received index\.html instead of json|return json instead of index\.html|returns? html for api json)\b/i
+    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|duplicate conversation jobs?|duplicate messages?|duplicate websocket messages?|appended twice|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|invert user and assistant turns?|inverted user and assistant turns?|out-of-order writes?|file-order parsing can invert|orphan note_tags rows?|orphan tags?|unused tags?|count 0|joins? whose note_id no longer existed|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream)|false serve success|dead server|looked like a running server|running server|nonzero exit codes?|non-zero exit codes?|exit code\s*\d+|migration (?:does not )?fail(?:s|ed)?|migration failures?|existing row failures?|constraint violation|violated the constraint|fell through to the spa fallback|clients? received index\.html instead of json|return json instead of index\.html|returns? html for api json)\b/i
       .test(text) ||
     hasGeneralUniqueConstraintFailureSignal(text) ||
     /(?:旧(?:的)?\s*)?(?:\/api\/search\s*)?响应.{0,20}覆盖.{0,12}(?:当前查询结果|新结果)/i
       .test(text);
   const hasCausalFlow =
-    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|left|no longer existed|deleting notes?|note deletion|cleanup|filter|prune|remounts?|unmount|duplicate|deduplicate|dedupe|enqueued|enqueue|pending job|appended twice|spawn handshake|exit event|exit code|nonzero|non-zero|dead server|backfill|not null|default|constraint|violat(?:e|ed|es|ing)|migration|fell through|spa fallback|fallback handler|index\.html)\b/i
+    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|left|no longer existed|deleting notes?|note deletion|cleanup|filter|prune|remounts?|unmount|duplicate|deduplicate|dedupe|enqueued|enqueue|pending job|appended twice|spawn handshake|exit event|exit code|nonzero|non-zero|dead server|backfill|not null|default|constraint|violat(?:e|ed|es|ing)|migration|fell through|spa fallback|fallback handler|index\.html|out-of-order|file-order|invert|timestamp|conversation sequence)\b/i
       .test(text) ||
     /(?:因为|所以|导致|避免|防止|覆盖|校验|没有|未)/i.test(text);
   return hasStrictStructuralEngineeringEvidence(text) && hasNamedConsequence && hasCausalFlow;
@@ -2201,6 +2217,7 @@ function isGenericVisibleBoilerplateClaim(value: string) {
 function isGenericReleaseValidationClaim(value: string) {
   const text = value.toLowerCase();
   return (
+    /\bvalidat(?:e|ing|ion)\b.+(?:\/api\/[\w/-]+|api requests?|requests?)\b.+\bbefore release\b/i.test(text) ||
     /\bvalidat(?:e|ing|ion)\b.+\b(api requests?|requests?)\b.+\bbefore release\b/i.test(text) ||
     /\b(api requests?|requests?)\b.+\bvalidat(?:e|ing|ion)\b.+\bbefore release\b/i.test(text)
   );
@@ -2308,6 +2325,9 @@ function isLowQualityVisibleConclusion(value: string) {
     isVagueGenericFixClaim(body) ||
     isGenericVisibleBoilerplateClaim(value) ||
     isGenericVisibleBoilerplateClaim(body);
+  if (label === 'observation' && isBareObservationStatusConclusion(body)) {
+    return true;
+  }
   if (label === 'root cause') {
     return hasLowQualityBody || !hasVisibleRootCauseConclusionQuality(body);
   }
@@ -2315,6 +2335,18 @@ function isLowQualityVisibleConclusion(value: string) {
     return hasLowQualityBody || !hasVisibleResolutionConclusionQuality(body);
   }
   return hasLowQualityBody || (shouldApplyGenericLessonGate && !hasConcreteConclusionValue(body));
+}
+
+function isBareObservationStatusConclusion(value: string) {
+  const text = value.trim();
+  const hasBareStatus =
+    /\b(?:returned|returns|responded|responds|hit|hits|threw|throws?|failed|fails?)\b.+\b(?:http\s*[45]\d\d|[45]\d\d|econrefused|typeerror|error)\b/i
+      .test(text) ||
+    /\b(?:http\s*[45]\d\d|econrefused|typeerror)\b\.?$/i.test(text);
+  const hasMechanismOrAction =
+    /\b(because|so|before|after|without|instead of|when|while|by|ensure|gate|register|wait|normalize|deduplicate|dedupe|bind|add|remove|wrap|use)\b/i
+      .test(text);
+  return hasBareStatus && !hasMechanismOrAction;
 }
 
 function hasConcreteConclusionValue(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1239,11 +1239,19 @@ function hasSqlParameterizationMechanism(value: string) {
     /\binterpolat(?:e|ed|ing)\b.+\b(tag text|tag strings?|tag names?|strings?|text)\b.+\b(where clauses?|sql syntax|queries?|lookups?|quotes?)\b/i
       .test(text) ||
     /\b(where clauses?)\b.+\binterpolat(?:e|ed|ing)\b.+\b(tag text|tag strings?|tag names?)\b/i
+      .test(text) ||
+    /\binterpolat(?:e|ed|ing)\b.+\buser-controlled tag names?\b.+\b(?:sql\s+)?where clauses?\b/i
+      .test(text) ||
+    /\bquotes?\b.+\btag\b.+\b(?:alter(?:ed|s|ing)|chang(?:ed|es|ing))\b.+\bsql syntax\b/i
       .test(text);
   const hasParameterizationFix =
     /\bbind\b.+\btag names?\b.+\b(sql\.js\s+)?parameters?\b.+\bquotes?\b.+\bdata\b.+\binstead of sql syntax\b/i
       .test(text) ||
     /\bquotes?\b.+\bstay\b.+\bdata\b.+\binstead of sql syntax\b/i
+      .test(text) ||
+    /\bquotes?\b.+\bstay\b.+\bdata\b.+\binstead of\b.+\balter(?:ing)?\b.+\bwhere clause syntax\b/i
+      .test(text) ||
+    /\bbind\b.+\btag names?\b.+\bsql parameters?\b.+\binstead of\b.+\binterpolat(?:e|ing)\b.+\bwhere clauses?\b/i
       .test(text);
   const hasCausalFlow =
     /\b(because|so|before|prevent|prevents|broke|breakage|instead of|interpolat(?:e|ed|ing)|bind|where clauses?|sql syntax)\b/i
@@ -1262,6 +1270,12 @@ function hasSqlParameterizationFailureSignal(value: string) {
     /\b(broke|breaks?|breakage|broken)\b.+\b(sql lookup queries?|lookup queries?|queries?|lookups?)\b/i
       .test(text) ||
     /\bsql syntax\b.+\b(quotes?|tag text|tag strings?|tag names?)\b/i
+      .test(text) ||
+    /\bsql syntax injection\b/i
+      .test(text) ||
+    /\bquotes?\b.+\btag\b.+\b(?:alter(?:ed|s|ing)|chang(?:ed|es|ing))\b.+\bsql syntax\b/i
+      .test(text) ||
+    /\balter(?:ed|s|ing)\b.+\bwhere clause syntax\b/i
       .test(text);
   const hasCausalFlow =
     /\b(because|so|before|prevent|prevents|broke|breakage|instead of|interpolat(?:e|ed|ing)|where clauses?|sql syntax)\b/i
@@ -2042,7 +2056,7 @@ function isGenericReleaseValidationClaim(value: string) {
 }
 
 function isVisibleStatusSnapshotText(value: string) {
-  const hasPassStatus = /\b(build|npm test|tests?|testing|typecheck|lint|ci)\b.+\bpassed\b/i
+  const hasPassStatus = /\b(build|npm test|tests?|testing|typecheck|lint|ci|verification)\b.+\bpassed\b/i
     .test(value);
   const hasSuccessStatus =
     /\b(ci green|ci completed successfully|tests? succeeded|testing succeeded|verification succeeded|build succeeded|typecheck succeeded|lint succeeded)\b/i

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1220,7 +1220,16 @@ function hasSqlParameterizationEvidence(value: string) {
   const hasInterpolationBoundary =
     /\b(quotes?|quote breakage|sql syntax|executable sql|where clauses?|interpolat(?:e|ed|ing)|bind(?:ing)?|parameteriz(?:e|ed|ing)|parameteris(?:e|ed|ing))\b/i
       .test(text);
-  return hasQueryContext && hasParameterOrTagContext && hasInterpolationBoundary;
+  const hasChineseQueryContext =
+    /(?:sql|sql\.js|where\s*子句|查询)/i.test(text);
+  const hasChineseParameterOrTagContext =
+    /(?:参数化查询|sql\.js\s*参数|参数|tag\s*值|tag\s*文本|标签文本|用户控制的标签文本|标签)/i
+      .test(text);
+  const hasChineseInterpolationBoundary =
+    /(?:引号|sql\s*语法|语法注入|可执行\s*sql|where\s*子句|插入|绑定|参数化)/i
+      .test(text);
+  return (hasQueryContext && hasParameterOrTagContext && hasInterpolationBoundary) ||
+    (hasChineseQueryContext && hasChineseParameterOrTagContext && hasChineseInterpolationBoundary);
 }
 
 function hasSqlParameterizationAction(value: string) {
@@ -1232,6 +1241,10 @@ function hasSqlParameterizationAction(value: string) {
       /\b(bind|binding)\b.+\b(tag values?|tag filters?|tag payload|tag text)\b.+\b(sql\.js\s+)?parameters?\b/i
         .test(text) ||
       /\b(use)\b.+\b(parameterized queries?|parameterised queries?|sql parameters?)\b/i
+        .test(text) ||
+      /(?:绑定|使用).{0,40}(?:sql\.js\s*)?参数/i
+        .test(text) ||
+      /参数化查询.{0,24}绑定.{0,24}(?:tag|标签)/i
         .test(text)
     );
 }
@@ -1250,6 +1263,14 @@ function hasSqlParameterizationMechanism(value: string) {
     /\binterpolat(?:e|ed|ing)\b.+\btag text\b.+\bcrafted tag payloads?\b.+\bchang(?:e|ed|es|ing)\b.+\b(?:sql\s+)?where clause syntax\b/i
       .test(text) ||
     /\bquotes?\b.+\btag\b.+\b(?:alter(?:ed|s|ing)|chang(?:ed|es|ing))\b.+\bsql syntax\b/i
+      .test(text) ||
+    /(?:标签查询|tag\s*文本|标签文本|用户控制的.{0,12}标签).{0,40}(?:插入|插值|拼接).{0,30}where\s*子句/i
+      .test(text) ||
+    /(?:引号|带引号的标签).{0,20}(?:改变|造成).{0,20}sql\s*语法/i
+      .test(text) ||
+    /(?:引号|带引号的标签).{0,20}(?:改变|造成).{0,20}where\s*子句语法/i
+      .test(text) ||
+    /sql\s*语法注入/i
       .test(text);
   const hasParameterizationFix =
     /\bbind\b.+\btag names?\b.+\b(sql\.js\s+)?parameters?\b.+\bquotes?\b.+\bdata\b.+\binstead of sql syntax\b/i
@@ -1265,10 +1286,15 @@ function hasSqlParameterizationMechanism(value: string) {
     /\bquotes?\b.+\bstay\b.+\bdata\b.+\binstead of\b.+\balter(?:ing)?\b.+\bwhere clause syntax\b/i
       .test(text) ||
     /\bbind\b.+\btag names?\b.+\bsql parameters?\b.+\binstead of\b.+\binterpolat(?:e|ing)\b.+\bwhere clauses?\b/i
+      .test(text) ||
+    /(?:绑定|参数化查询).{0,40}(?:tag|标签|用户控制的标签文本).{0,40}(?:数据|可执行\s*sql|where\s*子句|sql\s*语法)/i
+      .test(text) ||
+    /(?:tag\s*文本|标签文本|用户控制的标签文本).{0,40}绑定.{0,30}(?:sql\.js\s*)?参数/i
       .test(text);
   const hasCausalFlow =
     /\b(because|so|before|prevent|prevents|broke|breakage|instead of|interpolat(?:e|ed|ing)|bind|where clauses?|sql syntax)\b/i
-      .test(text);
+      .test(text) ||
+    /(?:避免|防止|改变|插入|绑定|而不是|作为数据|造成)/i.test(text);
   return hasSqlParameterizationEvidence(text) &&
     hasCausalFlow &&
     (hasInterpolationFailure || hasParameterizationFix);
@@ -1291,10 +1317,13 @@ function hasSqlParameterizationFailureSignal(value: string) {
     /\bcrafted tag payloads?\b.+\bchang(?:e|ed|es|ing)\b.+\b(?:sql\s+)?where clause syntax\b/i
       .test(text) ||
     /\balter(?:ed|s|ing)\b.+\bwhere clause syntax\b/i
+      .test(text) ||
+    /(?:sql\s*语法注入|引号.{0,20}(?:改变|造成).{0,20}(?:sql\s*语法|where\s*子句语法)|可执行\s*sql)/i
       .test(text);
   const hasCausalFlow =
     /\b(because|so|before|prevent|prevents|broke|breakage|instead of|interpolat(?:e|ed|ing)|where clauses?|sql syntax)\b/i
-      .test(text);
+      .test(text) ||
+    /(?:避免|防止|改变|插入|造成|而不是|作为数据)/i.test(text);
   return hasSqlParameterizationEvidence(text) && hasQueryBreakage && hasCausalFlow;
 }
 
@@ -1930,10 +1959,16 @@ function isVisibleWorkLogClaim(value: string) {
 
 function isExplicitEnglishStatusShell(value: string) {
   return hasTechnicalPrefixStatusShell(value) ||
-    /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task|progress|verification|diagnostics?|(?:smoke\s+)?test)\s+(?:record|report|note|summary|update|log|entry|check)|(?:implementation|task|fix|execution|run|work|status)\s+results?|run\s+results?|work\s*log(?:\s+entry)?|worklog(?:\s+entry)?|status|record|update|implementation|result|outcome|progress|verification|check|diagnostics?|(?:smoke\s+)?test|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
+    /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task|progress|verification|validation|regression|qa|diagnostics?|(?:smoke\s+)?test)\s+(?:record|report|note|summary|update|log|entry|check|result|results?|confirmed)|(?:implementation|task|fix|execution|run|work|status)\s+results?|run\s+results?|work\s*log(?:\s+entry)?|worklog(?:\s+entry)?|status|record|update|implementation|result|outcome|progress|verification|validation|regression|qa|check|diagnostics?|(?:smoke\s+)?test|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
       .test(value.trim()) ||
+    isValidationResultStatusShell(value) ||
     isCurrentRunImplementationShell(value) ||
     isCurrentRunStatusObservationClaim(value);
+}
+
+function isValidationResultStatusShell(value: string) {
+  return /^\s*(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,2}\s+)?(?:validation|regression|qa)\s+(?:confirmed|passed|succeeded|completed)\b/i
+    .test(value.trim());
 }
 
 function hasTechnicalPrefixStatusShell(value: string) {
@@ -1943,7 +1978,7 @@ function hasTechnicalPrefixStatusShell(value: string) {
   const englishDescriptorPrefix = String.raw`(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,3})`;
   const chineseDescriptorPrefix = String.raw`(?:[\u3400-\u9fff]{2,16})`;
   const technicalPrefix = String.raw`(?:\/api\/[\w/-]+|[a-z0-9]+_[a-z0-9_]+|[a-z][a-z0-9_]*\.[a-z_][a-z0-9_]*|activerequestid|setresults|data_dir|node_env|child_process|jsonl|sqlite|sql\.js|websocket|mcp|json-rpc|${descriptorWord}(?:\s+${descriptorWord}){0,2}|${chineseDescriptorWord}(?:\s+${chineseDescriptorWord}){0,2}|${englishDescriptorPrefix}|${chineseDescriptorPrefix})`;
-  const englishShell = String.raw`(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task|progress|verification|diagnostics?|(?:smoke\s+)?test)\s+(?:record|report|note|summary|update|log|entry|check)|(?:status|record|update|implementation|result|outcome|progress|verification|check|diagnostics?|(?:smoke\s+)?test|completion(?:\s+(?:note|record))?|completed|done))`;
+  const englishShell = String.raw`(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task|progress|verification|validation|regression|qa|diagnostics?|(?:smoke\s+)?test)\s+(?:record|report|note|summary|update|log|entry|check|result|results?|confirmed)|(?:status|record|update|implementation|result|outcome|progress|verification|validation|regression|qa|check|diagnostics?|(?:smoke\s+)?test|completion(?:\s+(?:note|record))?|completed|done))`;
   const chineseShell = String.raw`(?:状态记录|记录状态|状态检查|工作日志|日志记录|工作记录|执行记录|完成记录|完成检查|状态更新|运行结果|执行结果|结果记录|结果报告|结果检查|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|测试记录|状态|结果|进度|验证|测试|诊断|完成|已完成|完成说明)`;
   return new RegExp(`^\\s*${technicalPrefix}\\s+${englishShell}\\s*(?:[:\\-\\u2013\\u2014])`, 'i')
     .test(text) ||

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -249,7 +249,10 @@ function isFirstPersonDiaryClaim(value: string) {
     'fixed',
     'found',
     'implemented',
+    'reviewed',
+    'resolved',
     'switched',
+    'tested',
     'updated',
     'verified',
   ].join('|');
@@ -489,7 +492,7 @@ function hasVisibleSummaryQuality(summary: string) {
 }
 
 function isVisibleWorkLogClaim(value: string) {
-  return /^(added|changed|checked|confirmed|diagnosed|discovered|fixed|found|implemented|noted|observed|switched|updated|verified)\b/i
+  return /^(added|changed|checked|confirmed|diagnosed|discovered|fixed|found|implemented|noted|observed|reviewed|resolved|switched|tested|testing|updated|verified)\b/i
     .test(value.trim());
 }
 
@@ -526,9 +529,10 @@ function isGenericVisibleBoilerplateClaim(value: string) {
 }
 
 function isVisibleStatusSnapshotText(value: string) {
-  const hasStatusVerb = /\b(checked|noted|observed|verified|verification|current|status)\b/i.test(value);
+  const hasStatusVerb = /\b(checked|noted|observed|reviewed|resolved|tested|testing passed|verified|verification|current|status)\b/i
+    .test(value);
   const hasStatusObject =
-    /\b(node_env|env|environment|production|local|package version|version|generated dist output|dist output)\b/i
+    /\b(node_env|env|environment|production|local|testing|server readiness|fastify readiness|api requests?|package version|version|generated dist output|dist output)\b/i
       .test(value);
   return hasStatusVerb && hasStatusObject && !hasStrongReusableMechanism(value);
 }

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -55,6 +55,7 @@ function hasConcreteTransferableAction(value: string) {
   if (hasImportDedupeAction(text)) return true;
   if (hasPersistenceSerializationAction(text)) return true;
   if (hasElectronResourceAction(text)) return true;
+  if (hasCrossPlatformPathAction(text)) return true;
   const concreteActionWords = [
     'add',
     'block',
@@ -207,6 +208,7 @@ function hasSpecificEvidence(value: string) {
     hasPersistenceSnapshotEvidence(text) ||
     hasIndexConsistencyEvidence(text) ||
     hasElectronResourceEvidence(text) ||
+    hasCrossPlatformPathEvidence(text) ||
     hasHttpFailureSignal(text) ||
     /\b(api requests?|fastify readiness|server readiness|request setup|package metadata|package version|dist output|generated dist output|data directory|electron server|server entrypoint|client calls?)\b/i
       .test(text)
@@ -484,6 +486,45 @@ function hasElectronResourceFailureSignal(value: string) {
   return hasElectronResourceEvidence(text) && hasResourceFailure && hasCausalFlow;
 }
 
+function hasCrossPlatformPathEvidence(value: string) {
+  const text = value.toLowerCase();
+  return /\b(path\.win32|resolvedatadirfortest|data_dir|posix|ubuntu runners?|windows data_dir|windows fixture|windows paths?|c:\/users|c:\\users|repository path|repo path)\b/i
+    .test(text);
+}
+
+function hasCrossPlatformPathAction(value: string) {
+  const text = value.toLowerCase();
+  const hasPathAction = /\b(normalize|compare|comparing|resolve|treat|treated)\b/i.test(text);
+  const hasPathTarget =
+    /\b(path\.win32|resolvedatadirfortest|data_dir|fixture expectations?|windows paths?|posix runners?|path parsing)\b/i
+      .test(text);
+  return hasCrossPlatformPathEvidence(text) && hasPathAction && hasPathTarget;
+}
+
+function hasCrossPlatformPathMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasNormalizationFlow =
+    /\b(normalize|compare|comparing|resolve)\b.+\b(path\.win32|windows data_dir|windows fixture|c:\/users|posix runners?|resolvedatadirfortest)\b/i
+      .test(text) ||
+    /\b(path\.win32|windows data_dir|windows fixture|c:\/users|posix runners?|resolvedatadirfortest)\b.+\b(normalize|compare|comparing|resolve)\b/i
+      .test(text);
+  const hasRelativePathFlow =
+    /\b(posix|ubuntu runners?|node posix path parsing|path parsing)\b.+\b(prepend(?:ed|s)?|relative|treated)\b/i
+      .test(text) ||
+    /\b(windows data_dir|windows fixture|c:\/users|c:\\users)\b.+\b(relative|prepended|repository path|repo path)\b/i
+      .test(text);
+  return hasCrossPlatformPathEvidence(text) && (hasNormalizationFlow || hasRelativePathFlow);
+}
+
+function hasCrossPlatformPathFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasPathFailure =
+    /\b(prepend(?:ed|s)? the (?:repository|repo) path|treated .+ as relative|as relative|relative path|wrong path|wrong directory)\b/i
+      .test(text);
+  const hasCausalFlow = /\b(because|when|so|before|treated|prepended)\b/i.test(text);
+  return hasCrossPlatformPathEvidence(text) && hasPathFailure && hasCausalFlow;
+}
+
 function hasConcreteMechanism(value: string) {
   const text = value.toLowerCase();
   const hasGenericReleaseValidation = isGenericReleaseValidationClaim(text);
@@ -534,6 +575,7 @@ function hasConcreteMechanism(value: string) {
   const hasPersistenceSerializationFlow = hasPersistenceSerializationMechanism(text);
   const hasIndexConsistencyFlow = hasIndexConsistencyMechanism(text);
   const hasElectronResourceFlow = hasElectronResourceMechanism(text);
+  const hasCrossPlatformPathFlow = hasCrossPlatformPathMechanism(text);
   return (
     hasTimingOrder ||
     hasRaceReadiness ||
@@ -551,7 +593,8 @@ function hasConcreteMechanism(value: string) {
     hasContentSanitizationFlow ||
     hasPersistenceSerializationFlow ||
     hasIndexConsistencyFlow ||
-    hasElectronResourceFlow
+    hasElectronResourceFlow ||
+    hasCrossPlatformPathFlow
   );
 }
 
@@ -575,6 +618,7 @@ function hasConcreteTransferableText(value: string) {
 }
 
 function isFirstPersonDiaryClaim(value: string) {
+  if (hasChineseFirstPersonDiaryClaim(value)) return true;
   const diaryVerbs = [
     'added',
     'changed',
@@ -605,6 +649,11 @@ function isFirstPersonDiaryClaim(value: string) {
     .test(value);
 }
 
+function hasChineseFirstPersonDiaryClaim(value: string) {
+  return /(?:我|我们)(?:已经|已)?(?:添加|修复|设置|配置|注册|等待|发现|验证|检查|确认|诊断|切换|更新|实现|改动|修改|处理|解决)/i
+    .test(value);
+}
+
 function hasPackageItemSignal(value: string) {
   const text = value.toLowerCase();
   if (/\b(current|local|status checks?|checked)\b/i.test(text)) return false;
@@ -623,6 +672,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     hasPersistenceSnapshotFailureSignal(value) ||
     hasIndexConsistencyFailureSignal(value) ||
     hasElectronResourceFailureSignal(value) ||
+    hasCrossPlatformPathFailureSignal(value) ||
     hasDefaultDataDirectoryConsequence(value) ||
     hasHttpFailureSignal(value)
   );
@@ -1127,10 +1177,9 @@ function hasUsefulCodeSnippet(
 
   const combined = `${language}\n${code}\n${description}`;
   const hasConcreteCodeShape =
-    /[{}();=<>]/.test(code) ||
+    /[{}()[\];:=<>]/.test(code) ||
     /\b(pragma|select|insert|update|delete|create table|json\.parse|z\.object|z\.array|const|let|function|return|import|export|class)\b/i
-      .test(code) ||
-    /\/api\/[\w/-]+|\b[a-z0-9]+_[a-z0-9_]+\b/i.test(code);
+      .test(code);
   const hasConcreteEvidence =
     /\b(pragma\s+foreign_keys|foreign_keys|json\.parse|z\.object|z\.array|response_item\.content|data_dir|node_env|source_run_key|note_tags)\b/i
       .test(combined) ||
@@ -1142,8 +1191,7 @@ function hasUsefulCodeSnippet(
     hasImportDedupeEvidence(combined) ||
     hasDurableEngineeringEvidence(combined) ||
     hasSpecificEvidence(combined);
-  const isPlainText = /^(text|txt|plain|plaintext)$/.test(language);
-  return hasConcreteEvidence && (!isPlainText || hasConcreteCodeShape);
+  return hasConcreteEvidence && hasConcreteCodeShape;
 }
 
 function hasLowQualityTags(note: MaterializedTaskMemoryNote) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1719,7 +1719,7 @@ function isVisibleWorkLogClaim(value: string) {
 }
 
 function isExplicitEnglishStatusShell(value: string) {
-  return /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task)\s+(?:record|report|note|summary|update|log)|run\s+results?|work\s*log|worklog|status|record|update|implementation|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
+  return /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task)\s+(?:record|report|note|summary|update|log)|(?:implementation|task|fix|execution|run|work|status)\s+results?|run\s+results?|work\s*log|worklog|status|record|update|implementation|result|outcome|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
     .test(value.trim()) ||
     isCurrentRunImplementationShell(value);
 }
@@ -1767,7 +1767,7 @@ function hasChineseVisibleMechanism(value: string) {
 function isChineseVisibleStatusShell(value: string) {
   if (!/[\u3400-\u9fff]/.test(value)) return false;
   const hasStatusRecordShell =
-    /^\s*(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|运行结果|执行结果|结果记录|结果报告|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|完成|已完成|完成说明)\s*(?:[：:\-\u2013\u2014]|$)/i
+    /^\s*(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|运行结果|执行结果|结果记录|结果报告|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|结果|完成|已完成|完成说明)\s*(?:[：:\-\u2013\u2014]|$)/i
       .test(value) ||
     /(?:^|[\s：:])(?:状态记录|记录状态|工作日志|日志记录|工作记录)(?:[\s：:]|$)|^(?:状态|记录)\s*[：:]/i
       .test(value) ||

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -114,6 +114,7 @@ function hasConcreteTransferableAction(value: string) {
   if (hasFrontendCacheInvalidationAction(text)) return true;
   if (hasSqliteWalSidecarAction(text)) return true;
   if (hasProviderBaseUrlAction(text)) return true;
+  if (hasEmbeddingModelConfigAction(text)) return true;
   if (hasImportContentArrayAction(text)) return true;
   return concreteActionWords.some((word) => hasWord(text, word));
 }
@@ -218,6 +219,7 @@ function hasSpecificEvidence(value: string) {
     hasSchemaBoundaryEvidence(text) ||
     hasJsonParsingEvidence(text) ||
     hasProviderBaseUrlEvidence(text) ||
+    hasEmbeddingModelConfigEvidence(text) ||
     hasImportContentArrayEvidence(text) ||
     hasDurableEngineeringEvidence(text) ||
     hasImportDedupeEvidence(text) ||
@@ -381,6 +383,57 @@ function hasProviderBaseUrlFailureSignal(value: string) {
     hasHttpNotFound &&
     hasWrongEndpointFlow &&
     hasCausalFlow;
+}
+
+function hasEmbeddingModelConfigEvidence(value: string) {
+  const text = value.toLowerCase();
+  const hasConcreteConfig =
+    /\bembedding\.(?:provider|model)\b|\/v1\/embeddings\b|\btext-embedding-[\w-]+\b/i
+      .test(text);
+  const hasSemanticEmbeddingBoundary =
+    /\bsemantic search\b/i.test(text) &&
+    /\b(embedding model|embeddings? endpoint|chat llm|llm|\/v1\/embeddings)\b/i
+      .test(text);
+  return hasConcreteConfig || hasSemanticEmbeddingBoundary;
+}
+
+function hasEmbeddingModelConfigAction(value: string) {
+  const text = value.toLowerCase();
+  const hasAction = /\b(configure|configured|set|separate|use)\b/i.test(text);
+  const hasTarget =
+    /\bembedding\.(?:provider|model)\b|\/v1\/embeddings\b|\btext-embedding-[\w-]+\b|\breal embedding model\b/i
+      .test(text);
+  return hasEmbeddingModelConfigEvidence(text) && hasAction && hasTarget;
+}
+
+function hasEmbeddingModelConfigMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasCapabilityBoundary =
+    /\b(embedding model|embedding\.(?:provider|model)|semantic search)\b.+\b(supports?|calls?|expose[sd]?|endpoint|\/v1\/embeddings)\b/i
+      .test(text) ||
+    /\b(chat llm|llm)\b.+\b(did not expose|does not expose|lacked|missing|without|reused)\b.+\/v1\/embeddings\b/i
+      .test(text) ||
+    /\/v1\/embeddings\b.+\b(supports?|endpoint|embedding model|semantic search)\b/i
+      .test(text);
+  const hasSeparatedModelFlow =
+    /\b(configure|set)\b.+\bembedding\.(?:provider|model)\b.+\b(separately|real embedding model|text-embedding-[\w-]+|semantic search)\b/i
+      .test(text) ||
+    /\bembedding model\b.+\b(reused|reuse)\b.+\b(chat llm|llm)\b/i
+      .test(text) ||
+    /\bmodel mismatch\b.+\b(semantic search|embedding model|http\s*500|500)\b/i
+      .test(text);
+  return hasEmbeddingModelConfigEvidence(text) && (hasCapabilityBoundary || hasSeparatedModelFlow);
+}
+
+function hasEmbeddingModelConfigFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasNamedFailure =
+    /\b(http\s*500|returned\s+500|semantic search\s+500|model mismatch|did not expose|does not expose|missing \/v1\/embeddings|lacked \/v1\/embeddings|without \/v1\/embeddings)\b/i
+      .test(text);
+  const hasCausalFlow =
+    /\b(because|so|which|caused|returned|reused|missing|did not expose|does not expose|without)\b/i
+      .test(text);
+  return hasEmbeddingModelConfigEvidence(text) && hasNamedFailure && hasCausalFlow;
 }
 
 function hasImportContentArrayEvidence(value: string) {
@@ -828,6 +881,7 @@ function hasConcreteMechanism(value: string) {
   const hasSchemaBoundaryFlow = hasSchemaBoundaryMechanism(text);
   const hasJsonParsingFlow = hasJsonParsingMechanism(text);
   const hasProviderBaseUrlFlow = hasProviderBaseUrlMechanism(text);
+  const hasEmbeddingModelConfigFlow = hasEmbeddingModelConfigMechanism(text);
   const hasImportContentArrayFlow = hasImportContentArrayMechanism(text);
   const hasDurableEngineeringFlow = hasDurableEngineeringMechanism(text);
   const hasImportDedupeFlow = hasImportDedupeMechanism(text);
@@ -855,6 +909,7 @@ function hasConcreteMechanism(value: string) {
     hasSchemaBoundaryFlow ||
     hasJsonParsingFlow ||
     hasProviderBaseUrlFlow ||
+    hasEmbeddingModelConfigFlow ||
     hasImportContentArrayFlow ||
     hasDurableEngineeringFlow ||
     hasImportDedupeFlow ||
@@ -973,6 +1028,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     hasSchemaBoundaryFailureSignal(value) ||
     hasJsonParsingFailureSignal(value) ||
     hasProviderBaseUrlFailureSignal(value) ||
+    hasEmbeddingModelConfigFailureSignal(value) ||
     hasImportContentArrayFailureSignal(value) ||
     hasDurableEngineeringFailureSignal(value) ||
     hasImportDedupeFailureSignal(value) ||
@@ -1396,6 +1452,7 @@ function hasConcreteHttpRootCauseSignal(value: string) {
   return hasConcreteRootCauseMechanism(value) ||
     hasRateLimitRetryRootCauseSignal(value) ||
     hasProviderBaseUrlFailureSignal(value) ||
+    hasEmbeddingModelConfigFailureSignal(value) ||
     hasSchemaBoundaryFailureSignal(value) ||
     (
       hasStrictStructuralEngineeringMechanism(value) &&
@@ -1534,7 +1591,7 @@ function isVisibleWorkLogClaim(value: string) {
 }
 
 function isExplicitEnglishStatusShell(value: string) {
-  return /^\s*(?:work\s*log|worklog|status\s+record|status\s+update|status|record|execution\s+record|completion\s+record|fix\s+record|this\s+fix|this\s+run|run\s+log)\s*(?:[:\-\u2013\u2014])/i
+  return /^\s*(?:work\s*log|worklog|status\s+record|status\s+update|status|record|execution\s+record|completion(?:\s+(?:note|record))?|completed|done|fix\s+record|this\s+fix|this\s+run|run\s+log)\s*(?:[:\-\u2013\u2014])/i
     .test(value.trim());
 }
 
@@ -1571,7 +1628,7 @@ function hasChineseVisibleMechanism(value: string) {
 function isChineseVisibleStatusShell(value: string) {
   if (!/[\u3400-\u9fff]/.test(value)) return false;
   const hasStatusRecordShell =
-    /^\s*(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|本次修复|本次执行|修复记录)\s*(?:[：:\-\u2013\u2014]|$)/i
+    /^\s*(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|本次修复|本次执行|修复记录|完成|已完成|完成说明)\s*(?:[：:\-\u2013\u2014]|$)/i
       .test(value) ||
     /(?:^|[\s：:])(?:状态记录|记录状态|工作日志|日志记录|工作记录)(?:[\s：:]|$)|^(?:状态|记录)\s*[：:]/i
       .test(value) ||

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -213,7 +213,7 @@ function hasConcreteTransferableText(value: string) {
 }
 
 function hasFailureOrConsequenceSignal(value: string) {
-  return /\b(avoid|prevents?|fix(?:es)?|fail(?:s|ed|ure|ures)?|race|raced|orphan|dedupe|deduplicate|stale|diverge|diverged|fallback|fell back|default data directory|econrefused|readiness issue|startup race|unreliable|invalid|mismatch)\b/i
+  return /\b(race|raced|orphan|dedupe|deduplicate|stale dist|dist diverge|dist diverged|diverge|diverged|fallback|fell back|default data directory|econrefused|readiness issue|startup race|unreliable|invalid note_tags|foreign_keys|cascade|nulling|source_run_key collision)\b/i
     .test(value);
 }
 
@@ -278,7 +278,29 @@ function isMostlyOneOffStatus(note: MaterializedTaskMemoryNote) {
     '状态',
   ];
   const statusHits = statusWords.filter((word) => text.includes(word)).length;
-  return statusHits >= 3 && (!hasConcreteTransferableAction(text) || isGenericStatusAction(text));
+  return (
+    statusHits >= 3 &&
+    (
+      !hasConcreteTransferableAction(text) ||
+      isGenericStatusAction(text) ||
+      isStatusShapedSelfContainedItem(note)
+    )
+  );
+}
+
+function isStatusShapedSelfContainedItem(note: MaterializedTaskMemoryNote) {
+  if (note.raw_payload.root_cause || note.raw_payload.resolution) return false;
+
+  const text = joined(note);
+  const hasStatusShape =
+    /\b(current|checked|checks?|status|local|package version|version|dist output|generated dist output)\b/i
+      .test(text);
+  return hasStatusShape && !hasStrongReusableMechanism(text);
+}
+
+function hasStrongReusableMechanism(value: string) {
+  return /\b(normalize|normalizing|parse|parsing|diverge|diverged|default data directory|fallback|fell back|race|raced|orphan|dedupe|deduplicate|foreign_keys|cascade|nulling|source_run_key)\b/i
+    .test(value);
 }
 
 export function validateMaterializedNoteQuality(

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -284,7 +284,7 @@ function isPackageArtifactObservationClaim(value: string) {
 function hasDefaultDataDirectoryConsequence(value: string) {
   return /\b(prevents?|preventing|avoid|avoids|avoiding)\b.+\b(fallback\b.+\bdefault data directory|default data directory fallback)\b/i
     .test(value) ||
-    /\b(fallback|fell back)\b.+\bdefault data directory\b/i.test(value) ||
+    /\bfell back\b.+\bdefault data directory\b/i.test(value) ||
     /\bused the default data directory\b/i.test(value);
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -233,6 +233,7 @@ function hasFailureOrConsequenceSignal(value: string) {
 
 function hasStrongRootCauseSignal(value: string) {
   if (isExistenceOnlyClaim(value)) return false;
+  if (isWeakRootCauseClaim(value)) return false;
   return (
     hasFailureOrConsequenceSignal(value) ||
     /\b(version parsing|package metadata|package version)\b.+\b(inconsistent|mismatch|wrong comparison|stale|diverged|diverge)\b.+\b(dist comparison|dist comparisons|generated dist output|dist output)\b/i
@@ -251,7 +252,7 @@ function hasStrongRootCauseSignal(value: string) {
 function isExistenceOnlyClaim(value: string) {
   const text = value.toLowerCase();
   const hasExistencePhrase =
-    /\b(existed|exists|was present|were present|present during|is available|was available|on disk|is on disk|was on disk|was there|were there|there was|there were)\b/
+    /\b(existed|exists|was present|were present|present during|is available|was available|on disk|is on disk|was on disk|was there|were there|there was|there were|was found|were found|was included|were included|was located|were located|was listed)\b/
       .test(text);
   return hasExistencePhrase && !hasDefaultDataDirectoryConsequence(text);
 }
@@ -260,8 +261,20 @@ function hasDefaultDataDirectoryConsequence(value: string) {
   return /\b(prevents?|preventing|avoid|avoids|avoiding)\b.+\b(fallback\b.+\bdefault data directory|default data directory fallback)\b/i
     .test(value) ||
     /\b(fallback|fell back)\b.+\bdefault data directory\b/i.test(value) ||
-    /\bdefault data directory fallback\b/i.test(value) ||
     /\bused the default data directory\b/i.test(value);
+}
+
+function isWeakRootCauseClaim(value: string) {
+  const text = value.toLowerCase();
+  const hasWeakPhrase =
+    /\b(not correct before|was not correct|not configured correctly|was wrong|incomplete|not proper|not properly|properly)\b/
+      .test(text);
+  return hasWeakPhrase && !hasConcreteRootCauseMechanism(text);
+}
+
+function hasConcreteRootCauseMechanism(value: string) {
+  return /\b(registration ran after request setup|missing route|route was unregistered|unregistered route|imported .+ after request setup|ran after request setup)\b/i
+    .test(value);
 }
 
 function hasHttpFailureSignal(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1050,7 +1050,7 @@ function isFirstPersonDiaryClaim(value: string) {
     .map(regexEscape)
     .join('|');
   return new RegExp(
-    `(?:^|[:.!?,;]\\s*|\\b(?:and|then|but|so)\\s+)\\b(?:i|we)\\s+(?:${diaryVerbs})\\b`,
+    `(?:^|[:.!?,;]\\s*|\\b(?:and|then|but|so)\\s+)\\b(?:i|we)\\s+(?:(?:now|then|just|already|currently|also|finally)\\s+)?(?:${diaryVerbs})\\b`,
     'i',
   )
     .test(value) ||
@@ -1247,7 +1247,7 @@ function hasSqlParameterizationMechanism(value: string) {
       .test(text) ||
     /\binterpolat(?:e|ed|ing)\b.+\buser-controlled tag names?\b.+\b(?:sql\s+)?where clauses?\b/i
       .test(text) ||
-    /\binterpolat(?:e|ed|ing)\b.+\btag text\b.+\bcrafted tag payload\b.+\bchang(?:e|ed|es|ing)\b.+\b(?:sql\s+)?where clause syntax\b/i
+    /\binterpolat(?:e|ed|ing)\b.+\btag text\b.+\bcrafted tag payloads?\b.+\bchang(?:e|ed|es|ing)\b.+\b(?:sql\s+)?where clause syntax\b/i
       .test(text) ||
     /\bquotes?\b.+\btag\b.+\b(?:alter(?:ed|s|ing)|chang(?:ed|es|ing))\b.+\bsql syntax\b/i
       .test(text);
@@ -1257,6 +1257,8 @@ function hasSqlParameterizationMechanism(value: string) {
     /\bbind\b.+\btag values?\b.+\b(sql\.js\s+)?parameters?\b.+\binstead of\b.+\binterpolat(?:e|ing)\b.+\btag text\b.+\bwhere clauses?\b/i
       .test(text) ||
     /\bsql parameters?\b.+\btag filters?\b.+\buser-controlled tag text\b.+\bstays?\b.+\bdata\b.+\binstead of executable sql\b/i
+      .test(text) ||
+    /\bparameterized queries?\b.+\btag lookups?\b.+\buser-controlled tag text\b.+\bstays?\b.+\bdata\b.+\binstead of executable sql\b/i
       .test(text) ||
     /\bquotes?\b.+\bstay\b.+\bdata\b.+\binstead of sql syntax\b/i
       .test(text) ||
@@ -1286,7 +1288,7 @@ function hasSqlParameterizationFailureSignal(value: string) {
       .test(text) ||
     /\bquotes?\b.+\btag\b.+\b(?:alter(?:ed|s|ing)|chang(?:ed|es|ing))\b.+\bsql syntax\b/i
       .test(text) ||
-    /\bcrafted tag payload\b.+\bchang(?:e|ed|es|ing)\b.+\b(?:sql\s+)?where clause syntax\b/i
+    /\bcrafted tag payloads?\b.+\bchang(?:e|ed|es|ing)\b.+\b(?:sql\s+)?where clause syntax\b/i
       .test(text) ||
     /\balter(?:ed|s|ing)\b.+\bwhere clause syntax\b/i
       .test(text);
@@ -1917,7 +1919,7 @@ function isVisibleWorkLogClaim(value: string) {
 
 function isExplicitEnglishStatusShell(value: string) {
   return hasTechnicalPrefixStatusShell(value) ||
-    /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task)\s+(?:record|report|note|summary|update|log|entry)|(?:implementation|task|fix|execution|run|work|status)\s+results?|run\s+results?|work\s*log(?:\s+entry)?|worklog(?:\s+entry)?|status|record|update|implementation|result|outcome|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
+    /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task|progress)\s+(?:record|report|note|summary|update|log|entry)|(?:implementation|task|fix|execution|run|work|status)\s+results?|run\s+results?|work\s*log(?:\s+entry)?|worklog(?:\s+entry)?|status|record|update|implementation|result|outcome|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
       .test(value.trim()) ||
     isCurrentRunImplementationShell(value) ||
     isCurrentRunStatusObservationClaim(value);
@@ -1930,7 +1932,7 @@ function hasTechnicalPrefixStatusShell(value: string) {
   const englishDescriptorPrefix = String.raw`(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,3})`;
   const chineseDescriptorPrefix = String.raw`(?:[\u3400-\u9fff]{2,16})`;
   const technicalPrefix = String.raw`(?:\/api\/[\w/-]+|[a-z0-9]+_[a-z0-9_]+|[a-z][a-z0-9_]*\.[a-z_][a-z0-9_]*|activerequestid|setresults|data_dir|node_env|child_process|jsonl|sqlite|sql\.js|websocket|mcp|json-rpc|${descriptorWord}(?:\s+${descriptorWord}){0,2}|${chineseDescriptorWord}(?:\s+${chineseDescriptorWord}){0,2}|${englishDescriptorPrefix}|${chineseDescriptorPrefix})`;
-  const englishShell = String.raw`(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task)\s+(?:record|report|note|summary|update|log|entry)|(?:status|record|update|implementation|result|outcome|completion(?:\s+(?:note|record))?|completed|done))`;
+  const englishShell = String.raw`(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task|progress)\s+(?:record|report|note|summary|update|log|entry)|(?:status|record|update|implementation|result|outcome|completion(?:\s+(?:note|record))?|completed|done))`;
   const chineseShell = String.raw`(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|运行结果|执行结果|结果记录|结果报告|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|状态|结果|完成|已完成|完成说明)`;
   return new RegExp(`^\\s*${technicalPrefix}\\s+${englishShell}\\s*(?:[:\\-\\u2013\\u2014])`, 'i')
     .test(text) ||

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1203,7 +1203,7 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
     /\b(writeback|receipt|source_agent|source_run_key)\b.+\b(unique key|unique constraint)\b/i
       .test(text);
   const hasNamedAsyncObject =
-    /\b(abortcontroller|react search|search view|\/api\/search|search request sequence|stale search requests?|stale responses?|stale results?|previous responses?|current query results?|current results|overlapping requests?|overlapping \/api\/search requests?)\b/i
+    /\b(abortcontroller|activerequestid|setresults|react search|search view|\/api\/search|search request sequence|stale search requests?|stale responses?|stale results?|previous responses?|current query results?|current results|overlapping requests?|overlapping \/api\/search requests?)\b/i
       .test(text);
   const hasNamedRelationObject =
     /\b(note_ids?|note_tags|tag counts?|filter chips?|webui|deletenotewithreview|note deletion|orphan tags?|unused tags?|joins? whose note_id|existing notes?)\b/i
@@ -1240,7 +1240,7 @@ function hasStrictStructuralEngineeringAction(value: string) {
   const hasConcreteAsyncAction =
     /\b(use\b.+\babortcontroller|abortcontroller\b.+\bcancel|cancel(?: older| previous| prior)?\b.+\b(?:\/api\/search|requests?|responses?))\b/i
       .test(text) ||
-    /\b(gate)\b.+\b(result updates?|responses?|requests?)\b.+\b(active|latest|request id|query)\b/i
+    /\b(gate)\b.+\b(result updates?|responses?|requests?|setresults)\b.+\b(active|activerequestid|latest|request id|query)\b/i
       .test(text) ||
     /\b(ignore)\b.+\b(responses?)\b.+\b(not from the latest query|older|previous|stale|latest query)\b/i
       .test(text);
@@ -1301,9 +1301,15 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       .test(text) ||
     /\bstale responses?\b.+\b(cannot|do not|does not)\b.+\b(replace|overwrite)\b.+\bcurrent results\b/i
       .test(text) ||
-    /\b(gate)\b.+\b(result updates?|search result updates?|current results)\b.+\b(active|latest|request id|\/api\/search|query)\b/i
+    /\bgat(?:e|es|ed|ing)\b.+\b(result updates?|search result updates?|current results)\b.+\b(active|activerequestid|latest|request id|\/api\/search|query)\b/i
+      .test(text) ||
+    /\b(gate)\b.+\bsetresults\b.+\bactiverequestid\b/i
+      .test(text) ||
+    /\bactiverequestid\b.+\bgat(?:e|es|ed|ing)\b.+\bstale\b.+\b(?:\/api\/search|responses?)\b/i
       .test(text) ||
     /\b(active|latest)\b.+\b(\/api\/search\s+)?request id\b.+\b(older responses?|stale responses?|current results|overwrite)\b/i
+      .test(text) ||
+    /\bactiverequestid\b.+\b(?:was\s+)?not checked\b.+\bbefore\b.+\bsetresults\b/i
       .test(text) ||
     /\b(ignore)\b.+\bresponses?\b.+\b(not from the latest query|older|previous|stale|latest query)\b/i
       .test(text) ||
@@ -1339,7 +1345,7 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
     /\b(reserve)\b.+\b(process\.stdout|stdout)\b.+\b(json-rpc|json rpc|response frames?|stdio)\b/i
       .test(text);
   const hasCausalFlow =
-    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gate|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve|left|no longer existed|deleting notes?|note deletion|cleanup|prune|filter)\b/i
+    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gat(?:e|es|ed|ing)|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve|left|no longer existed|deleting notes?|note deletion|cleanup|prune|filter)\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) &&
     hasCausalFlow &&
@@ -1646,7 +1652,7 @@ function isVisibleWorkLogClaim(value: string) {
 }
 
 function isExplicitEnglishStatusShell(value: string) {
-  return /^\s*(?:(?:status|work|implementation|execution|completion|fix|run)\s+(?:record|report|note|summary|update|log)|work\s*log|worklog|status|record|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
+  return /^\s*(?:(?:status|work|implementation|execution|completion|fix|result)\s+(?:record|report|note|summary|update|log)|run\s+results?|work\s*log|worklog|status|record|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
     .test(value.trim()) ||
     isCurrentRunImplementationShell(value);
 }
@@ -1694,7 +1700,7 @@ function hasChineseVisibleMechanism(value: string) {
 function isChineseVisibleStatusShell(value: string) {
   if (!/[\u3400-\u9fff]/.test(value)) return false;
   const hasStatusRecordShell =
-    /^\s*(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|本次修复|本次执行|修复记录|完成|已完成|完成说明)\s*(?:[：:\-\u2013\u2014]|$)/i
+    /^\s*(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|运行结果|执行结果|结果记录|结果报告|本次修复|本次执行|修复记录|完成|已完成|完成说明)\s*(?:[：:\-\u2013\u2014]|$)/i
       .test(value) ||
     /(?:^|[\s：:])(?:状态记录|记录状态|工作日志|日志记录|工作记录)(?:[\s：:]|$)|^(?:状态|记录)\s*[：:]/i
       .test(value) ||

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -231,10 +231,10 @@ function hasFailureOrConsequenceSignal(value: string) {
 }
 
 function hasStrongRootCauseSignal(value: string) {
+  if (hasPackageDistRootCauseShape(value)) return hasPackageDistRootCauseSignal(value);
   if (isExistenceOnlyClaim(value)) return false;
   if (isPackageArtifactObservationClaim(value)) return false;
   if (isWeakRootCauseClaim(value)) return false;
-  if (hasPackageDistRootCauseShape(value)) return hasPackageDistRootCauseSignal(value);
   return (
     hasFailureOrConsequenceSignal(value) ||
     /\b(because|so)\b.+\b(ran before|ran after|returned http [45]\d\d|returned [45]\d\d|http [45]\d\d|imported.+before|used the default data directory|version parsing.+(inconsistent|mismatch|wrong|stale|diverged|diverge)|raced|race|econrefused)\b/i
@@ -253,15 +253,16 @@ function hasPackageDistRootCauseShape(value: string) {
 
 function hasPackageDistRootCauseSignal(value: string) {
   const text = value.toLowerCase();
-  if (isPackageArtifactObservationClaim(text) || isExistenceOnlyClaim(text)) return false;
-  return (
+  const hasPositiveSignal =
     /\b(package metadata|package version|generated dist output|dist output)\b.+\b(diverged|diverge|mismatch|stale|wrong)\b.+\bbecause\b.+\b(version parsing|parsing|normalization|normalize|normalized)\b.+\b(inconsistent|different formats|mismatch|wrong|stale)\b/i
       .test(text) ||
     /\b(generated dist output|dist output)\b.+\b(diverged|diverge|mismatch|stale|wrong)\b.+\b(package metadata|package version)\b.+\bbecause\b.+\b(version parsing|parsing|normalization|normalize|normalized)\b.+\b(inconsistent|different formats|mismatch|wrong|stale)\b/i
       .test(text) ||
     /\b(inconsistent|mismatch|wrong comparison|wrong|stale|different formats)\b.+\b(version parsing|package version parsing|package metadata|package version|version normalization|package normalization)\b.+\b(generated dist output|dist output|dist comparisons?|dist)\b/i
-      .test(text)
-  );
+      .test(text);
+  if (hasPositiveSignal) return true;
+  if (isPackageArtifactObservationClaim(text) || isExistenceOnlyClaim(text)) return false;
+  return false;
 }
 
 function isExistenceOnlyClaim(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1647,7 +1647,18 @@ function isVisibleWorkLogClaim(value: string) {
 
 function isExplicitEnglishStatusShell(value: string) {
   return /^\s*(?:(?:status|work|implementation|execution|completion|fix|run)\s+(?:record|report|note|summary|update|log)|work\s*log|worklog|status|record|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
-    .test(value.trim());
+    .test(value.trim()) ||
+    isCurrentRunImplementationShell(value);
+}
+
+function isCurrentRunImplementationShell(value: string) {
+  const text = value.trim();
+  const hasCurrentRunPrefix =
+    /^\s*(?:this|current)\s+(?:run|execution|fix|task|change)\b/i.test(text);
+  const hasImplementationAction =
+    /^\s*(?:this|current)\s+(?:run|execution|fix|task|change)\b.{0,40}\b(?:use|uses|used|did|add|adds|added|set|sets|configured?|register(?:s|ed)?|wait(?:s|ed)?|block(?:s|ed)?|gate(?:s|d)?|ignore(?:s|d)?|cancel(?:s|ed|led)?|move(?:s|d)?|place(?:s|d)?|import(?:s|ed)?|update(?:s|d)?|fix(?:es|ed)?|change(?:s|d)?|validat(?:e|es|ed)|normaliz(?:e|es|ed)|parse(?:s|d)?|strip(?:s|ped)?|debounce(?:s|d)?|route(?:s|d)?|return(?:s|ed)?|prune(?:s|d)?|remove(?:s|d)?|wrap(?:s|ped)?)\b/i
+      .test(text);
+  return hasCurrentRunPrefix && hasImplementationAction && hasSpecificEvidence(text);
 }
 
 function isLowValueOutcomeStatusClaim(value: string) {
@@ -1690,6 +1701,7 @@ function isChineseVisibleStatusShell(value: string) {
     /(?:已记录|记录了).{0,80}(?:已修复|修复完成|已完成|完成|处理完成|解决完成)/i
       .test(value);
   if (hasStatusRecordShell) return true;
+  if (isChineseCurrentRunImplementationShell(value)) return true;
 
   const hasCompletionShell =
     /问题处理完|处理完成|处理完毕|修复好了|修好了|已经处理|已处理|回归正常|恢复正常|更稳定|不再返回|已解决|解决完成|已完成|修复完成|修复已完成/i
@@ -1698,6 +1710,15 @@ function isChineseVisibleStatusShell(value: string) {
     /这次.{0,20}(?:修复|处理).{0,8}(?:好了|完成|完毕)|(?:接口|问题|路由|请求).{0,12}(?:更稳定|回归正常|恢复正常)/i
       .test(value);
   return (hasCompletionShell || hasWorkLogShell) && !hasChineseVisibleMechanism(value);
+}
+
+function isChineseCurrentRunImplementationShell(value: string) {
+  const hasCurrentRunPrefix =
+    /^\s*(?:本次运行|本次执行|本次修复|本次任务|本次改动)\b/i.test(value);
+  const hasImplementationAction =
+    /^\s*(?:本次运行|本次执行|本次修复|本次任务|本次改动).{0,40}(?:使用|用了|添加|设置|配置|注册|等待|阻塞|拦截|修复|改动|修改|更新|解析|清理|规范化|去重|剥离|去掉|取消|移动|放置|验证|校验)/i
+      .test(value);
+  return hasCurrentRunPrefix && hasImplementationAction && hasSpecificEvidence(value);
 }
 
 function isMetaReusableClaim(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -878,7 +878,7 @@ function hasChineseFirstPersonDiaryClaim(value: string) {
   ]))
     .map(regexEscape)
     .join('|');
-  return new RegExp(`(?:我|我们)(?:已经|已)?${chineseAction}|(?:我|我们)(?:已经|已)?(?:把|将).{0,80}(?:${chineseAction}|\\b(?:${englishAction})\\b)`, 'i')
+  return new RegExp(`(?:我|我们)(?:已经|已)?${chineseAction}|(?:我|我们)(?:已经|已)?(?:把|将).{0,80}(?:${chineseAction}|\\b(?:${englishAction})\\b)|(?:已经|已)(?:把|将).{0,80}(?:${chineseAction}|\\b(?:${englishAction})\\b)`, 'i')
     .test(value);
 }
 
@@ -1282,8 +1282,10 @@ function isVisibleStatusSnapshotText(value: string) {
   const hasStatusObject =
     /\b(node_env|env|environment|production|local|testing|server readiness|fastify readiness|api requests?|package version|version|generated dist output|dist output)\b/i
       .test(value);
-  return (hasPassStatus || hasSuccessStatus || hasChineseStatus || (hasStatusVerb && hasStatusObject)) &&
-    !hasStrongReusableMechanism(value);
+  return hasPassStatus ||
+    hasSuccessStatus ||
+    hasChineseStatus ||
+    ((hasStatusVerb && hasStatusObject) && !hasStrongReusableMechanism(value));
 }
 
 function conclusionText(
@@ -1469,7 +1471,7 @@ function isPlaceholderFunctionCallSnippet(code: string) {
   if (!match) return false;
 
   const functionName = match[1].toLowerCase();
-  const placeholderNames = /^(fix|handle|dothing|do_thing|process|update|set)$/i;
+  const placeholderNames = /^(fix|handle|dothing|do_thing|process|update|set|parse|normalize|prune|strip|sanitize)$/i;
   if (!placeholderNames.test(functionName)) return false;
 
   const args = match[2].trim();

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -67,7 +67,6 @@ function hasConcreteTransferableAction(value: string) {
     'migrate',
     'normalize',
     'parse',
-    'persist',
     'prune',
     'rebuild',
     'retry',
@@ -98,7 +97,7 @@ function isVagueGenericLesson(value: string) {
 
 function isGenericStatusAction(value: string) {
   const text = value.toLowerCase();
-  const hasGenericAction = ['validate', 'investigate', 'check', 'checked']
+  const hasGenericAction = ['validate', 'investigate', 'check', 'checked', 'persist', 'record', 'recorded']
     .some((word) => hasWord(text, word));
   const hasStatusSubject =
     /\b(node_env|env|environment|deployment|production|status|local|package version|version)\b/i
@@ -141,8 +140,7 @@ function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
     (hasMeaningfulRootCause && hasMeaningfulResolution) ||
     Boolean(payload.reusable_patterns?.some((item) => hasConcreteTransferableText(item))) ||
     Boolean(payload.pitfalls?.some((item) => hasConcreteTransferableText(item))) ||
-    Boolean(payload.decisions?.some((item) => hasConcreteTransferableText(item))) ||
-    Boolean(payload.error_signatures?.length && (hasMeaningfulRootCause || hasMeaningfulResolution));
+    Boolean(payload.decisions?.some((item) => hasConcreteTransferableText(item)));
   const hasVisibleSignal =
     /root cause:|resolution:|pitfall:|pattern:|decision:|error signature:/i.test(conclusions);
   return hasStructuredSignal && hasVisibleSignal;

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -422,15 +422,15 @@ function hasDurableEngineeringFailureSignal(value: string) {
 
 function hasImportDedupeEvidence(value: string) {
   const text = value.toLowerCase();
-  return /\b(chokidar|jsonl|mtime|file size|source file size|file revision|import scan|adapter|import dedupe key|dedupe key|duplicate inserts?|unchanged [\w -]*files?|reparsed|reparse|same file revision)\b/i
+  return /\b(chokidar|jsonl|mtime|file size|source file size|file revision|import scan|adapter|import dedupe key|dedupe key|duplicate inserts?|unchanged [\w -]*files?|reparsed|reparse|same file revision|claude code|appends?|appending|truncated lines?|partial writes?|latest (?:imported )?(?:conversation )?messages?|file size and mtime|stop changing|stay stable|stabiliz(?:e|es|ed|ing))\b/i
     .test(text);
 }
 
 function hasImportDedupeAction(value: string) {
   const text = value.toLowerCase();
-  const hasDedupeAction = /\b(use|skip|dedupe|deduplicate|key|compare|track)\b/i.test(text);
+  const hasDedupeAction = /\b(use|skip|dedupe|deduplicate|key|compare|track|debounce|wait)\b/i.test(text);
   const hasRevisionKey =
-    /\b(file size|source file size|mtime|dedupe key|file revision|skip parsing|same file revision)\b/i
+    /\b(file size|source file size|mtime|dedupe key|file revision|skip parsing|same file revision|stay stable|stop changing|stable before parsing|partial writes? (?:are )?skipped)\b/i
       .test(text);
   return hasImportDedupeEvidence(text) && hasDedupeAction && hasRevisionKey;
 }
@@ -443,15 +443,25 @@ function hasImportDedupeMechanism(value: string) {
   const hasRevisionOrWatcherEvidence =
     /\b(file size|source file size|mtime|file revision|same file revision|chokidar|unchanged [\w -]*files?|jsonl|reparsed|reparse|repeated)\b/i
       .test(text);
-  return hasImportDedupeEvidence(text) && hasDedupeFlow && hasRevisionOrWatcherEvidence;
+  const hasPartialWriteFlow =
+    /\b(chokidar|jsonl|claude code|adapter)\b.+\b(appends?|appending|partial writes?|truncated lines?|file size|mtime|stable|stabiliz(?:e|es|ed|ing)|stop changing)\b/i
+      .test(text) ||
+    /\b(debounce|wait)\b.+\b(imports?|jsonl)\b.+\b(until|before)\b.+\b(file size|mtime|stable|stabiliz(?:e|es|ed|ing)|stop changing|parsing|appends?)\b/i
+      .test(text) ||
+    /\bparsing\b.+\bwhile\b.+\b(claude code|[\w -]+)?\s*appending\b/i
+      .test(text) ||
+    /\b(imports?|jsonl)\b.+\buntil\b.+\bappends?\b.+\bstabiliz(?:e|es|ed|ing)\b/i
+      .test(text);
+  return hasImportDedupeEvidence(text) &&
+    ((hasDedupeFlow && hasRevisionOrWatcherEvidence) || hasPartialWriteFlow);
 }
 
 function hasImportDedupeFailureSignal(value: string) {
   const text = value.toLowerCase();
   const hasRepeatedImportConsequence =
-    /\b(repeated events?|repeated jsonl parsing|reparsed|reparse|duplicate inserts?|same conversation|every chokidar event)\b/i
+    /\b(repeated events?|repeated jsonl parsing|reparsed|reparse|duplicate inserts?|same conversation|every chokidar event|truncated lines?|drop(?:ped)? (?:the )?(?:latest )?(?:imported )?(?:conversation )?messages?|partial writes?)\b/i
       .test(text);
-  const hasCausalFlow = /\b(because|so|otherwise|attempted|prevents?|preventing)\b/i.test(text);
+  const hasCausalFlow = /\b(because|so|otherwise|attempted|prevents?|preventing|while|before|until|skipped)\b/i.test(text);
   return hasImportDedupeEvidence(text) && hasRepeatedImportConsequence && hasCausalFlow;
 }
 
@@ -1448,6 +1458,7 @@ function hasVisibleSummaryQuality(summary: string) {
 
 function hasVisibleConcreteContent(value: string) {
   const text = value.toLowerCase();
+  if (isExplicitEnglishStatusShell(text)) return false;
   if (isLowValueOutcomeStatusClaim(text)) return false;
   if (isChineseVisibleStatusShell(text)) return false;
   if (isGenericReleaseValidationClaim(text)) return false;
@@ -1463,9 +1474,15 @@ function isVisibleWorkLogClaim(value: string) {
     .test(value.trim());
 }
 
+function isExplicitEnglishStatusShell(value: string) {
+  return /^\s*(?:work\s*log|worklog|status\s+record|status|record)\s*:/i
+    .test(value.trim());
+}
+
 function isLowValueOutcomeStatusClaim(value: string) {
   const text = value.toLowerCase();
   return (
+    isExplicitEnglishStatusShell(value) ||
     /\ball good(?: now)?\b/i.test(text) ||
     /\brecorded that\b/i.test(text) ||
     /\bis now fixed\b/i.test(text) ||
@@ -1640,6 +1657,8 @@ function isLowQualityVisibleConclusion(value: string) {
     isPlaceholderText(body) ||
     isFirstPersonDiaryClaim(value) ||
     isFirstPersonDiaryClaim(body) ||
+    isExplicitEnglishStatusShell(value) ||
+    isExplicitEnglishStatusShell(body) ||
     isVisibleWorkLogClaim(body) ||
     isVisibleStatusSnapshotText(body) ||
     isLowValueOutcomeStatusClaim(value) ||

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -234,6 +234,7 @@ function hasStrongRootCauseSignal(value: string) {
   if (hasPackageDistRootCauseShape(value)) return hasPackageDistRootCauseSignal(value);
   if (isExistenceOnlyClaim(value)) return false;
   if (isPackageArtifactObservationClaim(value)) return false;
+  if (hasGenericRootCauseRationale(value)) return false;
   if (isWeakRootCauseClaim(value)) return false;
   if (hasHttpFailureSignal(value)) return hasConcreteHttpRootCauseSignal(value);
   return (
@@ -299,7 +300,27 @@ function isWeakRootCauseClaim(value: string) {
 }
 
 function hasConcreteRootCauseMechanism(value: string) {
-  return /\b(registration ran after request setup|missing route|route was unregistered|unregistered route|imported .+ after request setup|ran after request setup)\b/i
+  const text = value.toLowerCase();
+  const hasRegistrationOrdering =
+    /(?:\/api\/[\w/-]+|route|registration).+\b(was registered after request setup|registration ran after request setup|registered after request setup|ran after request setup)\b/i
+      .test(text);
+  const hasConfigOrdering =
+    /\b(config|node_env config)\b.+\b(imported|was imported)\b.+\b(node_env\s+)?after request setup\b/i
+      .test(text) ||
+    /\bnode_env\b.+\bconfig\b.+\b(imported|was imported)\b.+\bafter request setup\b/i
+      .test(text) ||
+    /\bimported\b.+\bnode_env\b.+\bafter request setup\b/i
+      .test(text);
+  const hasMissingRouteMechanism =
+    /\b(route|\/api\/[\w/-]+)\b.+\b(missing|unregistered|was missing|was unregistered)\b.+\b(before request setup|before api requests?|api requests?|request setup)\b/i
+      .test(text) ||
+    /\b(missing|unregistered)\b.+\b(route|\/api\/[\w/-]+)\b.+\b(before request setup|before api requests?|api requests?|request setup)\b/i
+      .test(text);
+  return hasRegistrationOrdering || hasConfigOrdering || hasMissingRouteMechanism;
+}
+
+function hasGenericRootCauseRationale(value: string) {
+  return /\bbecause\b.+\b(correctness|reliability|quality|it)\b.+\b(mattered|was important|is important)\b/i
     .test(value);
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1047,6 +1047,7 @@ function hasVisibleTitleQuality(title: string) {
     !isVagueGenericFixClaim(title) &&
     !isMetaReusableClaim(title) &&
     !isGenericVisibleBoilerplateClaim(title) &&
+    !isChineseVisibleStatusShell(title) &&
     !isVisibleStatusSnapshotText(title)
   );
 }
@@ -1061,6 +1062,7 @@ function hasVisibleSummaryQuality(summary: string) {
     !isVagueGenericFixClaim(summary) &&
     !isMetaReusableClaim(summary) &&
     !isGenericVisibleBoilerplateClaim(summary) &&
+    !isChineseVisibleStatusShell(summary) &&
     !isVisibleStatusSnapshotText(summary)
   );
 }
@@ -1068,6 +1070,7 @@ function hasVisibleSummaryQuality(summary: string) {
 function hasVisibleConcreteContent(value: string) {
   const text = value.toLowerCase();
   if (isLowValueOutcomeStatusClaim(text)) return false;
+  if (isChineseVisibleStatusShell(text)) return false;
   if (isGenericReleaseValidationClaim(text)) return false;
   if (hasSpecificEvidence(text) && hasConcreteMechanism(text)) return true;
   if (hasSpecificEvidence(text) && hasFailureOrConsequenceSignal(text)) return true;
@@ -1090,6 +1093,30 @@ function isLowValueOutcomeStatusClaim(value: string) {
     /\b(investigated|investigation)\b.+\b(issue|task|fix|route|request|requests?)\b/i
       .test(text)
   );
+}
+
+function hasChineseVisibleMechanism(value: string) {
+  return (
+    /(?:在|于)?\s*(?:request setup|请求设置|请求初始化).{0,8}前.{0,24}(?:注册|移动|放置|等待|校验|验证|加载|导入|设置|移除|清理|解析|规范化|去重|剥离|去掉)/i
+      .test(value) ||
+    /(?:注册|移动|放置|等待|校验|验证|加载|导入|设置|移除|清理|解析|规范化|去重|剥离|去掉).{0,40}(?:request setup\s*前|请求设置前|请求初始化前|before request setup)/i
+      .test(value) ||
+    /(?:避免|防止).{0,30}(?:http\s*[45]\d\d|econrefused|typeerror|syntaxerror|stale|重复|缺失|泄露|回退|错误)/i
+      .test(value) &&
+    /(?:注册|移动|放置|等待|校验|验证|加载|导入|设置|移除|清理|解析|规范化|去重|剥离|去掉)/i
+      .test(value)
+  );
+}
+
+function isChineseVisibleStatusShell(value: string) {
+  if (!/[\u3400-\u9fff]/.test(value)) return false;
+  const hasCompletionShell =
+    /问题处理完|处理完成|处理完毕|修复好了|修好了|已经处理|已处理|回归正常|恢复正常|更稳定|不再返回|已解决|解决完成|已完成|修复完成|修复已完成/i
+      .test(value);
+  const hasWorkLogShell =
+    /这次.{0,20}(?:修复|处理).{0,8}(?:好了|完成|完毕)|(?:接口|问题|路由|请求).{0,12}(?:更稳定|回归正常|恢复正常)/i
+      .test(value);
+  return (hasCompletionShell || hasWorkLogShell) && !hasChineseVisibleMechanism(value);
 }
 
 function isMetaReusableClaim(value: string) {
@@ -1149,6 +1176,7 @@ function isVisibleStatusSnapshotText(value: string) {
   const hasChineseStatus =
     /已验证|验证通过|测试通过|构建通过|编译通过|类型检查通过|检查通过|已修复|修复已验证|ci\s*通过|持续集成通过/i
       .test(value) ||
+    isChineseVisibleStatusShell(value) ||
     /(?:提高|提升).{0,12}(?:可靠性|正确性)|(?:可靠性|正确性).{0,12}(?:提高|提升)/
       .test(value);
   const hasStatusObject =

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -216,6 +216,7 @@ function hasConcreteTransferableText(value: string) {
     hasSpecificEvidence(value) &&
     hasConcreteMechanism(value) &&
     hasFailureOrConsequenceSignal(value) &&
+    !isExistenceOnlyClaim(value) &&
     !isGenericStatusAction(value) &&
     !isVagueGenericLesson(value)
   );
@@ -230,6 +231,7 @@ function hasFailureOrConsequenceSignal(value: string) {
 }
 
 function hasStrongRootCauseSignal(value: string) {
+  if (isExistenceOnlyClaim(value)) return false;
   return (
     hasFailureOrConsequenceSignal(value) ||
     /\b(version parsing|package metadata|package version)\b.+\b(inconsistent|mismatch|wrong comparison|stale|diverged|diverge)\b.+\b(dist comparison|dist comparisons|generated dist output|dist output)\b/i
@@ -243,6 +245,11 @@ function hasStrongRootCauseSignal(value: string) {
     /\b(ran before|ran after|returned http [45]\d\d|returned [45]\d\d|http [45]\d\d|imported.+before|used the default data directory|version parsing.+(inconsistent|mismatch|wrong|stale|diverged|diverge)|default data directory|fell back|fallback|diverged|raced|race|econrefused)\b.+\b(because|so)\b/i
       .test(value)
   );
+}
+
+function isExistenceOnlyClaim(value: string) {
+  const text = value.toLowerCase();
+  return /\b(existed|exists|was present|were present|available|present during)\b/.test(text);
 }
 
 function hasHttpFailureSignal(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -183,11 +183,15 @@ function hasSpecificEvidence(value: string) {
 
 function hasConcreteMechanism(value: string) {
   const text = value.toLowerCase();
+  const hasGenericReleaseValidation = isGenericReleaseValidationClaim(text);
   const hasTimingOrder =
-    /\b(before|after|until|when)\b.+\b(import|importing|issue|issuing|request|requests|setup|ready|readiness|server|startup|data_dir|entrypoint|metadata|dist|compare|comparing)\b/i
+    !hasGenericReleaseValidation &&
+    (
+      /\b(before|after|until|when)\b.+\b(import|importing|issue|issuing|request|requests|setup|ready|readiness|server|startup|data_dir|entrypoint|metadata|dist|compare|comparing)\b/i
       .test(text) ||
-    /\b(import|importing|issue|issuing|request|requests|setup|ready|readiness|server|startup|data_dir|entrypoint|metadata|dist|compare|comparing)\b.+\b(before|after|until|when)\b/i
-      .test(text);
+      /\b(import|importing|issue|issuing|request|requests|setup|ready|readiness|server|startup|data_dir|entrypoint|metadata|dist|compare|comparing)\b.+\b(before|after|until|when)\b/i
+        .test(text)
+    );
   const hasRaceReadiness =
     /\b(race|raced|readiness|startup|econrefused)\b.+\b(request|requests|ready|server|client calls?|fastify)\b/i
       .test(text) ||
@@ -245,6 +249,7 @@ function hasConcreteTransferableText(value: string) {
     hasConcreteConsequence &&
     !isExistenceOnlyClaim(value) &&
     !isFirstPersonDiaryClaim(value) &&
+    !isGenericReleaseValidationClaim(value) &&
     !isGenericStatusAction(value) &&
     !isVagueGenericLesson(value)
   );
@@ -525,6 +530,7 @@ function hasVisibleSummaryQuality(summary: string) {
 function hasVisibleConcreteContent(value: string) {
   const text = value.toLowerCase();
   if (isLowValueOutcomeStatusClaim(text)) return false;
+  if (isGenericReleaseValidationClaim(text)) return false;
   if (hasSpecificEvidence(text) && hasConcreteMechanism(text)) return true;
   if (hasSpecificEvidence(text) && hasFailureOrConsequenceSignal(text)) return true;
   if (hasPackageDistRootCauseSignal(text)) return true;
@@ -571,7 +577,8 @@ function isGenericVisibleBoilerplateClaim(value: string) {
   const hasGenericReleaseValidation =
     /\bvalidate behavior\b/i.test(text) ||
     /\balways validate behavior before release\b/i.test(text) ||
-    /\bvalidate behavior\b.+\bbefore release\b/i.test(text);
+    /\bvalidate behavior\b.+\bbefore release\b/i.test(text) ||
+    isGenericReleaseValidationClaim(text);
   const hasGenericResolvedInvestigation =
     /\bissue resolved after investigation\b/i.test(text) ||
     /\bresolved after investigation\b/i.test(text) ||
@@ -581,6 +588,14 @@ function isGenericVisibleBoilerplateClaim(value: string) {
     hasGenericFutureFailure ||
     hasGenericReleaseValidation
   ) && !hasConcreteMechanism(text);
+}
+
+function isGenericReleaseValidationClaim(value: string) {
+  const text = value.toLowerCase();
+  return (
+    /\bvalidat(?:e|ing|ion)\b.+\b(api requests?|requests?)\b.+\bbefore release\b/i.test(text) ||
+    /\b(api requests?|requests?)\b.+\bvalidat(?:e|ing|ion)\b.+\bbefore release\b/i.test(text)
+  );
 }
 
 function isVisibleStatusSnapshotText(value: string) {
@@ -669,6 +684,7 @@ function isLowQualityVisibleConclusion(value: string) {
 
 function hasConcreteConclusionValue(value: string) {
   if (isLowValueOutcomeStatusClaim(value)) return false;
+  if (isGenericReleaseValidationClaim(value)) return false;
   return (
     hasVisibleConcreteContent(value) ||
     hasConcreteTransferableText(value) ||

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -108,6 +108,7 @@ function hasConcreteTransferableAction(value: string) {
   if (hasImportDedupeAction(text)) return true;
   if (hasPersistenceSerializationAction(text)) return true;
   if (hasDbTransactionAtomicityAction(text)) return true;
+  if (hasSqlParameterizationAction(text)) return true;
   if (hasStrictStructuralEngineeringAction(text)) return true;
   if (hasElectronResourceAction(text)) return true;
   if (hasCrossPlatformPathAction(text)) return true;
@@ -228,6 +229,7 @@ function hasSpecificEvidence(value: string) {
     hasContentSanitizationEvidence(text) ||
     hasPersistenceSnapshotEvidence(text) ||
     hasDbTransactionAtomicityEvidence(text) ||
+    hasSqlParameterizationEvidence(text) ||
     hasStrictStructuralEngineeringEvidence(text) ||
     hasIndexConsistencyEvidence(text) ||
     hasElectronResourceEvidence(text) ||
@@ -941,6 +943,7 @@ function hasConcreteMechanism(value: string) {
   const hasContentSanitizationFlow = hasContentSanitizationMechanism(text);
   const hasPersistenceSerializationFlow = hasPersistenceSerializationMechanism(text);
   const hasDbTransactionAtomicityFlow = hasDbTransactionAtomicityMechanism(text);
+  const hasSqlParameterizationFlow = hasSqlParameterizationMechanism(text);
   const hasStrictStructuralEngineeringFlow = hasStrictStructuralEngineeringMechanism(text);
   const hasIndexConsistencyFlow = hasIndexConsistencyMechanism(text);
   const hasElectronResourceFlow = hasElectronResourceMechanism(text);
@@ -970,6 +973,7 @@ function hasConcreteMechanism(value: string) {
     hasContentSanitizationFlow ||
     hasPersistenceSerializationFlow ||
     hasDbTransactionAtomicityFlow ||
+    hasSqlParameterizationFlow ||
     hasStrictStructuralEngineeringFlow ||
     hasIndexConsistencyFlow ||
     hasElectronResourceFlow ||
@@ -1090,6 +1094,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     hasContentSanitizationFailureSignal(value) ||
     hasPersistenceSnapshotFailureSignal(value) ||
     hasDbTransactionAtomicityFailureSignal(value) ||
+    hasSqlParameterizationFailureSignal(value) ||
     hasStrictStructuralEngineeringFailureSignal(value) ||
     hasIndexConsistencyFailureSignal(value) ||
     hasElectronResourceFailureSignal(value) ||
@@ -1188,6 +1193,68 @@ function hasDbTransactionAtomicityFailureSignal(value: string) {
     /\b(because|so|failed|left|prevents?|rolls? back|rollback|roll back|before)\b/i
       .test(text);
   return hasDbTransactionAtomicityEvidence(text) && hasPartialImportConsequence && hasCausalFlow;
+}
+
+function hasSqlParameterizationEvidence(value: string) {
+  const text = value.toLowerCase();
+  const hasQueryContext =
+    /\b(sql|sql\.js|where clauses?|queries?|query|lookups?|lookup)\b/i.test(text);
+  const hasParameterOrTagContext =
+    /\b(sql parameters?|parameters?|parameterized|parameterised|tag names?|tags?|interpolated tag strings?|interpolated tag text)\b/i
+      .test(text);
+  const hasInterpolationBoundary =
+    /\b(quotes?|quote breakage|sql syntax|where clauses?|interpolat(?:e|ed|ing)|bind(?:ing)?|parameteriz(?:e|ed|ing)|parameteris(?:e|ed|ing))\b/i
+      .test(text);
+  return hasQueryContext && hasParameterOrTagContext && hasInterpolationBoundary;
+}
+
+function hasSqlParameterizationAction(value: string) {
+  const text = value.toLowerCase();
+  return hasSqlParameterizationEvidence(text) &&
+    (
+      /\b(bind|binding|parameteriz(?:e|es|ed|ing)|parameteris(?:e|es|ed|ing))\b.+\b(tag names?|tags?|sql parameters?|parameters?|queries?|lookups?)\b/i
+        .test(text) ||
+      /\b(use)\b.+\b(parameterized queries?|parameterised queries?|sql parameters?)\b/i
+        .test(text)
+    );
+}
+
+function hasSqlParameterizationMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasInterpolationFailure =
+    /\btag names?\b.+\bquotes?\b.+\bbroke\b.+\b(sql lookup queries?|lookup queries?|queries?)\b/i
+      .test(text) ||
+    /\binterpolat(?:e|ed|ing)\b.+\b(tag text|tag strings?|tag names?|strings?|text)\b.+\b(where clauses?|sql syntax|queries?|lookups?|quotes?)\b/i
+      .test(text) ||
+    /\b(where clauses?)\b.+\binterpolat(?:e|ed|ing)\b.+\b(tag text|tag strings?|tag names?)\b/i
+      .test(text);
+  const hasParameterizationFix =
+    /\bbind\b.+\btag names?\b.+\b(sql\.js\s+)?parameters?\b.+\bquotes?\b.+\bdata\b.+\binstead of sql syntax\b/i
+      .test(text) ||
+    /\bquotes?\b.+\bstay\b.+\bdata\b.+\binstead of sql syntax\b/i
+      .test(text);
+  const hasCausalFlow =
+    /\b(because|so|before|prevent|prevents|broke|breakage|instead of|interpolat(?:e|ed|ing)|bind|where clauses?|sql syntax)\b/i
+      .test(text);
+  return hasSqlParameterizationEvidence(text) &&
+    hasCausalFlow &&
+    (hasInterpolationFailure || hasParameterizationFix);
+}
+
+function hasSqlParameterizationFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasQueryBreakage =
+    /\bquote breakage\b/i.test(text) ||
+    /\bquotes?\b.+\b(broke|breaks?|breakage|broken)\b.+\b(sql lookup queries?|lookup queries?|queries?|lookups?)\b/i
+      .test(text) ||
+    /\b(broke|breaks?|breakage|broken)\b.+\b(sql lookup queries?|lookup queries?|queries?|lookups?)\b/i
+      .test(text) ||
+    /\bsql syntax\b.+\b(quotes?|tag text|tag strings?|tag names?)\b/i
+      .test(text);
+  const hasCausalFlow =
+    /\b(because|so|before|prevent|prevents|broke|breakage|instead of|interpolat(?:e|ed|ing)|where clauses?|sql syntax)\b/i
+      .test(text);
+  return hasSqlParameterizationEvidence(text) && hasQueryBreakage && hasCausalFlow;
 }
 
 function hasStrictStructuralEngineeringEvidence(value: string) {
@@ -1652,7 +1719,7 @@ function isVisibleWorkLogClaim(value: string) {
 }
 
 function isExplicitEnglishStatusShell(value: string) {
-  return /^\s*(?:(?:status|work|implementation|execution|completion|fix|result)\s+(?:record|report|note|summary|update|log)|run\s+results?|work\s*log|worklog|status|record|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
+  return /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task)\s+(?:record|report|note|summary|update|log)|run\s+results?|work\s*log|worklog|status|record|update|implementation|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
     .test(value.trim()) ||
     isCurrentRunImplementationShell(value);
 }
@@ -1700,7 +1767,7 @@ function hasChineseVisibleMechanism(value: string) {
 function isChineseVisibleStatusShell(value: string) {
   if (!/[\u3400-\u9fff]/.test(value)) return false;
   const hasStatusRecordShell =
-    /^\s*(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|运行结果|执行结果|结果记录|结果报告|本次修复|本次执行|修复记录|完成|已完成|完成说明)\s*(?:[：:\-\u2013\u2014]|$)/i
+    /^\s*(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|运行结果|执行结果|结果记录|结果报告|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|完成|已完成|完成说明)\s*(?:[：:\-\u2013\u2014]|$)/i
       .test(value) ||
     /(?:^|[\s：:])(?:状态记录|记录状态|工作日志|日志记录|工作记录)(?:[\s：:]|$)|^(?:状态|记录)\s*[：:]/i
       .test(value) ||

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -196,6 +196,7 @@ function hasSpecificEvidence(value: string) {
       .test(text) ||
     hasSchemaArrayEvidence(text) ||
     hasPersistenceSnapshotEvidence(text) ||
+    hasIndexConsistencyEvidence(text) ||
     hasHttpFailureSignal(text) ||
     /\b(api requests?|fastify readiness|server readiness|request setup|package metadata|package version|dist output|generated dist output|data directory|electron server|server entrypoint|client calls?)\b/i
       .test(text)
@@ -246,6 +247,45 @@ function hasPersistenceSerializationMechanism(value: string) {
     );
 }
 
+function hasIndexConsistencyEvidence(value: string) {
+  const text = value.toLowerCase();
+  return /\b(vectra|semantic search|note_id|search index|vector index|index entries?|deleted notes?|note rows?|sql\.js rows?)\b/i
+    .test(text);
+}
+
+function hasIndexConsistencyMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasIndexReference =
+    /\b(vectra|semantic search|note_id|search index|vector index|index entries?)\b/i
+      .test(text);
+  const hasDeletionOrCleanup =
+    /\b(delet(?:e|ed|es|ing|ion)|remov(?:e|ed|es|ing)|clean(?:up| up)|prun(?:e|ed|es|ing))\b/i
+      .test(text);
+  const hasStaleOrDeletedReference =
+    /\b(stale|orphan|deleted notes?|stale note_id hits?|note_id hits?|return(?:ed|s|ing)? stale|return(?:ed|s|ing)? deleted)\b/i
+      .test(text);
+  const hasRowIndexRelation =
+    /\b(sql\.js rows?|note rows?|rows?)\b.+\b(vectra|semantic search|search index|vector index|index entries?)\b/i
+      .test(text) ||
+    /\b(vectra|semantic search|search index|vector index|index entries?)\b.+\b(sql\.js rows?|note rows?|rows?)\b/i
+      .test(text);
+  return hasIndexConsistencyEvidence(text) &&
+    hasIndexReference &&
+    hasDeletionOrCleanup &&
+    (hasStaleOrDeletedReference || hasRowIndexRelation);
+}
+
+function hasIndexConsistencyFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasStaleReference =
+    /\b(stale|orphan|deleted notes?|stale note_id hits?|note_id hits?|return(?:ed|s|ing)? stale|return(?:ed|s|ing)? deleted)\b/i
+      .test(text);
+  const hasCausalDeletion =
+    /\b(because|without|after delet(?:e|ing)|after removing|removed|deletion|delet(?:e|ed|es|ing)|cannot return|leaves?)\b/i
+      .test(text);
+  return hasIndexConsistencyEvidence(text) && hasStaleReference && hasCausalDeletion;
+}
+
 function hasConcreteMechanism(value: string) {
   const text = value.toLowerCase();
   const hasGenericReleaseValidation = isGenericReleaseValidationClaim(text);
@@ -290,6 +330,7 @@ function hasConcreteMechanism(value: string) {
       .test(text);
   const hasSchemaDefaultArrayFlow = hasSchemaDefaultArrayMechanism(text);
   const hasPersistenceSerializationFlow = hasPersistenceSerializationMechanism(text);
+  const hasIndexConsistencyFlow = hasIndexConsistencyMechanism(text);
   return (
     hasTimingOrder ||
     hasRaceReadiness ||
@@ -301,7 +342,8 @@ function hasConcreteMechanism(value: string) {
     hasParserFieldValidation ||
     hasRetryBackoffFlow ||
     hasSchemaDefaultArrayFlow ||
-    hasPersistenceSerializationFlow
+    hasPersistenceSerializationFlow ||
+    hasIndexConsistencyFlow
   );
 }
 
@@ -367,6 +409,7 @@ function hasFailureOrConsequenceSignal(value: string) {
       .test(value) ||
     hasSchemaArrayFailureSignal(value) ||
     hasPersistenceSnapshotFailureSignal(value) ||
+    hasIndexConsistencyFailureSignal(value) ||
     hasDefaultDataDirectoryConsequence(value) ||
     hasHttpFailureSignal(value)
   );
@@ -697,9 +740,10 @@ function isGenericReleaseValidationClaim(value: string) {
 }
 
 function isVisibleStatusSnapshotText(value: string) {
-  const hasPassStatus = /\b(build|npm test|tests?|testing)\b.+\bpassed\b/i.test(value);
+  const hasPassStatus = /\b(build|npm test|tests?|testing|typecheck|lint|ci)\b.+\bpassed\b/i
+    .test(value);
   const hasSuccessStatus =
-    /\b(ci green|tests? succeeded|testing succeeded|verification succeeded|build succeeded)\b/i
+    /\b(ci green|ci completed successfully|tests? succeeded|testing succeeded|verification succeeded|build succeeded|typecheck succeeded|lint succeeded)\b/i
       .test(value);
   const hasStatusVerb = /\b(checked|noted|observed|reviewed|resolved|tested|testing passed|verified|verification|current|status)\b/i
     .test(value);

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -233,6 +233,7 @@ function hasFailureOrConsequenceSignal(value: string) {
 
 function hasStrongRootCauseSignal(value: string) {
   if (isExistenceOnlyClaim(value)) return false;
+  if (isPackageArtifactObservationClaim(value)) return false;
   if (isWeakRootCauseClaim(value)) return false;
   return (
     hasFailureOrConsequenceSignal(value) ||
@@ -255,6 +256,15 @@ function isExistenceOnlyClaim(value: string) {
     /\b(existed|exists|was present|were present|present during|is available|was available|on disk|is on disk|was on disk|was there|were there|there was|there were|was found|were found|was included|were included|was located|were located|was listed|was detected|were detected|was observed|were observed|was seen|were seen|was discovered|were discovered|appeared|showed up)\b/
       .test(text);
   return hasExistencePhrase && !hasDefaultDataDirectoryConsequence(text);
+}
+
+function isPackageArtifactObservationClaim(value: string) {
+  const text = value.toLowerCase();
+  const packageArtifact = '(?:package metadata|package version|package artifact|package artifacts)';
+  const observationVerb = '(?:exist(?:ed|s)?|present|available|found|included|located|listed|detect(?:ed)?|observ(?:ed)?|saw|seen|discover(?:ed)?|appeared|showed up|was there|were there)';
+  const activeObservation = new RegExp(`\\b${observationVerb}\\b(?:\\s+\\w+){0,4}\\s+${packageArtifact}\\b`, 'i');
+  const artifactObservation = new RegExp(`\\b${packageArtifact}\\b(?:\\s+\\w+){0,4}\\s+${observationVerb}\\b`, 'i');
+  return activeObservation.test(text) || artifactObservation.test(text);
 }
 
 function hasDefaultDataDirectoryConsequence(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -126,21 +126,30 @@ function isGenericStatusAction(value: string) {
 }
 
 function hasSpecificObject(value: string) {
+  return hasSpecificEvidence(value) || hasConcreteMechanism(value);
+}
+
+function hasSpecificEvidence(value: string) {
   const text = value.toLowerCase();
-  const hasSpecificIdentifier =
+  return (
     /\b(data_dir|node_env|econrefused|note_tags|chatcrystal\.db|port|source_run_key|foreign_keys)\b|\/api\/[\w/-]+|\b[a-z0-9]+_[a-z0-9_]+\b|[a-z]:\\|\/[\w.-]+|[\u3400-\u9fff]/i
-      .test(text);
-  const hasConcreteMechanism =
-    /\b(before importing|raced server startup|raced startup|resets foreign_keys|orphan rows|commits can diverge|used the default data directory|stale dist|dedupe by source_run_key|client calls raced|request setup|package version parsing|dist comparisons?|generated dist output|release checks?|startup used the default data directory|imported the server before)\b/i
-      .test(text);
-  return hasSpecificIdentifier || hasConcreteMechanism;
+      .test(text) ||
+    /\b(request setup|package version|dist output|generated dist output|data directory|electron server|server entrypoint|client calls?)\b/i
+      .test(text)
+  );
+}
+
+function hasConcreteMechanism(value: string) {
+  return /\b(before importing|raced server startup|raced startup|resets foreign_keys|orphan rows|commits can diverge|used the default data directory|stale dist|dedupe by source_run_key|client calls raced|request setup timing|package version parsing|dist comparisons?|release checks?|startup used the default data directory|imported the server before|until readiness resolves|default data directory)\b/i
+    .test(value.toLowerCase());
 }
 
 function hasConcreteTransferableText(value: string) {
   return (
     hasNonPlaceholderMeaningfulText(value) &&
     hasConcreteTransferableAction(value) &&
-    hasSpecificObject(value) &&
+    hasSpecificEvidence(value) &&
+    hasConcreteMechanism(value) &&
     !isGenericStatusAction(value) &&
     !isVagueGenericLesson(value)
   );

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -587,14 +587,22 @@ function hasVisibleConcreteFixSignal(note: MaterializedTaskMemoryNote) {
   const rootCauses = conclusionText(note, 'root cause');
   const resolutions = conclusionText(note, 'resolution');
   return (
-    rootCauses.some((item) =>
-      hasNonPlaceholderMeaningfulText(item) &&
-      hasStrongRootCauseSignal(item) &&
-      !isFirstPersonDiaryClaim(item) &&
-      !isVagueGenericFixClaim(item),
-    ) &&
-    resolutions.some((item) => hasActionableResolution(item) && !isFirstPersonDiaryClaim(item))
+    rootCauses.some((item) => hasVisibleRootCauseConclusionQuality(item)) &&
+    resolutions.some((item) => hasVisibleResolutionConclusionQuality(item))
   );
+}
+
+function hasVisibleRootCauseConclusionQuality(value: string) {
+  return (
+    hasNonPlaceholderMeaningfulText(value) &&
+    hasStrongRootCauseSignal(value) &&
+    !isFirstPersonDiaryClaim(value) &&
+    !isVagueGenericFixClaim(value)
+  );
+}
+
+function hasVisibleResolutionConclusionQuality(value: string) {
+  return hasActionableResolution(value) && !isFirstPersonDiaryClaim(value);
 }
 
 function hasVisibleStructuredSignal(note: MaterializedTaskMemoryNote) {
@@ -615,7 +623,7 @@ function isLowQualityVisibleConclusion(value: string) {
   const label = labelMatch?.[1]?.toLowerCase();
   const body = value.slice(labelMatch?.[0]?.length ?? 0);
   const shouldApplyGenericLessonGate = label !== 'root cause' && label !== 'resolution';
-  return (
+  const hasLowQualityBody =
     isPlaceholderText(value) ||
     isPlaceholderText(body) ||
     isFirstPersonDiaryClaim(value) ||
@@ -626,10 +634,15 @@ function isLowQualityVisibleConclusion(value: string) {
     isMetaReusableClaim(body) ||
     (shouldApplyGenericLessonGate && isVagueGenericLesson(body)) ||
     isVagueGenericFixClaim(body) ||
-    (shouldApplyGenericLessonGate && !hasConcreteConclusionValue(body)) ||
     isGenericVisibleBoilerplateClaim(value) ||
-    isGenericVisibleBoilerplateClaim(body)
-  );
+    isGenericVisibleBoilerplateClaim(body);
+  if (label === 'root cause') {
+    return hasLowQualityBody || !hasVisibleRootCauseConclusionQuality(body);
+  }
+  if (label === 'resolution') {
+    return hasLowQualityBody || !hasVisibleResolutionConclusionQuality(body);
+  }
+  return hasLowQualityBody || (shouldApplyGenericLessonGate && !hasConcreteConclusionValue(body));
 }
 
 function hasConcreteConclusionValue(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -369,9 +369,17 @@ function hasActionableResolution(value: string) {
   return (
     hasNonPlaceholderMeaningfulText(value) &&
     hasConcreteTransferableAction(value) &&
+    hasSpecificObject(value) &&
+    hasConcreteMechanism(value) &&
+    !isGenericResolutionClaim(value) &&
     !isGenericStatusAction(value) &&
     !isVagueGenericFixClaim(value)
   );
+}
+
+function isGenericResolutionClaim(value: string) {
+  return /\b(add|use|apply)\b.+\bvalidation\b.+\b(prevent|avoid)\b.+\b(future failures?|failures?|issues?)\b/i
+    .test(value);
 }
 
 function hasDurableFixSignal(note: MaterializedTaskMemoryNote) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1962,6 +1962,7 @@ function isExplicitEnglishStatusShell(value: string) {
     /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task|progress|verification|validation|regression|qa|diagnostics?|(?:smoke\s+)?test)\s+(?:record|report|note|summary|update|log|entry|check|result|results?|confirmed)|(?:implementation|task|fix|execution|run|work|status)\s+results?|run\s+results?|work\s*log(?:\s+entry)?|worklog(?:\s+entry)?|status|record|update|implementation|result|outcome|progress|verification|validation|regression|qa|check|diagnostics?|(?:smoke\s+)?test|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
       .test(value.trim()) ||
     isValidationResultStatusShell(value) ||
+    isConfirmationResultStatusShell(value) ||
     isCurrentRunImplementationShell(value) ||
     isCurrentRunStatusObservationClaim(value);
 }
@@ -1969,6 +1970,21 @@ function isExplicitEnglishStatusShell(value: string) {
 function isValidationResultStatusShell(value: string) {
   return /^\s*(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,2}\s+)?(?:validation|regression|qa)\s+(?:confirmed|passed|succeeded|completed)\b/i
     .test(value.trim());
+}
+
+function isConfirmationResultStatusShell(value: string) {
+  const text = value.trim();
+  return (
+    hasSpecificEvidence(text) &&
+    /^\s*(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,2}\s+)?(?:check\s+)?(?:confirmed|done|verified)\b/i
+      .test(text)
+  ) ||
+    (
+      hasSpecificEvidence(text) &&
+      /^\s*(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,2}\s+)?(?:check\s+)?fix\s+(?:confirmed|done|verified)\b/i
+        .test(text)
+    ) ||
+    isChineseConfirmationResultStatusShell(text);
 }
 
 function hasTechnicalPrefixStatusShell(value: string) {
@@ -2049,6 +2065,7 @@ function isChineseVisibleStatusShell(value: string) {
   if (!/[\u3400-\u9fff]/.test(value)) return false;
   const hasStatusRecordShell =
     hasTechnicalPrefixStatusShell(value) ||
+    isChineseConfirmationResultStatusShell(value) ||
     /^\s*(?:状态记录|记录状态|状态检查|工作日志|日志记录|工作记录|执行记录|完成记录|完成检查|状态更新|运行结果|执行结果|结果记录|结果报告|结果检查|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|测试记录|结果|进度|验证|测试|诊断|完成|已完成|完成说明)\s*(?:[：:\-\u2013\u2014]|$)/i
       .test(value) ||
     /(?:^|[\s：:])(?:状态记录|记录状态|工作日志|日志记录|工作记录)(?:[\s：:]|$)|^(?:状态|记录)\s*[：:]/i
@@ -2065,6 +2082,11 @@ function isChineseVisibleStatusShell(value: string) {
     /这次.{0,20}(?:修复|处理).{0,8}(?:好了|完成|完毕)|(?:接口|问题|路由|请求).{0,12}(?:更稳定|回归正常|恢复正常)/i
       .test(value);
   return (hasCompletionShell || hasWorkLogShell) && !hasChineseVisibleMechanism(value);
+}
+
+function isChineseConfirmationResultStatusShell(value: string) {
+  return hasSpecificEvidence(value) &&
+    /^\s*(?:[\u3400-\u9fff]{2,16})?(?:检查)?确认(?=\s|$|[a-z0-9_\/])/i.test(value.trim());
 }
 
 function isChineseCurrentRunImplementationShell(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1,0 +1,124 @@
+import type { MaterializedTaskMemoryNote } from '@chatcrystal/shared';
+
+type ValidationMode = 'auto' | 'manual';
+
+export type NoteQualityDecision = {
+  accepted: boolean;
+  reason: 'note-quality-ok' | 'manual-note-quality-warning' | 'low-note-quality';
+  warnings: string[];
+};
+
+function compactLength(value: string) {
+  return value.replace(/\s+/g, '').length;
+}
+
+function hasMeaningfulText(value: string, minLatin = 24, minCjk = 18) {
+  const text = value.trim();
+  if (!text) return false;
+  const hasCjk = /[\u3400-\u9fff]/.test(text);
+  return compactLength(text) >= (hasCjk ? minCjk : minLatin);
+}
+
+function isGenericTitle(title: string) {
+  return /^(task|memory|note|update|summary|investigate|check|fix)$/i.test(title.trim());
+}
+
+function joined(note: MaterializedTaskMemoryNote) {
+  return [
+    note.title,
+    note.summary,
+    ...note.key_conclusions,
+  ].join('\n').toLowerCase();
+}
+
+function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
+  if (isMostlyOneOffStatus(note)) return false;
+  const payload = note.raw_payload;
+  const conclusions = note.key_conclusions.join('\n').toLowerCase();
+  const hasStructuredSignal =
+    Boolean(payload.root_cause && payload.resolution) ||
+    Boolean(payload.reusable_patterns?.some((item) => hasMeaningfulText(item))) ||
+    Boolean(payload.pitfalls?.some((item) => hasMeaningfulText(item))) ||
+    Boolean(payload.decisions?.some((item) => hasMeaningfulText(item))) ||
+    Boolean(payload.error_signatures?.length && (payload.root_cause || payload.resolution));
+  const hasVisibleSignal =
+    /root cause:|resolution:|pitfall:|pattern:|decision:|error signature:/i.test(conclusions);
+  return hasStructuredSignal && hasVisibleSignal;
+}
+
+function isMostlyOneOffStatus(note: MaterializedTaskMemoryNote) {
+  const text = joined(note);
+  const statusWords = [
+    'version',
+    'status',
+    'checked',
+    'current',
+    'package',
+    'npm link',
+    'dist',
+    'local',
+    'environment',
+    '配置',
+    '版本',
+    '检查',
+    '状态',
+  ];
+  const durableWords = [
+    'root cause',
+    'resolution',
+    'pitfall',
+    'avoid',
+    'decision',
+    'rationale',
+    'reuse',
+    'transferable',
+    '原因',
+    '解决',
+    '避免',
+    '模式',
+    '决策',
+  ];
+  const statusHits = statusWords.filter((word) => text.includes(word)).length;
+  const durableHits = durableWords.filter((word) => text.includes(word)).length;
+  return statusHits >= 3 && durableHits === 0;
+}
+
+export function validateMaterializedNoteQuality(
+  note: MaterializedTaskMemoryNote,
+  options: { mode: ValidationMode },
+): NoteQualityDecision {
+  const warnings: string[] = [];
+
+  if (!hasMeaningfulText(note.title, 10, 6) || isGenericTitle(note.title)) {
+    warnings.push('title');
+  }
+  if (!hasMeaningfulText(note.summary)) {
+    warnings.push('summary');
+  }
+  if (!note.key_conclusions.some((item) => hasMeaningfulText(item, 16, 10))) {
+    warnings.push('key_conclusions');
+  }
+  if (!hasDurableReusableSignal(note)) {
+    warnings.push('durable_reusable_lesson');
+  }
+  if (isMostlyOneOffStatus(note)) {
+    warnings.push('one_off_status');
+  }
+
+  const manualReadable =
+    !warnings.includes('title') &&
+    !warnings.includes('summary') &&
+    !warnings.includes('key_conclusions');
+
+  if (warnings.length === 0) {
+    return { accepted: true, reason: 'note-quality-ok', warnings: [] };
+  }
+  if (options.mode === 'manual' && manualReadable) {
+    return {
+      accepted: true,
+      reason: 'manual-note-quality-warning',
+      warnings,
+    };
+  }
+  return { accepted: false, reason: 'low-note-quality', warnings };
+}

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1311,6 +1311,13 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
       .test(text) &&
     /\b(\/api\/[\w/-]+|api route|requests?|route|fallback handler)\b/i
       .test(text);
+  const hasNamedQueueDedupeObject =
+    /\b(summarize(?: --all)?|queue jobs?|conversation jobs?|conversation_id|enqueue(?:d|ing)?|retries|duplicate notes?|duplicate conversation jobs?)\b/i
+      .test(text) &&
+    /\b(duplicate|deduplicate|dedupe|retries|enqueue|enqueued|enqueueing|queue jobs?|conversation jobs?|conversation_id)\b/i
+      .test(text) &&
+    /\b(summarize|queue jobs?|conversation jobs?|conversation_id)\b/i
+      .test(text);
   const hasNamedMigrationObject =
     /\b(sqlite|chatcrystal\.db|migration|migrations?|not null|default|existing rows?|existing \w+ rows?|notes column|column nullable|backfill|constraint)\b/i
       .test(text) &&
@@ -1330,6 +1337,7 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
     hasNamedProcessLifecycleObject ||
     hasNamedProxyRoutingObject ||
     hasNamedSpaFallbackObject ||
+    hasNamedQueueDedupeObject ||
     hasNamedMigrationObject
   ) && hasEngineeringContext;
 }
@@ -1471,6 +1479,10 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
     /\bolder\b.+\b\/api\/search responses?\b.+\b(after a newer query|newer query)\b.+\boverwrite\b.+\bcurrent results\b/i
       .test(text);
   const hasQueueDedupeFlow =
+    /\bsummarize\b.+\bretries\b.+\benqueue\b.+\bduplicate conversation jobs?\b/i
+      .test(text) ||
+    /\benqueue\b.+\bduplicate conversation jobs?\b/i
+      .test(text) ||
     /\b(?:summarize --all|retries|retry)\b.+\benqueued\b.+\bsame conversation_id\b.+\bduplicate notes?\b/i
       .test(text) ||
     /\bqueue jobs?\b.+\bduplicate notes?\b.+\bsame conversation\b/i
@@ -1542,6 +1554,8 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
   const hasSpaFallbackRouteFlow =
     /(?:\/api\/[\w/-]+|\bapi route\b).+\bfell through\b.+\bspa fallback\b.+\bbecause\b.+\bregistered after\b.+\bfallback handler\b/i
       .test(text) ||
+    /\bspa fallback\b.+\broute order\b.+\breturns?\b.+\bhtml\b.+\bapi json\b/i
+      .test(text) ||
     /\bapi route\b.+\bbefore\b.+\bspa fallback\b.+\breturns?\b.+\bjson\b/i
       .test(text) ||
     /\bapi route\b.+\bregistered after\b.+\bfallback handler\b.+\bindex\.html\b.+\bjson\b/i
@@ -1587,7 +1601,7 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
 function hasStrictStructuralEngineeringFailureSignal(value: string) {
   const text = value.toLowerCase();
   const hasNamedConsequence =
-    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|duplicate messages?|duplicate websocket messages?|appended twice|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|orphan note_tags rows?|orphan tags?|unused tags?|count 0|joins? whose note_id no longer existed|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream)|false serve success|dead server|looked like a running server|running server|nonzero exit codes?|non-zero exit codes?|exit code\s*\d+|migration (?:does not )?fail(?:s|ed)?|migration failures?|existing row failures?|constraint violation|violated the constraint|fell through to the spa fallback|clients? received index\.html instead of json|return json instead of index\.html)\b/i
+    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|duplicate conversation jobs?|duplicate messages?|duplicate websocket messages?|appended twice|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|orphan note_tags rows?|orphan tags?|unused tags?|count 0|joins? whose note_id no longer existed|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream)|false serve success|dead server|looked like a running server|running server|nonzero exit codes?|non-zero exit codes?|exit code\s*\d+|migration (?:does not )?fail(?:s|ed)?|migration failures?|existing row failures?|constraint violation|violated the constraint|fell through to the spa fallback|clients? received index\.html instead of json|return json instead of index\.html|returns? html for api json)\b/i
       .test(text);
   const hasCausalFlow =
     /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|left|no longer existed|deleting notes?|note deletion|cleanup|filter|prune|remounts?|unmount|duplicate|deduplicate|dedupe|enqueued|enqueue|pending job|appended twice|spawn handshake|exit event|exit code|nonzero|non-zero|dead server|backfill|not null|default|constraint|violat(?:e|ed|es|ing)|migration|fell through|spa fallback|fallback handler|index\.html)\b/i

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -56,6 +56,7 @@ function hasConcreteTransferableAction(value: string) {
   if (hasPersistenceSerializationAction(text)) return true;
   if (hasElectronResourceAction(text)) return true;
   if (hasCrossPlatformPathAction(text)) return true;
+  if (hasFrontendCacheInvalidationAction(text)) return true;
   const concreteActionWords = [
     'add',
     'block',
@@ -209,6 +210,7 @@ function hasSpecificEvidence(value: string) {
     hasIndexConsistencyEvidence(text) ||
     hasElectronResourceEvidence(text) ||
     hasCrossPlatformPathEvidence(text) ||
+    hasFrontendCacheEvidence(text) ||
     hasHttpFailureSignal(text) ||
     /\b(api requests?|fastify readiness|server readiness|request setup|package metadata|package version|dist output|generated dist output|data directory|electron server|server entrypoint|client calls?)\b/i
       .test(text)
@@ -444,6 +446,46 @@ function hasIndexConsistencyFailureSignal(value: string) {
   return hasIndexConsistencyEvidence(text) && hasStaleReference && hasCausalDeletion;
 }
 
+function hasFrontendCacheEvidence(value: string) {
+  const text = value.toLowerCase();
+  return /\b(react query|query keys?|deletenote|delete mutation|note delete mutation|tags cache|notes cache|sidebar|tag counts?|filter chips?|stale tag filters?|derived tag counts?)\b/i
+    .test(text);
+}
+
+function hasFrontendCacheInvalidationAction(value: string) {
+  const text = value.toLowerCase();
+  const hasCacheAction = /\b(invalidate|invalidated|refetch|reload|refresh|update)\b/i.test(text);
+  const hasCacheTarget = /\b(cache|query keys?|react query|tags?|notes?|tag counts?)\b/i.test(text);
+  return hasFrontendCacheEvidence(text) && hasCacheAction && hasCacheTarget;
+}
+
+function hasFrontendCacheInvalidationMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasInvalidationFlow =
+    /\b(invalidate|invalidated|refetch|reload|refresh|update)\b.+\b(cache|query keys?|react query|tags?|notes?|tag counts?)\b/i
+      .test(text) ||
+    /\b(cache|query keys?|react query|tags?|notes?|tag counts?)\b.+\b(invalidate|invalidated|refetch|reload|refresh|update)\b/i
+      .test(text);
+  const hasMutationOrDeleteContext =
+    /\b(after|when|once|succeeds?|delete|deleted|deletenote|delete mutation|mutation|removed sql row|sql row)\b/i
+      .test(text);
+  return hasFrontendCacheEvidence(text) && hasInvalidationFlow && hasMutationOrDeleteContext;
+}
+
+function hasFrontendCacheFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasStaleUi =
+    /\b(stale|kept stale|does not show stale|cannot show stale|stale tag filters?|stale filter chips?|stale tag counts?|stale note tags?)\b/i
+      .test(text);
+  const hasUiTarget =
+    /\b(sidebar|filter chips?|tag filters?|tag counts?|derived tag counts?|ui|react query|tags cache|notes cache)\b/i
+      .test(text);
+  const hasCausalFlow =
+    /\b(so|because|after|but|did not invalidate|removed|delete|deletion|leaves?)\b/i
+      .test(text);
+  return hasFrontendCacheEvidence(text) && hasStaleUi && hasUiTarget && hasCausalFlow;
+}
+
 function hasElectronResourceEvidence(value: string) {
   const text = value.toLowerCase();
   return /\b(packaged electron|packaged builds?|electron-builder|extraresources|process\.resourcespath|resourcespath|resource path|bundled server code|wasm|sql-wasm\.wasm|sql\.js|enoent|chatcrystal\.db)\b/i
@@ -576,6 +618,7 @@ function hasConcreteMechanism(value: string) {
   const hasIndexConsistencyFlow = hasIndexConsistencyMechanism(text);
   const hasElectronResourceFlow = hasElectronResourceMechanism(text);
   const hasCrossPlatformPathFlow = hasCrossPlatformPathMechanism(text);
+  const hasFrontendCacheFlow = hasFrontendCacheInvalidationMechanism(text);
   return (
     hasTimingOrder ||
     hasRaceReadiness ||
@@ -594,7 +637,8 @@ function hasConcreteMechanism(value: string) {
     hasPersistenceSerializationFlow ||
     hasIndexConsistencyFlow ||
     hasElectronResourceFlow ||
-    hasCrossPlatformPathFlow
+    hasCrossPlatformPathFlow ||
+    hasFrontendCacheFlow
   );
 }
 
@@ -652,7 +696,7 @@ function isFirstPersonDiaryClaim(value: string) {
 function hasChineseFirstPersonDiaryClaim(value: string) {
   const chineseAction = '(?:添加|修复|设置|配置|注册|等待|发现|验证|检查|确认|诊断|切换|更新|实现|改动|修改|处理|解决)';
   const englishAction = '(?:add|added|block|configure|configured|fix|fixed|import|importing|place|placed|register|registered|set|switch|switched|update|updated|validate|validated|verify|verified|wait)';
-  return new RegExp(`(?:我|我们)(?:已经|已)?${chineseAction}|(?:我|我们)(?:把|将).{0,80}(?:${chineseAction}|\\b${englishAction}\\b)`, 'i')
+  return new RegExp(`(?:我|我们)(?:已经|已)?${chineseAction}|(?:我|我们)(?:已经|已)?(?:把|将).{0,80}(?:${chineseAction}|\\b${englishAction}\\b)`, 'i')
     .test(value);
 }
 
@@ -675,6 +719,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     hasIndexConsistencyFailureSignal(value) ||
     hasElectronResourceFailureSignal(value) ||
     hasCrossPlatformPathFailureSignal(value) ||
+    hasFrontendCacheFailureSignal(value) ||
     hasDefaultDataDirectoryConsequence(value) ||
     hasHttpFailureSignal(value)
   );
@@ -1207,7 +1252,7 @@ function hasLowQualityTags(note: MaterializedTaskMemoryNote) {
 function isLowQualityTag(tag: string) {
   const normalized = tag.trim().toLowerCase();
   if (!normalized || isPlaceholderText(normalized)) return true;
-  return /^(fix|bug|issue|bugfix|bug[-_\s]?fix|success|fixed|reliable|reliability|quality|done|verified|test[-_\s]?passed|passed|ok|okay|resolved|working|complete|completed|all[-_\s]?good|status|checked|reviewed|tested|修复|已修复|已验证|测试通过|可靠性|成功|问题|质量)$/i
+  return /^(fix|bug|issue|bugfix|bug[-_\s]?fix|success|fixed|reliable|reliability|quality|done|verified|test[-_\s]?passed|passed|ok|okay|resolved|working|complete|completed|all[-_\s]?good|status|checked|reviewed|tested|修复|已修复|修复完成|已完成|完成|已验证|验证|测试通过|测试|通过|可靠性|成功|状态|检查|问题|质量)$/i
     .test(normalized);
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -103,6 +103,7 @@ function hasConcreteTransferableAction(value: string) {
   if (hasChineseRouteOrderingSignal(text)) return true;
   if (hasNegativeTransferableAction(text)) return true;
   if (hasSchemaDefaultArrayAction(text)) return true;
+  if (hasSchemaBoundaryAction(text)) return true;
   if (hasDurableEngineeringPreventionAction(text)) return true;
   if (hasImportDedupeAction(text)) return true;
   if (hasPersistenceSerializationAction(text)) return true;
@@ -214,6 +215,7 @@ function hasSpecificEvidence(value: string) {
       .test(text) ||
     hasChineseTechnicalEvidence(text) ||
     hasSchemaArrayEvidence(text) ||
+    hasSchemaBoundaryEvidence(text) ||
     hasJsonParsingEvidence(text) ||
     hasProviderBaseUrlEvidence(text) ||
     hasImportContentArrayEvidence(text) ||
@@ -257,6 +259,48 @@ function hasSchemaDefaultArrayMechanism(value: string) {
   const hasIterationOrHandler =
     /\b(iterat(?:e|ed|es|ing|ion)|handler|handler logic)\b/i.test(text);
   return hasSchemaArrayEvidence(text) && hasOptionalOrDefaultArray && hasIterationOrHandler;
+}
+
+function hasSchemaBoundaryEvidence(value: string) {
+  const text = value.toLowerCase();
+  const hasSchemaToken =
+    /(?:\bzod\b|z\.coerce\.[a-z]+\(\)|z\.[a-z]+\(\)|\brequest schema\b|\bdate schemas?\b|\bschema\b)/i
+      .test(text);
+  const hasBoundaryToken =
+    /\b(http boundaries?|json request bodies?|json payloads?|request bodies?|iso date strings?|date instance|handler logic|validation|payloads?)\b/i
+      .test(text);
+  return hasSchemaToken && hasBoundaryToken;
+}
+
+function hasSchemaBoundaryAction(value: string) {
+  const text = value.toLowerCase();
+  const hasCoercionAction =
+    /\b(use|change|set|configure)\b.+\bz\.coerce\.[a-z]+\(\)/i.test(text) ||
+    /\b(coerce|convert|transform)\b.+\b(iso strings?|json request bodies?|request schema|before validation|handler logic)\b/i
+      .test(text) ||
+    /\bz\.coerce\.[a-z]+\(\)\b.+\b(request schema|validation|handler logic)\b/i
+      .test(text);
+  return hasSchemaBoundaryEvidence(text) && hasCoercionAction;
+}
+
+function hasSchemaBoundaryMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasBoundaryConversion =
+    /\b(coercion|coerce|coerce\.[a-z]+|convert|converts?|transform)\b/i.test(text) &&
+    /\b(json|payloads?|request schema|date schemas?|iso strings?|validation|handler logic)\b/i
+      .test(text);
+  const hasJsonTypeMismatch =
+    /\b(json request bodies?|json payloads?|request bodies?)\b.+\b(carry|supplied|supply|strings?|iso date strings?)\b/i
+      .test(text) ||
+    /z\.date\(\).+\b(expected|expects?)\b.+\bdate instance\b.+\b(iso date strings?|json request bodies?|supplied|supply)\b/i
+      .test(text) ||
+    /\bdate instance\b.+\bwhile\b.+\b(json request bodies?|request bodies?|iso date strings?)\b.+\b(supplied|supply|carry)\b/i
+      .test(text);
+  const hasValidationBoundary =
+    /\b(before validation|before handler logic|validation reaches handler logic|handler logic runs?|rejects? them before handler logic)\b/i
+      .test(text);
+  return hasSchemaBoundaryEvidence(text) &&
+    (hasBoundaryConversion || hasJsonTypeMismatch || hasValidationBoundary);
 }
 
 function hasJsonParsingEvidence(value: string) {
@@ -781,6 +825,7 @@ function hasConcreteMechanism(value: string) {
     /\b(rate[- ]limit|http 429|429|retry-after|backoff|delay)\b.+\b(retry|retried|retries|queue|queued|provider requests?)\b/i
       .test(text);
   const hasSchemaDefaultArrayFlow = hasSchemaDefaultArrayMechanism(text);
+  const hasSchemaBoundaryFlow = hasSchemaBoundaryMechanism(text);
   const hasJsonParsingFlow = hasJsonParsingMechanism(text);
   const hasProviderBaseUrlFlow = hasProviderBaseUrlMechanism(text);
   const hasImportContentArrayFlow = hasImportContentArrayMechanism(text);
@@ -807,6 +852,7 @@ function hasConcreteMechanism(value: string) {
     hasParserFieldValidation ||
     hasRetryBackoffFlow ||
     hasSchemaDefaultArrayFlow ||
+    hasSchemaBoundaryFlow ||
     hasJsonParsingFlow ||
     hasProviderBaseUrlFlow ||
     hasImportContentArrayFlow ||
@@ -924,6 +970,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     /\b(race|raced|orphan|dedupe|deduplicate|stale dist|dist diverge|dist diverged|diverge|diverged|econrefused|typeerror|threw|throws?|readiness issue|startup race|invalid note_tags|foreign_keys|cascade|nulling|source_run_key collision)\b/i
       .test(value) ||
     hasSchemaArrayFailureSignal(value) ||
+    hasSchemaBoundaryFailureSignal(value) ||
     hasJsonParsingFailureSignal(value) ||
     hasProviderBaseUrlFailureSignal(value) ||
     hasImportContentArrayFailureSignal(value) ||
@@ -951,6 +998,17 @@ function hasSchemaArrayFailureSignal(value: string) {
   const hasIterationOrHandler =
     /\b(iterat(?:e|ed|es|ing|ion)|handler|handler logic)\b/i.test(text);
   return hasSchemaArrayEvidence(text) && hasArrayFailure && hasIterationOrHandler;
+}
+
+function hasSchemaBoundaryFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasValidationFailure =
+    /\b(http\s*400|returned\s+400|rejects?|rejected|validation failure|before handler logic|before handler logic runs?)\b/i
+      .test(text);
+  const hasCausalFlow =
+    /\b(because|so|before|while|expected|expects?|supplied|supply|carry|convert|converts?)\b/i
+      .test(text);
+  return hasSchemaBoundaryEvidence(text) && hasValidationFailure && hasCausalFlow;
 }
 
 function hasPersistenceSnapshotFailureSignal(value: string) {
@@ -1338,6 +1396,7 @@ function hasConcreteHttpRootCauseSignal(value: string) {
   return hasConcreteRootCauseMechanism(value) ||
     hasRateLimitRetryRootCauseSignal(value) ||
     hasProviderBaseUrlFailureSignal(value) ||
+    hasSchemaBoundaryFailureSignal(value) ||
     (
       hasStrictStructuralEngineeringMechanism(value) &&
       hasStrictStructuralEngineeringFailureSignal(value)
@@ -1475,7 +1534,7 @@ function isVisibleWorkLogClaim(value: string) {
 }
 
 function isExplicitEnglishStatusShell(value: string) {
-  return /^\s*(?:work\s*log|worklog|status\s+record|status|record)\s*:/i
+  return /^\s*(?:work\s*log|worklog|status\s+record|status|record)\s*(?:[:\-\u2013\u2014])/i
     .test(value.trim());
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -235,6 +235,7 @@ function hasStrongRootCauseSignal(value: string) {
   if (isExistenceOnlyClaim(value)) return false;
   if (isPackageArtifactObservationClaim(value)) return false;
   if (isWeakRootCauseClaim(value)) return false;
+  if (hasHttpFailureSignal(value)) return hasConcreteHttpRootCauseSignal(value);
   return (
     hasFailureOrConsequenceSignal(value) ||
     /\b(because|so)\b.+\b(ran before|ran after|returned http [45]\d\d|returned [45]\d\d|http [45]\d\d|imported.+before|used the default data directory|version parsing.+(inconsistent|mismatch|wrong|stale|diverged|diverge)|raced|race|econrefused)\b/i
@@ -300,6 +301,10 @@ function isWeakRootCauseClaim(value: string) {
 function hasConcreteRootCauseMechanism(value: string) {
   return /\b(registration ran after request setup|missing route|route was unregistered|unregistered route|imported .+ after request setup|ran after request setup)\b/i
     .test(value);
+}
+
+function hasConcreteHttpRootCauseSignal(value: string) {
+  return hasConcreteRootCauseMechanism(value);
 }
 
 function hasHttpFailureSignal(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -242,7 +242,7 @@ function isFirstPersonDiaryClaim(value: string) {
     'updated',
     'verified',
   ].join('|');
-  return new RegExp(`(?:^|:\\s*)\\b(?:i|we)\\s+(?:${diaryVerbs})\\b`, 'i')
+  return new RegExp(`(?:^|[:.!?]\\s*)\\b(?:i|we)\\s+(?:${diaryVerbs})\\b`, 'i')
     .test(value);
 }
 
@@ -457,6 +457,7 @@ function hasVisibleTitleQuality(title: string) {
     !isGenericTitle(title) &&
     !isFirstPersonDiaryClaim(title) &&
     !isVagueGenericFixClaim(title) &&
+    !isMetaReusableClaim(title) &&
     !isVisibleStatusSnapshotText(title)
   );
 }
@@ -466,8 +467,17 @@ function hasVisibleSummaryQuality(summary: string) {
     hasNonPlaceholderMeaningfulText(summary) &&
     !isFirstPersonDiaryClaim(summary) &&
     !isVagueGenericFixClaim(summary) &&
+    !isMetaReusableClaim(summary) &&
     !isVisibleStatusSnapshotText(summary)
   );
+}
+
+function isMetaReusableClaim(value: string) {
+  const text = value.toLowerCase();
+  const hasMetaClaim =
+    /\b(reusable lesson|reusable note|future tasks?|this note captures|captures a reusable|for future tasks?)\b/i
+      .test(text);
+  return hasMetaClaim && !hasConcreteMechanism(text);
 }
 
 function isVisibleStatusSnapshotText(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -49,6 +49,7 @@ function hasWord(text: string, word: string) {
 
 function hasConcreteTransferableAction(value: string) {
   const text = value.toLowerCase();
+  if (hasNegativeTransferableAction(text)) return true;
   const concreteActionWords = [
     'add',
     'block',
@@ -94,6 +95,11 @@ function hasConcreteTransferableAction(value: string) {
     '复用',
   ];
   return concreteActionWords.some((word) => hasWord(text, word));
+}
+
+function hasNegativeTransferableAction(text: string) {
+  return /\bdo not\b.+\b(read|write|call|use|access|parse)\b.+\bbefore\b.+\b(validat(?:e|ing)|check(?:ing)?|parse|parsing)\b/i
+    .test(text);
 }
 
 function isVagueGenericLesson(value: string) {
@@ -494,6 +500,7 @@ function hasVisibleTitleQuality(title: string) {
     !isGenericTitle(title) &&
     !isFirstPersonDiaryClaim(title) &&
     !isVisibleWorkLogClaim(title) &&
+    !isLowValueOutcomeStatusClaim(title) &&
     !isVagueGenericFixClaim(title) &&
     !isMetaReusableClaim(title) &&
     !isGenericVisibleBoilerplateClaim(title) &&
@@ -507,6 +514,7 @@ function hasVisibleSummaryQuality(summary: string) {
     hasVisibleConcreteContent(summary) &&
     !isFirstPersonDiaryClaim(summary) &&
     !isVisibleWorkLogClaim(summary) &&
+    !isLowValueOutcomeStatusClaim(summary) &&
     !isVagueGenericFixClaim(summary) &&
     !isMetaReusableClaim(summary) &&
     !isGenericVisibleBoilerplateClaim(summary) &&
@@ -516,6 +524,7 @@ function hasVisibleSummaryQuality(summary: string) {
 
 function hasVisibleConcreteContent(value: string) {
   const text = value.toLowerCase();
+  if (isLowValueOutcomeStatusClaim(text)) return false;
   if (hasSpecificEvidence(text) && hasConcreteMechanism(text)) return true;
   if (hasSpecificEvidence(text) && hasFailureOrConsequenceSignal(text)) return true;
   if (hasPackageDistRootCauseSignal(text)) return true;
@@ -526,6 +535,17 @@ function hasVisibleConcreteContent(value: string) {
 function isVisibleWorkLogClaim(value: string) {
   return /^(added|changed|checked|confirmed|diagnosed|discovered|fixed|found|implemented|noted|observed|reviewed|resolved|switched|tested|testing|updated|verified)\b/i
     .test(value.trim());
+}
+
+function isLowValueOutcomeStatusClaim(value: string) {
+  const text = value.toLowerCase();
+  return (
+    /\ball good(?: now)?\b/i.test(text) ||
+    /\b(issue|task|fix|route fix|route|request|requests?)\b.+\b(investigated|investigation)\b/i
+      .test(text) ||
+    /\b(investigated|investigation)\b.+\b(issue|task|fix|route|request|requests?)\b/i
+      .test(text)
+  );
 }
 
 function isMetaReusableClaim(value: string) {
@@ -630,6 +650,8 @@ function isLowQualityVisibleConclusion(value: string) {
     isFirstPersonDiaryClaim(body) ||
     isVisibleWorkLogClaim(body) ||
     isVisibleStatusSnapshotText(body) ||
+    isLowValueOutcomeStatusClaim(value) ||
+    isLowValueOutcomeStatusClaim(body) ||
     isMetaReusableClaim(value) ||
     isMetaReusableClaim(body) ||
     (shouldApplyGenericLessonGate && isVagueGenericLesson(body)) ||
@@ -646,6 +668,7 @@ function isLowQualityVisibleConclusion(value: string) {
 }
 
 function hasConcreteConclusionValue(value: string) {
+  if (isLowValueOutcomeStatusClaim(value)) return false;
   return (
     hasVisibleConcreteContent(value) ||
     hasConcreteTransferableText(value) ||

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -20,7 +20,7 @@ function hasMeaningfulText(value: string, minLatin = 24, minCjk = 18) {
 }
 
 function isPlaceholderText(value: string) {
-  return /\b(unknown|n\/a|not sure|todo|tbd|appropriate change|fix the issue|task needed investigation|expected behavior|task works correctly|expected pattern|was wrong)\b/i
+  return /\b(unknown|n\/a|not sure|todo|tbd|appropriate change|fix the issue|task needed investigation|expected behavior|task (?:now )?works correctly|now works correctly|expected pattern|was wrong)\b/i
     .test(value);
 }
 
@@ -541,8 +541,26 @@ function hasVisibleStructuredSignal(note: MaterializedTaskMemoryNote) {
 }
 
 function hasVisibleConclusionBoilerplate(note: MaterializedTaskMemoryNote) {
-  return note.key_conclusions.some((item) =>
-    isMetaReusableClaim(item) || isGenericVisibleBoilerplateClaim(item));
+  return note.key_conclusions.some((item) => isLowQualityVisibleConclusion(item));
+}
+
+function isLowQualityVisibleConclusion(value: string) {
+  const body = value.replace(
+    /^\s*(root cause|resolution|pattern|decision|pitfall|takeaway|error signature):\s*/i,
+    '',
+  );
+  return (
+    isPlaceholderText(value) ||
+    isPlaceholderText(body) ||
+    isFirstPersonDiaryClaim(value) ||
+    isFirstPersonDiaryClaim(body) ||
+    isVisibleWorkLogClaim(body) ||
+    isVisibleStatusSnapshotText(body) ||
+    isMetaReusableClaim(value) ||
+    isMetaReusableClaim(body) ||
+    isGenericVisibleBoilerplateClaim(value) ||
+    isGenericVisibleBoilerplateClaim(body)
+  );
 }
 
 function hasVisibleQualitySignal(note: MaterializedTaskMemoryNote) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -65,7 +65,10 @@ function hasConcreteTransferableAction(value: string) {
     'filter',
     'gate',
     'group',
+    'import',
     'index',
+    'initialize',
+    'load',
     'migrate',
     'normalize',
     'parse',
@@ -209,6 +212,7 @@ function hasConcreteMechanism(value: string) {
 }
 
 function hasConcreteTransferableText(value: string) {
+  if (hasPackageDistRootCauseShape(value) && !hasPackageItemSignal(value)) return false;
   return (
     hasNonPlaceholderMeaningfulText(value) &&
     hasConcreteTransferableAction(value) &&
@@ -219,6 +223,12 @@ function hasConcreteTransferableText(value: string) {
     !isGenericStatusAction(value) &&
     !isVagueGenericLesson(value)
   );
+}
+
+function hasPackageItemSignal(value: string) {
+  const text = value.toLowerCase();
+  if (/\b(current|local|status checks?|checked)\b/i.test(text)) return false;
+  return hasPackageDistRootCauseSignal(text);
 }
 
 function hasFailureOrConsequenceSignal(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -118,6 +118,30 @@ function isVagueGenericLesson(value: string) {
   return hasBoilerplateClaim || (hasGenericTerms && !hasSpecificObject(text));
 }
 
+function isVagueGenericFixClaim(value: string) {
+  const text = value.toLowerCase();
+  return (
+    /\b(unknown|n\/a|not sure|todo|tbd|appropriate change|fix the issue|task needed investigation|expected behavior|task works correctly|expected pattern|was wrong)\b/i
+      .test(text) ||
+    /\bvalidation is important for correctness\b/.test(text) ||
+    /\bcorrectness matters\b/.test(text) ||
+    /\bcorrect pattern\b/.test(text) ||
+    /\bright value for reliability\b/.test(text) ||
+    /\bbecause\b.+\bis important for correctness\b/.test(text) ||
+    /\bshould\b.+\bbecause correctness\b/.test(text) ||
+    /\bshould\b.+\bcorrect pattern\b/.test(text) ||
+    /\bbecause it should work\b/.test(text) ||
+    /\bit should work correctly\b/.test(text) ||
+    /\bshould work\b/.test(text) ||
+    /\bshould work correctly\b/.test(text) ||
+    /\bso\b.+\bworks?\b/.test(text) ||
+    /\badd api config\b/.test(text) ||
+    /\bcache server config\b/.test(text) ||
+    /\bbetter approach\b/.test(text) ||
+    /\bhandle\b.+\bproperly\b/.test(text)
+  );
+}
+
 function isGenericStatusAction(value: string) {
   const text = value.toLowerCase();
   const hasGenericAction = ['validate', 'investigate', 'check', 'checked', 'persist', 'record', 'recorded']
@@ -182,9 +206,15 @@ function hasConcreteTransferableText(value: string) {
     hasConcreteTransferableAction(value) &&
     hasSpecificEvidence(value) &&
     hasConcreteMechanism(value) &&
+    hasFailureOrConsequenceSignal(value) &&
     !isGenericStatusAction(value) &&
     !isVagueGenericLesson(value)
   );
+}
+
+function hasFailureOrConsequenceSignal(value: string) {
+  return /\b(avoid|prevents?|fix(?:es)?|fail(?:s|ed|ure|ures)?|race|raced|orphan|dedupe|deduplicate|stale|diverge|diverged|fallback|fell back|default data directory|econrefused|readiness issue|startup race|unreliable|invalid|mismatch)\b/i
+    .test(value);
 }
 
 function hasActionableResolution(value: string) {
@@ -192,7 +222,7 @@ function hasActionableResolution(value: string) {
     hasNonPlaceholderMeaningfulText(value) &&
     hasConcreteTransferableAction(value) &&
     !isGenericStatusAction(value) &&
-    !isVagueGenericLesson(value)
+    !isVagueGenericFixClaim(value)
   );
 }
 
@@ -208,7 +238,7 @@ function hasDurableFixSignal(note: MaterializedTaskMemoryNote) {
     hasSpecificEvidence(combined) &&
     hasConcreteMechanism(combined) &&
     !isGenericStatusAction(rootCause) &&
-    !isVagueGenericLesson(rootCause)
+    !isVagueGenericFixClaim(rootCause)
   );
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -251,15 +251,16 @@ function hasStrongRootCauseSignal(value: string) {
 function isExistenceOnlyClaim(value: string) {
   const text = value.toLowerCase();
   const hasExistencePhrase =
-    /\b(existed|exists|was present|were present|present during|is available|was available|on disk|is on disk|was on disk)\b/
+    /\b(existed|exists|was present|were present|present during|is available|was available|on disk|is on disk|was on disk|was there|were there|there was|there were)\b/
       .test(text);
   return hasExistencePhrase && !hasDefaultDataDirectoryConsequence(text);
 }
 
 function hasDefaultDataDirectoryConsequence(value: string) {
-  return /\b(prevents?|preventing|avoid|avoids|avoiding)\b.+\bfallback\b.+\bdefault data directory\b/i
+  return /\b(prevents?|preventing|avoid|avoids|avoiding)\b.+\b(fallback\b.+\bdefault data directory|default data directory fallback)\b/i
     .test(value) ||
     /\b(fallback|fell back)\b.+\bdefault data directory\b/i.test(value) ||
+    /\bdefault data directory fallback\b/i.test(value) ||
     /\bused the default data directory\b/i.test(value);
 }
 
@@ -297,17 +298,22 @@ function hasDurableFixSignal(note: MaterializedTaskMemoryNote) {
 }
 
 function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
-  if (isMostlyOneOffStatus(note)) return false;
   const payload = note.raw_payload;
-  const conclusions = note.key_conclusions.join('\n').toLowerCase();
+  const hasVisibleSignal = hasVisibleQualitySignal(note);
+  const hasFixSignal = hasDurableFixSignal(note);
+  if (hasFixSignal) return hasVisibleSignal;
+  if (isMostlyOneOffStatus(note)) return false;
+
   const hasStructuredSignal =
-    hasDurableFixSignal(note) ||
     Boolean(payload.reusable_patterns?.some((item) => hasConcreteTransferableText(item))) ||
     Boolean(payload.pitfalls?.some((item) => hasConcreteTransferableText(item))) ||
     Boolean(payload.decisions?.some((item) => hasConcreteTransferableText(item)));
-  const hasVisibleSignal =
-    /root cause:|resolution:|pitfall:|pattern:|decision:|error signature:/i.test(conclusions);
   return hasStructuredSignal && hasVisibleSignal;
+}
+
+function hasVisibleQualitySignal(note: MaterializedTaskMemoryNote) {
+  const conclusions = note.key_conclusions.join('\n').toLowerCase();
+  return /root cause:|resolution:|pitfall:|pattern:|decision:|error signature:/i.test(conclusions);
 }
 
 function isMostlyOneOffStatus(note: MaterializedTaskMemoryNote) {
@@ -362,6 +368,7 @@ export function validateMaterializedNoteQuality(
   options: { mode: ValidationMode },
 ): NoteQualityDecision {
   const warnings: string[] = [];
+  const acceptedDurableFix = hasDurableFixSignal(note) && hasVisibleQualitySignal(note);
 
   if (!hasMeaningfulText(note.title, 10, 6) || isGenericTitle(note.title)) {
     warnings.push('title');
@@ -375,7 +382,7 @@ export function validateMaterializedNoteQuality(
   if (!hasDurableReusableSignal(note)) {
     warnings.push('durable_reusable_lesson');
   }
-  if (isMostlyOneOffStatus(note)) {
+  if (!acceptedDurableFix && isMostlyOneOffStatus(note)) {
     warnings.push('one_off_status');
   }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -35,12 +35,18 @@ function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
   if (isMostlyOneOffStatus(note)) return false;
   const payload = note.raw_payload;
   const conclusions = note.key_conclusions.join('\n').toLowerCase();
+  const hasMeaningfulRootCause = Boolean(
+    payload.root_cause && hasMeaningfulText(payload.root_cause),
+  );
+  const hasMeaningfulResolution = Boolean(
+    payload.resolution && hasMeaningfulText(payload.resolution),
+  );
   const hasStructuredSignal =
-    Boolean(payload.root_cause && payload.resolution) ||
+    (hasMeaningfulRootCause && hasMeaningfulResolution) ||
     Boolean(payload.reusable_patterns?.some((item) => hasMeaningfulText(item))) ||
     Boolean(payload.pitfalls?.some((item) => hasMeaningfulText(item))) ||
     Boolean(payload.decisions?.some((item) => hasMeaningfulText(item))) ||
-    Boolean(payload.error_signatures?.length && (payload.root_cause || payload.resolution));
+    Boolean(payload.error_signatures?.length && (hasMeaningfulRootCause || hasMeaningfulResolution));
   const hasVisibleSignal =
     /root cause:|resolution:|pitfall:|pattern:|decision:|error signature:/i.test(conclusions);
   return hasStructuredSignal && hasVisibleSignal;
@@ -63,29 +69,43 @@ function isMostlyOneOffStatus(note: MaterializedTaskMemoryNote) {
     '检查',
     '状态',
   ];
-  const reusableLessonWords = [
-    'avoid',
-    'because',
-    'cause',
-    'causes',
-    'must',
-    'should',
-    'pattern',
-    'prevent',
-    'prevents',
-    'rationale',
-    'reuse',
-    'transferable',
+  const concreteActionWords = [
+    'block',
+    'cache',
+    'collapse',
+    'debounce',
+    'deduplicate',
+    'defer',
+    'enqueue',
+    'extract',
+    'filter',
+    'gate',
+    'group',
+    'index',
+    'migrate',
+    'normalize',
+    'parse',
+    'persist',
+    'prune',
+    'retry',
+    'sanitize',
+    'truncate',
+    'validate',
+    'wait for',
     '避免',
-    '模式',
-    '必须',
-    '应该',
     '防止',
     '复用',
   ];
   const statusHits = statusWords.filter((word) => text.includes(word)).length;
-  const reusableLessonHits = reusableLessonWords.filter((word) => text.includes(word)).length;
-  return statusHits >= 3 && reusableLessonHits === 0;
+  const hasConcreteTransferableAction = text
+    .split(/[.!?。！？\n]+/)
+    .some((sentence) => {
+      const sentenceStatusHits = statusWords.filter((word) => sentence.includes(word)).length;
+      const sentenceActionHits = concreteActionWords
+        .filter((word) => sentence.includes(word)).length;
+      return sentenceStatusHits === 0 && sentenceActionHits > 0;
+    });
+  return statusHits >= 3 && !hasConcreteTransferableAction;
 }
 
 export function validateMaterializedNoteQuality(

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -384,6 +384,8 @@ function hasActionableResolution(value: string) {
 
 function isGenericResolutionClaim(value: string) {
   return /\b(add|use|apply)\b.+\bvalidation\b.+\b(prevent|avoid)\b.+\b(future failures?|failures?|issues?)\b/i
+    .test(value) ||
+    /\bvalidate\b.+\b(?:to\s+)?(?:prevent|avoid)\b.+\b(future failures?|failures?|issues?)\b/i
     .test(value);
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -267,7 +267,8 @@ function hasPackageDistRootCauseShape(value: string) {
 function hasPackageDistRootCauseSignal(value: string) {
   const text = value.toLowerCase();
   const packageMechanism = '(?:version parsing|parsing|version normalization|normalization|normalize|normalized|different formats|inconsistent normalization|comparison|comparing|version bump|bumping package metadata|dist generation|generated dist output)';
-  const packageOutcome = '(?:diverged|divergence|mismatch|stale(?: package metadata| output| dist)?|wrong comparison|comparison failure|dist comparisons? unreliable|differed from package metadata|differed from package version)';
+  const packageOutcome = '(?:diverged|divergence|mismatch|stale(?: package metadata| output| dist)?|wrong comparison|comparison failure|dist comparisons? unreliable|differ(?:ed|s)? from package metadata|differ(?:ed|s)? from package version)';
+  const hasExplicitCausality = hasExplicitPackageCausality(text);
   const hasPositiveSignal =
     new RegExp(`\\b(package metadata|package version|generated dist output|dist output)\\b.+\\b${packageOutcome}\\b.+\\bbecause\\b.+\\b${packageMechanism}\\b.+\\b(inconsistent|different formats|mismatch|wrong|stale)\\b`, 'i')
       .test(text) ||
@@ -281,10 +282,10 @@ function hasPackageDistRootCauseSignal(value: string) {
       .test(text) ||
     /\b(generated dist output|dist output)\b.+\bstale\b.+\bbecause\b.+\bdist generation\b.+\bran before\b.+\b(package metadata )?version bump\b/i
       .test(text);
-  if ((isPackageArtifactObservationClaim(text) || isExistenceOnlyClaim(text)) && !hasExplicitPackageCausality(text)) {
+  if ((isPackageArtifactObservationClaim(text) || isExistenceOnlyClaim(text)) && !hasExplicitCausality) {
     return false;
   }
-  if (hasPositiveSignal) return true;
+  if (hasPositiveSignal || hasExplicitCausality) return true;
   if (isPackageArtifactObservationClaim(text) || isExistenceOnlyClaim(text)) return false;
   return false;
 }
@@ -292,9 +293,9 @@ function hasPackageDistRootCauseSignal(value: string) {
 function hasExplicitPackageCausality(value: string) {
   const text = value.toLowerCase();
   return (
-    /\b(diverged|divergence|mismatch|stale(?: package metadata| output| dist)?|wrong comparison|comparison failure|dist comparisons? unreliable|differed from package metadata|differed from package version)\b.+\bbecause\b.+\b(version parsing|parsing|version normalization|normalization|normalize|normalized|different formats|inconsistent normalization|comparison|comparing)\b/i
+    /\b(diverged|divergence|mismatch|stale(?: package metadata| output| dist)?|wrong comparison|comparison failure|dist comparisons? unreliable|differ(?:ed|s)? from package metadata|differ(?:ed|s)? from package version)\b.+\bbecause\b.+\b(version parsing|parsing|version normalization|normalization|normalize|normalized|different formats|inconsistent normalization|comparison|comparing)\b/i
       .test(text) ||
-    /\b(version parsing|parsing|version normalization|normalization|normalize|normalized|different formats|inconsistent normalization|comparison|comparing)\b.+\b(caused|produced|led to|made)\b.+\b(diverged|divergence|mismatch|stale(?: package metadata| output| dist)?|wrong comparison|comparison failure|dist comparisons? unreliable|differed from package metadata|differed from package version)\b/i
+    /\b(version parsing|parsing|version normalization|normalization|normalize|normalized|different formats|inconsistent normalization|comparison|comparing)\b.+\b(caused|produced|led to|made)\b.+\b(diverged|divergence|mismatch|stale(?: package metadata| output| dist)?|wrong comparison|comparison failure|dist comparisons? unreliable|differ(?:ed|s)? from package metadata|differ(?:ed|s)? from package version)\b/i
       .test(text)
   );
 }
@@ -345,6 +346,8 @@ function hasConcreteRootCauseMechanism(value: string) {
       .test(text);
   const hasMissingRouteMechanism =
     /\b(route|\/api\/[\w/-]+)\b.+\b(missing|unregistered|was missing|was unregistered)\b.+\b(before request setup|before api requests?|api requests?|request setup)\b/i
+      .test(text) ||
+    /\b(route|\/api\/[\w/-]+)\b.+\b(was not registered|not registered)\b.+\b(before request setup|before api requests?|api requests?|request setup)\b/i
       .test(text) ||
     /\b(missing|unregistered)\b.+\b(route|\/api\/[\w/-]+)\b.+\b(before request setup|before api requests?|api requests?|request setup)\b/i
       .test(text);

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1010,17 +1010,37 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
   const hasConcreteToken =
     /\b[a-z0-9]+_[a-z0-9_]+\b|\b[a-z][a-z0-9_]*\.[a-z_][a-z0-9_]*\b|\/api\/[\w/-]+/i
       .test(text);
-  const hasEngineeringContext =
-    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl)\b/i
+  const hasNamedDbObject =
+    /\b(unique\s*\([^)]*\)|writeback receipts?|writeback_receipts|receipt rows?|source_agent|source_run_key|write_task_memory)\b/i
+      .test(text) ||
+    /\b(unique key|unique constraint)\b.+\b(writeback|receipt|source_agent|source_run_key)\b/i
+      .test(text) ||
+    /\b(writeback|receipt|source_agent|source_run_key)\b.+\b(unique key|unique constraint)\b/i
       .test(text);
-  return hasConcreteToken && hasEngineeringContext;
+  const hasNamedAsyncObject =
+    /\b(abortcontroller|react search|search view|\/api\/search|stale search requests?|stale responses?|previous responses?|current query results?|current results|overlapping requests?|overlapping \/api\/search requests?)\b/i
+      .test(text);
+  const hasEngineeringContext =
+    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?)\b/i
+      .test(text);
+  return (hasConcreteToken || hasNamedDbObject || hasNamedAsyncObject) && hasEngineeringContext;
 }
 
 function hasStrictStructuralEngineeringAction(value: string) {
   const text = value.toLowerCase();
-  return hasStrictStructuralEngineeringEvidence(text) &&
-    /\b(add|create|remove|wrap|validate|normalize|configure|set|index)\b/i
+  const hasAction =
+    /\b(add|create|remove|wrap|validate|normalize|configure|set|index|return|reuse|cancel|use)\b/i
       .test(text);
+  const hasConcreteDbAction =
+    /\b(add|create)\b.+\b(unique\s*\([^)]*\)|unique key|unique constraint|constraint|index|idx_[a-z0-9_]+)\b/i
+      .test(text) ||
+    /\b(return|reuse)\b.+\b(existing receipt row|first note|existing row)\b/i
+      .test(text);
+  const hasConcreteAsyncAction =
+    /\b(use\b.+\babortcontroller|abortcontroller\b.+\bcancel|cancel(?: older| previous| prior)?\b.+\b(?:\/api\/search|requests?|responses?))\b/i
+      .test(text);
+  return hasStrictStructuralEngineeringEvidence(text) &&
+    (hasAction || hasConcreteDbAction || hasConcreteAsyncAction);
 }
 
 function hasStrictStructuralEngineeringMechanism(value: string) {
@@ -1034,25 +1054,49 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
   const hasFilterWithoutIndex =
     /\b(filtered|filtering)\b.+\bby\b.+\b[a-z_][a-z0-9_]*\b.+\bwithout an index\b/i
       .test(text);
+  const hasUniquenessConstraintFlow =
+    /\b(unique\s*\([^)]*\)|unique key|unique constraint)\b.+\b(prevents?|preventing|duplicate rows?|duplicate notes?|receipt rows?)\b/i
+      .test(text) ||
+    /\b(retried|retries|retry|reused|reuse)\b.+\b(source_run_key|same source_run_key|same run|one agent run|write_task_memory)\b.+\b(duplicate receipt rows?|duplicate rows?|duplicate notes?|no unique|unique constraint)\b/i
+      .test(text) ||
+    /\b(no|without|had no)\b.+\b(unique\s*\([^)]*\)|unique key|unique constraint)\b.+\b(duplicate receipt rows?|duplicate rows?|duplicate notes?)\b/i
+      .test(text) ||
+    /\b(return|reuse)\b.+\b(existing receipt row|existing row|first note)\b.+\b(retries|reuse|instead of inserting duplicate rows?)\b/i
+      .test(text) ||
+    /\b(source_run_key|writeback_receipts|receipt rows?)\b.+\b(unique\s*\([^)]*\)|unique key|unique constraint|duplicate receipt rows?|duplicate notes?)\b/i
+      .test(text);
+  const hasStaleAsyncResponseFlow =
+    /\b(overlapping|slower previous|previous|older|stale)\b.+\b(\/api\/search|search requests?|responses?)\b.+\b(overwrote|overwrite|replace|current query results?|current results)\b/i
+      .test(text) ||
+    /\b(overwrote|overwrite|replace)\b.+\b(current query results?|current results)\b/i
+      .test(text) ||
+    /\b(cancel|abortcontroller)\b.+\b(previous|older|prior|stale)\b.+\b(\/api\/search|requests?|responses?)\b/i
+      .test(text) ||
+    /\b(cancel|abortcontroller)\b.+\b(before starting the next query|before updating results|next query)\b/i
+      .test(text) ||
+    /\bstale responses?\b.+\b(cannot|do not|does not)\b.+\b(replace|overwrite)\b.+\bcurrent results\b/i
+      .test(text);
   const hasCausalFlow =
-    /\b(because|so|caused|without|instead of|before|avoid|avoids|prevent|prevents|timed out)\b/i
+    /\b(because|so|but|caused|without|instead of|before|after|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing)\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) &&
     hasCausalFlow &&
     (
       (hasIndexDefinition && hasLookupScanFlow) ||
       hasFilterWithoutIndex ||
-      hasLookupScanFlow
+      hasLookupScanFlow ||
+      hasUniquenessConstraintFlow ||
+      hasStaleAsyncResponseFlow
     );
 }
 
 function hasStrictStructuralEngineeringFailureSignal(value: string) {
   const text = value.toLowerCase();
   const hasNamedConsequence =
-    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row)\b/i
+    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|stale responses?|overwrote the current query results?|overwrote current results?|replace current results?)\b/i
       .test(text);
   const hasCausalFlow =
-    /\b(because|so|caused|without|instead of|before|avoid|avoids|prevent|prevents)\b/i
+    /\b(because|so|but|caused|without|instead of|before|after|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing)\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) && hasNamedConsequence && hasCausalFlow;
 }

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -87,24 +87,22 @@ function isMostlyOneOffStatus(note: MaterializedTaskMemoryNote) {
     'parse',
     'persist',
     'prune',
+    'rebuild',
     'retry',
     'sanitize',
     'truncate',
     'validate',
+    'compare',
+    'comparing',
+    'wait',
     'wait for',
     '避免',
     '防止',
     '复用',
   ];
   const statusHits = statusWords.filter((word) => text.includes(word)).length;
-  const hasConcreteTransferableAction = text
-    .split(/[.!?。！？\n]+/)
-    .some((sentence) => {
-      const sentenceStatusHits = statusWords.filter((word) => sentence.includes(word)).length;
-      const sentenceActionHits = concreteActionWords
-        .filter((word) => sentence.includes(word)).length;
-      return sentenceStatusHits === 0 && sentenceActionHits > 0;
-    });
+  const hasConcreteTransferableAction = concreteActionWords
+    .some((word) => text.includes(word));
   return statusHits >= 3 && !hasConcreteTransferableAction;
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -54,6 +54,7 @@ function hasConcreteTransferableAction(value: string) {
   if (hasDurableEngineeringPreventionAction(text)) return true;
   if (hasImportDedupeAction(text)) return true;
   if (hasPersistenceSerializationAction(text)) return true;
+  if (hasElectronResourceAction(text)) return true;
   const concreteActionWords = [
     'add',
     'block',
@@ -205,6 +206,7 @@ function hasSpecificEvidence(value: string) {
     hasContentSanitizationEvidence(text) ||
     hasPersistenceSnapshotEvidence(text) ||
     hasIndexConsistencyEvidence(text) ||
+    hasElectronResourceEvidence(text) ||
     hasHttpFailureSignal(text) ||
     /\b(api requests?|fastify readiness|server readiness|request setup|package metadata|package version|dist output|generated dist output|data directory|electron server|server entrypoint|client calls?)\b/i
       .test(text)
@@ -440,6 +442,48 @@ function hasIndexConsistencyFailureSignal(value: string) {
   return hasIndexConsistencyEvidence(text) && hasStaleReference && hasCausalDeletion;
 }
 
+function hasElectronResourceEvidence(value: string) {
+  const text = value.toLowerCase();
+  return /\b(packaged electron|packaged builds?|electron-builder|extraresources|process\.resourcespath|resourcespath|resource path|bundled server code|wasm|sql-wasm\.wasm|sql\.js|enoent|chatcrystal\.db)\b/i
+    .test(text);
+}
+
+function hasElectronResourceAction(value: string) {
+  const text = value.toLowerCase();
+  const hasResourceAction =
+    /\b(add|include|copy|resolve|load|initialize|open)\b/i.test(text);
+  const hasResourceTarget =
+    /\b(sql-wasm\.wasm|wasm|process\.resourcespath|resourcespath|extraresources|resource path|resources?|sql\.js|chatcrystal\.db)\b/i
+      .test(text);
+  return hasElectronResourceEvidence(text) && hasResourceAction && hasResourceTarget;
+}
+
+function hasElectronResourceMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasResourcePathFlow =
+    /\b(add|include|copy|resolve|load)\b.+\b(sql-wasm\.wasm|wasm|process\.resourcespath|resourcespath|extraresources|resource path|resources?|sql\.js)\b/i
+      .test(text) ||
+    /\b(sql-wasm\.wasm|wasm|process\.resourcespath|resourcespath|extraresources|resource path|resources?|sql\.js)\b.+\b(add|include|copy|resolve|load)\b/i
+      .test(text);
+  const hasPackagedResourceFlow =
+    /\b(packaged electron|packaged builds?|electron-builder|bundled server code)\b.+\b(sql-wasm\.wasm|wasm|resource|resourcespath|extraresources|copy|copied|location)\b/i
+      .test(text) ||
+    /\b(sql-wasm\.wasm|wasm|resource|resourcespath|extraresources|copy|copied|location)\b.+\b(packaged electron|packaged builds?|electron-builder|bundled server code)\b/i
+      .test(text);
+  return hasElectronResourceEvidence(text) && (hasResourcePathFlow || hasPackagedResourceFlow);
+}
+
+function hasElectronResourceFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasResourceFailure =
+    /\b(enoent|initialization throws?|throws? enoent|missing resource|not copied|did not copy|cannot open|cannot init|cannot initialize|failed to open|failed to initialize)\b/i
+      .test(text);
+  const hasCausalFlow =
+    /\b(because|when|but|relative to|before|without|not copied|did not copy)\b/i
+      .test(text);
+  return hasElectronResourceEvidence(text) && hasResourceFailure && hasCausalFlow;
+}
+
 function hasConcreteMechanism(value: string) {
   const text = value.toLowerCase();
   const hasGenericReleaseValidation = isGenericReleaseValidationClaim(text);
@@ -489,6 +533,7 @@ function hasConcreteMechanism(value: string) {
   const hasContentSanitizationFlow = hasContentSanitizationMechanism(text);
   const hasPersistenceSerializationFlow = hasPersistenceSerializationMechanism(text);
   const hasIndexConsistencyFlow = hasIndexConsistencyMechanism(text);
+  const hasElectronResourceFlow = hasElectronResourceMechanism(text);
   return (
     hasTimingOrder ||
     hasRaceReadiness ||
@@ -505,7 +550,8 @@ function hasConcreteMechanism(value: string) {
     hasImportDedupeFlow ||
     hasContentSanitizationFlow ||
     hasPersistenceSerializationFlow ||
-    hasIndexConsistencyFlow
+    hasIndexConsistencyFlow ||
+    hasElectronResourceFlow
   );
 }
 
@@ -576,6 +622,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     hasContentSanitizationFailureSignal(value) ||
     hasPersistenceSnapshotFailureSignal(value) ||
     hasIndexConsistencyFailureSignal(value) ||
+    hasElectronResourceFailureSignal(value) ||
     hasDefaultDataDirectoryConsequence(value) ||
     hasHttpFailureSignal(value)
   );
@@ -1106,7 +1153,7 @@ function hasLowQualityTags(note: MaterializedTaskMemoryNote) {
 function isLowQualityTag(tag: string) {
   const normalized = tag.trim().toLowerCase();
   if (!normalized || isPlaceholderText(normalized)) return true;
-  return /^(success|fixed|reliable|done|verified|test[-_\s]?passed|passed|ok|okay|resolved|working|complete|completed|all[-_\s]?good)$/i
+  return /^(fix|bugfix|bug[-_\s]?fix|success|fixed|reliable|done|verified|test[-_\s]?passed|passed|ok|okay|resolved|working|complete|completed|all[-_\s]?good|status|checked|reviewed|tested)$/i
     .test(normalized);
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -105,6 +105,7 @@ function hasConcreteTransferableAction(value: string) {
   if (hasImportDedupeAction(text)) return true;
   if (hasPersistenceSerializationAction(text)) return true;
   if (hasDbTransactionAtomicityAction(text)) return true;
+  if (hasStrictStructuralEngineeringAction(text)) return true;
   if (hasElectronResourceAction(text)) return true;
   if (hasCrossPlatformPathAction(text)) return true;
   if (hasFrontendCacheInvalidationAction(text)) return true;
@@ -219,6 +220,7 @@ function hasSpecificEvidence(value: string) {
     hasContentSanitizationEvidence(text) ||
     hasPersistenceSnapshotEvidence(text) ||
     hasDbTransactionAtomicityEvidence(text) ||
+    hasStrictStructuralEngineeringEvidence(text) ||
     hasIndexConsistencyEvidence(text) ||
     hasElectronResourceEvidence(text) ||
     hasCrossPlatformPathEvidence(text) ||
@@ -775,6 +777,7 @@ function hasConcreteMechanism(value: string) {
   const hasContentSanitizationFlow = hasContentSanitizationMechanism(text);
   const hasPersistenceSerializationFlow = hasPersistenceSerializationMechanism(text);
   const hasDbTransactionAtomicityFlow = hasDbTransactionAtomicityMechanism(text);
+  const hasStrictStructuralEngineeringFlow = hasStrictStructuralEngineeringMechanism(text);
   const hasIndexConsistencyFlow = hasIndexConsistencyMechanism(text);
   const hasElectronResourceFlow = hasElectronResourceMechanism(text);
   const hasCrossPlatformPathFlow = hasCrossPlatformPathMechanism(text);
@@ -799,6 +802,7 @@ function hasConcreteMechanism(value: string) {
     hasContentSanitizationFlow ||
     hasPersistenceSerializationFlow ||
     hasDbTransactionAtomicityFlow ||
+    hasStrictStructuralEngineeringFlow ||
     hasIndexConsistencyFlow ||
     hasElectronResourceFlow ||
     hasCrossPlatformPathFlow ||
@@ -912,6 +916,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     hasContentSanitizationFailureSignal(value) ||
     hasPersistenceSnapshotFailureSignal(value) ||
     hasDbTransactionAtomicityFailureSignal(value) ||
+    hasStrictStructuralEngineeringFailureSignal(value) ||
     hasIndexConsistencyFailureSignal(value) ||
     hasElectronResourceFailureSignal(value) ||
     hasCrossPlatformPathFailureSignal(value) ||
@@ -948,7 +953,7 @@ function hasDbTransactionAtomicityEvidence(value: string) {
   const hasDbImportContext = /\b(sql\.js|database|db|import|imports?|conversation imports?)\b/i
     .test(text);
   const hasAtomicityTarget =
-    /\b(conversation rows?|message rows?|conversation row|message insert|message inserts?|conversation inserts?|transaction|rollback|roll back|partial conversation rows?|partial rows?)\b/i
+    /\b(conversation rows?|message rows?|conversation row|conversation|message insert|message inserts?|message insert throws?|thrown message insert|conversation inserts?|transaction|rollback|roll back|partial conversation rows?|partial rows?|incomplete conversations?)\b/i
       .test(text);
   return hasDbImportContext && hasAtomicityTarget;
 }
@@ -958,7 +963,7 @@ function hasDbTransactionAtomicityAction(value: string) {
   const hasTransactionAction =
     /\b(wrap|begin|commit|rollback|roll back|use)\b/i.test(text);
   const hasRelatedInsertTarget =
-    /\b(transaction|conversation and message inserts?|conversation rows?|message rows?|message inserts?|failed imports?|whole conversation)\b/i
+    /\b(transaction|conversation and message inserts?|conversation rows?|message rows?|message inserts?|failed imports?|whole conversation|incomplete conversations?)\b/i
       .test(text);
   return hasDbTransactionAtomicityEvidence(text) && hasTransactionAction && hasRelatedInsertTarget;
 }
@@ -971,28 +976,85 @@ function hasDbTransactionAtomicityMechanism(value: string) {
     /\btransaction\b.+\b(conversation|message|insert|imports?)\b/i
       .test(text);
   const hasRollbackFlow =
-    /\b(failed imports?|failed message insert|failure)\b.+\b(rollback|roll back|partial|whole conversation)\b/i
+    /\b(failed imports?|failed message insert|thrown message insert|message insert throws?|any message insert throws?|failure)\b.+\b(rollback|roll back|partial|whole conversation|incomplete conversations?)\b/i
       .test(text) ||
-    /\b(rollback|roll back)\b.+\b(failed imports?|failed message insert|whole conversation)\b/i
+    /\b(rollback|roll back)\b.+\b(failed imports?|failed message insert|message insert throws?|any message insert throws?|whole conversation)\b/i
       .test(text);
   const hasPartialInsertFlow =
     /\binserted\b.+\bconversation row\b.+\bbefore\b.+\bmessage rows?\b/i
       .test(text) ||
-    /\bfailed message insert\b.+\bleft\b.+\bpartial conversation rows?\b/i
+    /\b(thrown|failed) message insert\b.+\bleft\b.+\b(partial conversation rows?|incomplete conversations?)\b/i
+      .test(text) ||
+    /\bwrote\b.+\bconversation\b.+\bbefore\b.+\bmessages\b/i
+      .test(text);
+  const hasPreventionSummaryFlow =
+    /\btransaction\b.+\b(prevents?|avoids?)\b.+\b(partial conversation rows?|partial rows?|incomplete conversations?)\b/i
       .test(text);
   return hasDbTransactionAtomicityEvidence(text) &&
-    ((hasTransactionWrapFlow && hasRollbackFlow) || hasPartialInsertFlow);
+    ((hasTransactionWrapFlow && hasRollbackFlow) || hasPartialInsertFlow || hasPreventionSummaryFlow);
 }
 
 function hasDbTransactionAtomicityFailureSignal(value: string) {
   const text = value.toLowerCase();
   const hasPartialImportConsequence =
-    /\b(partial conversation rows?|partial rows?|failed message insert left|incomplete import|inconsistent data)\b/i
+    /\b(partial conversation rows?|partial rows?|failed message insert left|thrown message insert left|incomplete conversations?|incomplete import|inconsistent data)\b/i
       .test(text);
   const hasCausalFlow =
     /\b(because|so|failed|left|prevents?|rolls? back|rollback|roll back|before)\b/i
       .test(text);
   return hasDbTransactionAtomicityEvidence(text) && hasPartialImportConsequence && hasCausalFlow;
+}
+
+function hasStrictStructuralEngineeringEvidence(value: string) {
+  const text = value.toLowerCase();
+  const hasConcreteToken =
+    /\b[a-z0-9]+_[a-z0-9_]+\b|\b[a-z][a-z0-9_]*\.[a-z_][a-z0-9_]*\b|\/api\/[\w/-]+/i
+      .test(text);
+  const hasEngineeringContext =
+    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl)\b/i
+      .test(text);
+  return hasConcreteToken && hasEngineeringContext;
+}
+
+function hasStrictStructuralEngineeringAction(value: string) {
+  const text = value.toLowerCase();
+  return hasStrictStructuralEngineeringEvidence(text) &&
+    /\b(add|create|remove|wrap|validate|normalize|configure|set|index)\b/i
+      .test(text);
+}
+
+function hasStrictStructuralEngineeringMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasIndexDefinition =
+    /\b(add|create)\b.+\b(index|idx_[a-z0-9_]+)\b.+\b(on|for)\b.+\b[a-z][a-z0-9_]*\.[a-z_][a-z0-9_]*\b/i
+      .test(text);
+  const hasLookupScanFlow =
+    /\b(indexed lookup|uses? an indexed lookup|full table scans?|scanned the full \w+ table|scanning every \w+ row|request timeouts?|timed out)\b/i
+      .test(text);
+  const hasFilterWithoutIndex =
+    /\b(filtered|filtering)\b.+\bby\b.+\b[a-z_][a-z0-9_]*\b.+\bwithout an index\b/i
+      .test(text);
+  const hasCausalFlow =
+    /\b(because|so|caused|without|instead of|before|avoid|avoids|prevent|prevents|timed out)\b/i
+      .test(text);
+  return hasStrictStructuralEngineeringEvidence(text) &&
+    hasCausalFlow &&
+    (
+      (hasIndexDefinition && hasLookupScanFlow) ||
+      hasFilterWithoutIndex ||
+      hasLookupScanFlow
+    );
+}
+
+function hasStrictStructuralEngineeringFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasNamedConsequence =
+    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row)\b/i
+      .test(text);
+  const hasCausalFlow =
+    /\b(because|so|caused|without|instead of|before|avoid|avoids|prevent|prevents)\b/i
+      .test(text);
+  return hasStrictStructuralEngineeringEvidence(text) && hasNamedConsequence && hasCausalFlow;
 }
 
 function hasStrongRootCauseSignal(value: string) {
@@ -1083,7 +1145,10 @@ function isWeakRootCauseClaim(value: string) {
   const hasWeakPhrase =
     /\b(not correct before|was not correct|not configured correctly|was wrong|incomplete|not proper|not properly|properly)\b/
       .test(text);
-  return hasWeakPhrase && !hasConcreteRootCauseMechanism(text);
+  return hasWeakPhrase &&
+    !hasConcreteRootCauseMechanism(text) &&
+    !hasDbTransactionAtomicityFailureSignal(text) &&
+    !hasStrictStructuralEngineeringFailureSignal(text);
 }
 
 function hasConcreteRootCauseMechanism(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -208,6 +208,11 @@ function hasConcreteMechanism(value: string) {
       .test(text) ||
     /\b(before|after|without content|validat(?:e|ing)|read(?:ing)?|skips?)\b.+\b(typeerror|parser|parsing|jsonl|response_item\.content|partial events?|partial codex events?|event shape|parser fields)\b/i
       .test(text);
+  const hasRetryBackoffFlow =
+    /\b(retry|retried|retries|queue|queued|provider requests?)\b.+\b(rate[- ]limit|http 429|429|retry-after|backoff|delay|resuming batch summarization)\b/i
+      .test(text) ||
+    /\b(rate[- ]limit|http 429|429|retry-after|backoff|delay)\b.+\b(retry|retried|retries|queue|queued|provider requests?)\b/i
+      .test(text);
   return (
     hasTimingOrder ||
     hasRaceReadiness ||
@@ -216,7 +221,8 @@ function hasConcreteMechanism(value: string) {
     hasRelationalCleanup ||
     hasDedupeKey ||
     hasRequestFailureOrdering ||
-    hasParserFieldValidation
+    hasParserFieldValidation ||
+    hasRetryBackoffFlow
   );
 }
 
@@ -397,7 +403,18 @@ function hasGenericRootCauseRationale(value: string) {
 }
 
 function hasConcreteHttpRootCauseSignal(value: string) {
-  return hasConcreteRootCauseMechanism(value);
+  return hasConcreteRootCauseMechanism(value) || hasRateLimitRetryRootCauseSignal(value);
+}
+
+function hasRateLimitRetryRootCauseSignal(value: string) {
+  const text = value.toLowerCase();
+  return (
+    /\b(http\s*)?429\b/.test(text) &&
+    /\b(rate[- ]limit|retry-after|backoff|queue|queued|provider api requests?|provider requests?)\b/i
+      .test(text) &&
+    /\b(retried immediately|retry immediately|without rate[- ]limit backoff|without backoff|backoff|retry-after|delay)\b/i
+      .test(text)
+  );
 }
 
 function hasHttpFailureSignal(value: string) {
@@ -608,7 +625,7 @@ function isLowQualityVisibleConclusion(value: string) {
     isMetaReusableClaim(value) ||
     isMetaReusableClaim(body) ||
     (shouldApplyGenericLessonGate && isVagueGenericLesson(body)) ||
-    (shouldApplyGenericLessonGate && isVagueGenericFixClaim(body)) ||
+    isVagueGenericFixClaim(body) ||
     (shouldApplyGenericLessonGate && !hasConcreteConclusionValue(body)) ||
     isGenericVisibleBoilerplateClaim(value) ||
     isGenericVisibleBoilerplateClaim(body)

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -75,6 +75,7 @@ function hasConcreteTransferableAction(value: string) {
     'pin',
     'prune',
     'rebuild',
+    'regenerate',
     'register',
     'remove',
     'replace',
@@ -265,7 +266,7 @@ function hasPackageDistRootCauseShape(value: string) {
 
 function hasPackageDistRootCauseSignal(value: string) {
   const text = value.toLowerCase();
-  const packageMechanism = '(?:version parsing|parsing|version normalization|normalization|normalize|normalized|different formats|inconsistent normalization|comparison|comparing)';
+  const packageMechanism = '(?:version parsing|parsing|version normalization|normalization|normalize|normalized|different formats|inconsistent normalization|comparison|comparing|version bump|bumping package metadata|dist generation|generated dist output)';
   const packageOutcome = '(?:diverged|divergence|mismatch|stale(?: package metadata| output| dist)?|wrong comparison|comparison failure|dist comparisons? unreliable|differed from package metadata|differed from package version)';
   const hasPositiveSignal =
     new RegExp(`\\b(package metadata|package version|generated dist output|dist output)\\b.+\\b${packageOutcome}\\b.+\\bbecause\\b.+\\b${packageMechanism}\\b.+\\b(inconsistent|different formats|mismatch|wrong|stale)\\b`, 'i')
@@ -275,6 +276,8 @@ function hasPackageDistRootCauseSignal(value: string) {
     new RegExp(`\\b(inconsistent|different formats)\\b.+\\b(version parsing|package version parsing|version normalization|package normalization)\\b.+\\b(generated dist output|dist output|dist comparisons?|dist)\\b.+\\b${packageOutcome}\\b`, 'i')
       .test(text) ||
     /\b(inconsistent|different formats)\b.+\b(version parsing|package version parsing|version normalization|package normalization)\b.+\bdist comparisons?\b.+\bunreliable\b/i
+      .test(text) ||
+    /\b(generated dist output|dist output)\b.+\bstale package metadata\b.+\bbecause\b.+\bversion bump\b.+\bran after\b.+\bdist generation\b/i
       .test(text);
   if ((isPackageArtifactObservationClaim(text) || isExistenceOnlyClaim(text)) && !hasExplicitPackageCausality(text)) {
     return false;

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -408,7 +408,9 @@ function hasDurableFixSignal(note: MaterializedTaskMemoryNote) {
     hasSpecificEvidence(combined) &&
     hasConcreteMechanism(combined) &&
     !isGenericStatusAction(rootCause) &&
-    !isVagueGenericFixClaim(rootCause)
+    !isVagueGenericFixClaim(rootCause) &&
+    !isFirstPersonDiaryClaim(rootCause) &&
+    !isFirstPersonDiaryClaim(resolution)
   );
 }
 
@@ -424,10 +426,13 @@ function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
     Boolean(payload.reusable_patterns?.some((item) => hasConcreteTransferableText(item))) ||
     Boolean(payload.pitfalls?.some((item) => hasConcreteTransferableText(item))) ||
     Boolean(payload.decisions?.some((item) => hasConcreteTransferableText(item)));
-  return hasStructuredSignal && hasVisibleSignal;
+  return hasStructuredSignal && hasVisibleStructuredSignal(note) && hasVisibleSignal;
 }
 
-function conclusionText(note: MaterializedTaskMemoryNote, label: 'root cause' | 'resolution') {
+function conclusionText(
+  note: MaterializedTaskMemoryNote,
+  label: 'root cause' | 'resolution' | 'pattern' | 'decision' | 'pitfall',
+) {
   const pattern = new RegExp(`^\\s*${label}:\\s*(.+)$`, 'i');
   return note.key_conclusions
     .map((item) => pattern.exec(item)?.[1]?.trim())
@@ -441,10 +446,19 @@ function hasVisibleConcreteFixSignal(note: MaterializedTaskMemoryNote) {
     rootCauses.some((item) =>
       hasNonPlaceholderMeaningfulText(item) &&
       hasStrongRootCauseSignal(item) &&
+      !isFirstPersonDiaryClaim(item) &&
       !isVagueGenericFixClaim(item),
     ) &&
-    resolutions.some((item) => hasActionableResolution(item))
+    resolutions.some((item) => hasActionableResolution(item) && !isFirstPersonDiaryClaim(item))
   );
+}
+
+function hasVisibleStructuredSignal(note: MaterializedTaskMemoryNote) {
+  return [
+    ...conclusionText(note, 'pattern'),
+    ...conclusionText(note, 'decision'),
+    ...conclusionText(note, 'pitfall'),
+  ].some((item) => hasConcreteTransferableText(item));
 }
 
 function hasVisibleQualitySignal(note: MaterializedTaskMemoryNote) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -118,6 +118,7 @@ function hasConcreteTransferableAction(value: string) {
   if (hasEmbeddingModelConfigAction(text)) return true;
   if (hasEsmImportExtensionAction(text)) return true;
   if (hasImportContentArrayAction(text)) return true;
+  if (hasSignatureRawBodyAction(text)) return true;
   return concreteActionWords.some((word) => hasWord(text, word));
 }
 
@@ -224,6 +225,7 @@ function hasSpecificEvidence(value: string) {
     hasEmbeddingModelConfigEvidence(text) ||
     hasEsmImportExtensionEvidence(text) ||
     hasImportContentArrayEvidence(text) ||
+    hasSignatureRawBodyEvidence(text) ||
     hasDurableEngineeringEvidence(text) ||
     hasImportDedupeEvidence(text) ||
     hasContentSanitizationEvidence(text) ||
@@ -527,6 +529,54 @@ function hasImportContentArrayFailureSignal(value: string) {
       .test(text);
   const hasCausalFlow = /\b(so|because|instead of|produced|lost|missing)\b/i.test(text);
   return hasImportContentArrayEvidence(text) && hasContentLoss && hasCausalFlow;
+}
+
+function hasSignatureRawBodyEvidence(value: string) {
+  const text = value.toLowerCase();
+  return /\b(hmac|signature verification|webhook signatures?|webhook signature|rawbody|raw body|raw request body|signed bytes?|json\.parse|request body)\b/i
+    .test(text) &&
+    /\b(hmac|signature|webhook|rawbody|raw body|raw request body|signed bytes?)\b/i
+      .test(text);
+}
+
+function hasSignatureRawBodyAction(value: string) {
+  const text = value.toLowerCase();
+  const hasRawBodyAction =
+    /\b(read|use|preserve|verify)\b.+\b(rawbody|raw body|raw request body|hmac|signature)\b.+\b(before|over|json\.parse|parsing|signed bytes?)\b/i
+      .test(text) ||
+    /\bverify\b.+\b(hmac|signature)\b.+\b(rawbody|raw body|raw request body)\b/i
+      .test(text) ||
+    /\b(rawbody|raw body|raw request body)\b.+\b(before|hmac|signature|json\.parse|parsing)\b/i
+      .test(text);
+  return hasSignatureRawBodyEvidence(text) && hasRawBodyAction;
+}
+
+function hasSignatureRawBodyMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasRawBodySignatureFlow =
+    /\b(hmac|signature)\b.+\b(rawbody|raw body|raw request body|signed bytes?)\b/i
+      .test(text) ||
+    /\b(rawbody|raw body|raw request body)\b.+\b(hmac|signature|json\.parse|parsing)\b/i
+      .test(text);
+  const hasParsingByteChangeFlow =
+    /\bjson\.parse\b.+\b(reconstructed|changed|normalize|normalized|signed bytes?|hmac|signature|request body)\b/i
+      .test(text) ||
+    /\bparsing\b.+\b(normalize|normalized|change|changed)\b.+\b(bytes?|request body|signed bytes?)\b/i
+      .test(text) ||
+    /\brequest body\b.+\bbefore\b.+\b(hmac|signature)\b.+\bchanged\b.+\bsigned bytes?\b/i
+      .test(text);
+  return hasSignatureRawBodyEvidence(text) && (hasRawBodySignatureFlow || hasParsingByteChangeFlow);
+}
+
+function hasSignatureRawBodyFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasSignatureFailure =
+    /\b(http\s*400|returned\s+http\s*400|valid signatures? fail|valid signatures? (?:are )?not rejected|signatures? (?:are )?not rejected|signatures? (?:are )?rejected|signature verification returned)\b/i
+      .test(text);
+  const hasCausalFlow =
+    /\b(because|so|before|after|can|could|changed|normalize|normalized|reconstructed|fail|rejected)\b/i
+      .test(text);
+  return hasSignatureRawBodyEvidence(text) && hasSignatureFailure && hasCausalFlow;
 }
 
 function hasDurableEngineeringEvidence(value: string) {
@@ -956,6 +1006,7 @@ function hasConcreteMechanism(value: string) {
   const hasEmbeddingModelConfigFlow = hasEmbeddingModelConfigMechanism(text);
   const hasEsmImportExtensionFlow = hasEsmImportExtensionMechanism(text);
   const hasImportContentArrayFlow = hasImportContentArrayMechanism(text);
+  const hasSignatureRawBodyFlow = hasSignatureRawBodyMechanism(text);
   const hasDurableEngineeringFlow = hasDurableEngineeringMechanism(text);
   const hasImportDedupeFlow = hasImportDedupeMechanism(text);
   const hasContentSanitizationFlow = hasContentSanitizationMechanism(text);
@@ -986,6 +1037,7 @@ function hasConcreteMechanism(value: string) {
     hasEmbeddingModelConfigFlow ||
     hasEsmImportExtensionFlow ||
     hasImportContentArrayFlow ||
+    hasSignatureRawBodyFlow ||
     hasDurableEngineeringFlow ||
     hasImportDedupeFlow ||
     hasContentSanitizationFlow ||
@@ -1122,6 +1174,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     hasEmbeddingModelConfigFailureSignal(value) ||
     hasEsmImportExtensionFailureSignal(value) ||
     hasImportContentArrayFailureSignal(value) ||
+    hasSignatureRawBodyFailureSignal(value) ||
     hasDurableEngineeringFailureSignal(value) ||
     hasImportDedupeFailureSignal(value) ||
     hasContentSanitizationFailureSignal(value) ||
@@ -1773,6 +1826,7 @@ function hasStrongRootCauseSignal(value: string) {
   if (isPackageArtifactObservationClaim(value)) return false;
   if (hasGenericRootCauseRationale(value)) return false;
   if (isWeakRootCauseClaim(value)) return false;
+  if (hasSignatureRawBodyFailureSignal(value)) return true;
   if (hasHttpFailureSignal(value)) return hasConcreteHttpRootCauseSignal(value);
   return (
     hasFailureOrConsequenceSignal(value) ||
@@ -2087,6 +2141,7 @@ function isPredicateResultStatusShell(value: string) {
 
 function hasTechnicalPrefixStatusShell(value: string) {
   const text = value.trim();
+  if (hasSignatureRawBodyFailureSignal(text)) return false;
   const descriptorWord = String.raw`(?:api|search|vite|proxy|fastify|react|sqlite|database|mcp|websocket|codex|claude|import|jsonl|electron|daemon|embedding|llm|route)`;
   const chineseDescriptorWord = String.raw`(?:搜索|接口|代理|路由|导入|数据库|前端|后端)`;
   const englishDescriptorPrefix = String.raw`(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,3})`;
@@ -2235,6 +2290,8 @@ function isGenericVisibleBoilerplateClaim(value: string) {
 function isGenericReleaseValidationClaim(value: string) {
   const text = value.toLowerCase();
   return (
+    /\b(?:release\s+)?(?:validat(?:e|ed|ing|ion)|verified?)\b.+(?:\/api\/[\w/-]+|api requests?|requests?)\b.+\bbefore (?:release|shipping)\b/i.test(text) ||
+    /(?:\/api\/[\w/-]+|api requests?|requests?)\b.+\b(?:validat(?:e|ed|ing|ion)|verified?)\b.+\bbefore (?:release|shipping)\b/i.test(text) ||
     /\bvalidat(?:e|ing|ion)\b.+(?:\/api\/[\w/-]+|api requests?|requests?)\b.+\bbefore release\b/i.test(text) ||
     /\bvalidat(?:e|ing|ion)\b.+\b(api requests?|requests?)\b.+\bbefore release\b/i.test(text) ||
     /\b(api requests?|requests?)\b.+\bvalidat(?:e|ing|ion)\b.+\bbefore release\b/i.test(text)
@@ -2242,7 +2299,7 @@ function isGenericReleaseValidationClaim(value: string) {
 }
 
 function isVisibleStatusSnapshotText(value: string) {
-  const hasPassStatus = /\b(build|npm test|tests?|testing|typecheck|lint|ci|verification|checks?)\b.+\bpassed\b/i
+  const hasPassStatus = /\b(build|npm test|tests?|testing|typecheck|lint|ci|verification|checks?|smoke(?: tests?)?)\b.+\bpassed\b/i
     .test(value);
   const hasSuccessStatus =
     /\b(ci green|ci completed successfully|tests? succeeded|testing succeeded|verification succeeded|build succeeded|typecheck succeeded|lint succeeded)\b/i
@@ -2259,7 +2316,7 @@ function isVisibleStatusSnapshotText(value: string) {
   const hasStatusVerb = /\b(checked|noted|observed|reviewed|resolved|tested|testing passed|verified|verification|current|status)\b/i
     .test(value);
   const hasChineseStatus =
-    /已验证|验证通过|测试通过|构建通过|编译通过|类型检查通过|检查通过|检查已通过|已修复|修复已验证|ci\s*通过|持续集成通过/i
+    /已验证|验证通过|验证已通过|测试通过|构建通过|编译通过|类型检查通过|检查通过|检查已通过|冒烟通过|验收通过|已修复|修复已验证|ci\s*通过|持续集成通过/i
       .test(value) ||
     isChineseVisibleStatusShell(value) ||
     /(?:提高|提升).{0,12}(?:可靠性|正确性)|(?:可靠性|正确性).{0,12}(?:提高|提升)/

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1919,7 +1919,7 @@ function isVisibleWorkLogClaim(value: string) {
 
 function isExplicitEnglishStatusShell(value: string) {
   return hasTechnicalPrefixStatusShell(value) ||
-    /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task|progress)\s+(?:record|report|note|summary|update|log|entry)|(?:implementation|task|fix|execution|run|work|status)\s+results?|run\s+results?|work\s*log(?:\s+entry)?|worklog(?:\s+entry)?|status|record|update|implementation|result|outcome|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
+    /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task|progress|verification)\s+(?:record|report|note|summary|update|log|entry|check)|(?:implementation|task|fix|execution|run|work|status)\s+results?|run\s+results?|work\s*log(?:\s+entry)?|worklog(?:\s+entry)?|status|record|update|implementation|result|outcome|progress|verification|check|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
       .test(value.trim()) ||
     isCurrentRunImplementationShell(value) ||
     isCurrentRunStatusObservationClaim(value);
@@ -1932,8 +1932,8 @@ function hasTechnicalPrefixStatusShell(value: string) {
   const englishDescriptorPrefix = String.raw`(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,3})`;
   const chineseDescriptorPrefix = String.raw`(?:[\u3400-\u9fff]{2,16})`;
   const technicalPrefix = String.raw`(?:\/api\/[\w/-]+|[a-z0-9]+_[a-z0-9_]+|[a-z][a-z0-9_]*\.[a-z_][a-z0-9_]*|activerequestid|setresults|data_dir|node_env|child_process|jsonl|sqlite|sql\.js|websocket|mcp|json-rpc|${descriptorWord}(?:\s+${descriptorWord}){0,2}|${chineseDescriptorWord}(?:\s+${chineseDescriptorWord}){0,2}|${englishDescriptorPrefix}|${chineseDescriptorPrefix})`;
-  const englishShell = String.raw`(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task|progress)\s+(?:record|report|note|summary|update|log|entry)|(?:status|record|update|implementation|result|outcome|completion(?:\s+(?:note|record))?|completed|done))`;
-  const chineseShell = String.raw`(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|运行结果|执行结果|结果记录|结果报告|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|状态|结果|完成|已完成|完成说明)`;
+  const englishShell = String.raw`(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task|progress|verification)\s+(?:record|report|note|summary|update|log|entry|check)|(?:status|record|update|implementation|result|outcome|progress|verification|check|completion(?:\s+(?:note|record))?|completed|done))`;
+  const chineseShell = String.raw`(?:状态记录|记录状态|状态检查|工作日志|日志记录|工作记录|执行记录|完成记录|完成检查|状态更新|运行结果|执行结果|结果记录|结果报告|结果检查|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|状态|结果|进度|验证|完成|已完成|完成说明)`;
   return new RegExp(`^\\s*${technicalPrefix}\\s+${englishShell}\\s*(?:[:\\-\\u2013\\u2014])`, 'i')
     .test(text) ||
     new RegExp(`^\\s*${technicalPrefix}\\s+${englishShell}\\s+(?:for|on|about)\\b`, 'i')
@@ -2003,7 +2003,7 @@ function isChineseVisibleStatusShell(value: string) {
   if (!/[\u3400-\u9fff]/.test(value)) return false;
   const hasStatusRecordShell =
     hasTechnicalPrefixStatusShell(value) ||
-    /^\s*(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|运行结果|执行结果|结果记录|结果报告|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|结果|完成|已完成|完成说明)\s*(?:[：:\-\u2013\u2014]|$)/i
+    /^\s*(?:状态记录|记录状态|状态检查|工作日志|日志记录|工作记录|执行记录|完成记录|完成检查|状态更新|运行结果|执行结果|结果记录|结果报告|结果检查|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|结果|进度|验证|完成|已完成|完成说明)\s*(?:[：:\-\u2013\u2014]|$)/i
       .test(value) ||
     /(?:^|[\s：:])(?:状态记录|记录状态|工作日志|日志记录|工作记录)(?:[\s：:]|$)|^(?:状态|记录)\s*[：:]/i
       .test(value) ||

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -213,8 +213,22 @@ function hasConcreteTransferableText(value: string) {
 }
 
 function hasFailureOrConsequenceSignal(value: string) {
-  return /\b(race|raced|orphan|dedupe|deduplicate|stale dist|dist diverge|dist diverged|diverge|diverged|fallback|fell back|default data directory|econrefused|readiness issue|startup race|unreliable|invalid note_tags|foreign_keys|cascade|nulling|source_run_key collision)\b/i
+  return /\b(race|raced|orphan|dedupe|deduplicate|stale dist|dist diverge|dist diverged|diverge|diverged|fallback|fell back|default data directory|econrefused|readiness issue|startup race|invalid note_tags|foreign_keys|cascade|nulling|source_run_key collision)\b/i
     .test(value);
+}
+
+function hasStrongRootCauseSignal(value: string) {
+  return (
+    hasFailureOrConsequenceSignal(value) ||
+    /\b(version parsing|package metadata|package version)\b.+\b(dist comparison|dist comparisons|generated dist output|dist output)\b/i
+      .test(value) ||
+    /\b(dist comparison|dist comparisons|generated dist output|dist output)\b.+\b(version parsing|package metadata|package version)\b/i
+      .test(value) ||
+    /\b(because|so)\b.+\b(ran before|imported.+before|used the default data directory|version parsing|generated dist output|default data directory|fell back|fallback|diverged|raced|race|econrefused)\b/i
+      .test(value) ||
+    /\b(ran before|imported.+before|used the default data directory|version parsing|generated dist output|default data directory|fell back|fallback|diverged|raced|race|econrefused)\b.+\b(because|so)\b/i
+      .test(value)
+  );
 }
 
 function hasActionableResolution(value: string) {
@@ -234,6 +248,7 @@ function hasDurableFixSignal(note: MaterializedTaskMemoryNote) {
   const combined = `${rootCause}\n${resolution}`;
   return (
     hasNonPlaceholderMeaningfulText(rootCause) &&
+    hasStrongRootCauseSignal(rootCause) &&
     hasActionableResolution(resolution) &&
     hasSpecificEvidence(combined) &&
     hasConcreteMechanism(combined) &&

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1010,14 +1010,17 @@ function isFirstPersonDiaryClaim(value: string) {
   const diaryVerbs = Array.from(new Set([
     ...concreteActionWords.filter((word) => !/[\u3400-\u9fff]/.test(word)),
     'added',
+    'adds',
     'changed',
     'checked',
     'confirmed',
     'configured',
+    'configures',
     'diagnosed',
     'discovered',
     'fixed',
     'found',
+    'gates',
     'implemented',
     'imported',
     'caused',
@@ -1037,6 +1040,8 @@ function isFirstPersonDiaryClaim(value: string) {
     'updated',
     'use',
     'used',
+    'uses',
+    'sets',
     'verified',
   ]))
     .map(regexEscape)

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -51,6 +51,7 @@ function hasConcreteTransferableAction(value: string) {
   const text = value.toLowerCase();
   if (hasNegativeTransferableAction(text)) return true;
   if (hasSchemaDefaultArrayAction(text)) return true;
+  if (hasPersistenceSerializationAction(text)) return true;
   const concreteActionWords = [
     'add',
     'block',
@@ -110,6 +111,14 @@ function hasSchemaDefaultArrayAction(text: string) {
     /\b(schema|z\.array|default\(\[\]\)|empty array|omitted items?)\b.+\b(default|materializ(?:e|ed)|empty array)\b/i
       .test(text)
   );
+}
+
+function hasPersistenceSerializationAction(text: string) {
+  return hasPersistenceSnapshotEvidence(text) &&
+    /\b(queue|queued|serialize|serialized|route|routed|call|called|saveDatabase|p-queue)\b/i
+      .test(text) &&
+    /\b(writes?|mutations?|save|transaction|snapshots?|rows|database|db)\b/i
+      .test(text);
 }
 
 function isVagueGenericLesson(value: string) {
@@ -186,6 +195,7 @@ function hasSpecificEvidence(value: string) {
     /\b(data_dir|node_env|econrefused|typeerror|note_tags|chatcrystal\.db|port|source_run_key|foreign_keys)\b|\/api\/[\w/-]+|\b[a-z0-9]+_[a-z0-9_]+\b|[a-z]:\\|\/[\w.-]+|[\u3400-\u9fff]/i
       .test(text) ||
     hasSchemaArrayEvidence(text) ||
+    hasPersistenceSnapshotEvidence(text) ||
     hasHttpFailureSignal(text) ||
     /\b(api requests?|fastify readiness|server readiness|request setup|package metadata|package version|dist output|generated dist output|data directory|electron server|server entrypoint|client calls?)\b/i
       .test(text)
@@ -210,6 +220,30 @@ function hasSchemaDefaultArrayMechanism(value: string) {
   const hasIterationOrHandler =
     /\b(iterat(?:e|ed|es|ing|ion)|handler|handler logic)\b/i.test(text);
   return hasSchemaArrayEvidence(text) && hasOptionalOrDefaultArray && hasIterationOrHandler;
+}
+
+function hasPersistenceSnapshotEvidence(value: string) {
+  const text = value.toLowerCase();
+  return /\b(sql\.js|chatcrystal\.db|savedatabase|p-queue|db writes?|db mutations?|db snapshots?|database snapshots?|committed rows|in-memory connection|auto-save)\b/i
+    .test(text);
+}
+
+function hasPersistenceSerializationMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasPersistenceFlow =
+    /\b(auto-save|persist|persisted|saveDatabase|snapshots?|db bytes|bytes|committed rows|transaction|stale state|stale snapshots?|stale chatcrystal\.db|overwrite|newer rows)\b/i
+      .test(text);
+  const hasMutationConcurrency =
+    /\b(concurrent|concurrently|same in-memory connection|same sql\.js database|mutat(?:e|ed|es|ing|ion)|later save|overwrite|while)\b/i
+      .test(text);
+  const hasSerialization =
+    /\b(queue|queued|serialize|serialized|p-queue|through one p-queue|after the transaction|route|routed|saveDatabase after)\b/i
+      .test(text);
+  return hasPersistenceSnapshotEvidence(text) &&
+    (
+      (hasSerialization && hasPersistenceFlow) ||
+      (hasPersistenceFlow && hasMutationConcurrency)
+    );
 }
 
 function hasConcreteMechanism(value: string) {
@@ -255,6 +289,7 @@ function hasConcreteMechanism(value: string) {
     /\b(rate[- ]limit|http 429|429|retry-after|backoff|delay)\b.+\b(retry|retried|retries|queue|queued|provider requests?)\b/i
       .test(text);
   const hasSchemaDefaultArrayFlow = hasSchemaDefaultArrayMechanism(text);
+  const hasPersistenceSerializationFlow = hasPersistenceSerializationMechanism(text);
   return (
     hasTimingOrder ||
     hasRaceReadiness ||
@@ -265,7 +300,8 @@ function hasConcreteMechanism(value: string) {
     hasRequestFailureOrdering ||
     hasParserFieldValidation ||
     hasRetryBackoffFlow ||
-    hasSchemaDefaultArrayFlow
+    hasSchemaDefaultArrayFlow ||
+    hasPersistenceSerializationFlow
   );
 }
 
@@ -330,6 +366,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     /\b(race|raced|orphan|dedupe|deduplicate|stale dist|dist diverge|dist diverged|diverge|diverged|econrefused|typeerror|threw|throws?|readiness issue|startup race|invalid note_tags|foreign_keys|cascade|nulling|source_run_key collision)\b/i
       .test(value) ||
     hasSchemaArrayFailureSignal(value) ||
+    hasPersistenceSnapshotFailureSignal(value) ||
     hasDefaultDataDirectoryConsequence(value) ||
     hasHttpFailureSignal(value)
   );
@@ -343,6 +380,17 @@ function hasSchemaArrayFailureSignal(value: string) {
   const hasIterationOrHandler =
     /\b(iterat(?:e|ed|es|ing|ion)|handler|handler logic)\b/i.test(text);
   return hasSchemaArrayEvidence(text) && hasArrayFailure && hasIterationOrHandler;
+}
+
+function hasPersistenceSnapshotFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasSnapshotFailure =
+    /\b(stale|overwrite|newer rows|committed rows|persist stale|stale state|stale snapshots?|snapshot mismatch|snapshots? match)\b/i
+      .test(text);
+  const hasCausalFlow =
+    /\b(because|while|so|concurrent|concurrently|same in-memory connection|mutat(?:e|ed|es|ing|ion)|auto-save|later save|overwrite|transaction)\b/i
+      .test(text);
+  return hasPersistenceSnapshotEvidence(text) && hasSnapshotFailure && hasCausalFlow;
 }
 
 function hasStrongRootCauseSignal(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -109,6 +109,7 @@ function hasConcreteTransferableAction(value: string) {
   if (hasFrontendCacheInvalidationAction(text)) return true;
   if (hasSqliteWalSidecarAction(text)) return true;
   if (hasProviderBaseUrlAction(text)) return true;
+  if (hasImportContentArrayAction(text)) return true;
   return concreteActionWords.some((word) => hasWord(text, word));
 }
 
@@ -211,6 +212,7 @@ function hasSpecificEvidence(value: string) {
     hasSchemaArrayEvidence(text) ||
     hasJsonParsingEvidence(text) ||
     hasProviderBaseUrlEvidence(text) ||
+    hasImportContentArrayEvidence(text) ||
     hasDurableEngineeringEvidence(text) ||
     hasImportDedupeEvidence(text) ||
     hasContentSanitizationEvidence(text) ||
@@ -329,6 +331,45 @@ function hasProviderBaseUrlFailureSignal(value: string) {
     hasHttpNotFound &&
     hasWrongEndpointFlow &&
     hasCausalFlow;
+}
+
+function hasImportContentArrayEvidence(value: string) {
+  const text = value.toLowerCase();
+  return /\b(codex adapter|codex jsonl|response_item\.content|content arrays?|array-shaped assistant content|assistant content|assistant messages?|imported conversation messages?|empty imported conversation messages?|text fragments?)\b/i
+    .test(text);
+}
+
+function hasImportContentArrayAction(value: string) {
+  const text = value.toLowerCase();
+  const hasAction =
+    /\b(parse|parsed|extract|extracted|join|joined|save|saving)\b/i.test(text);
+  const hasTarget =
+    /\b(response_item\.content|content arrays?|assistant content|text fragments?|conversation messages?|assistant messages?)\b/i
+      .test(text);
+  return hasImportContentArrayEvidence(text) && hasAction && hasTarget;
+}
+
+function hasImportContentArrayMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasStringVsArrayFlow =
+    /\btreated\b.+\bresponse_item\.content\b.+\bplain string\b/i.test(text) ||
+    /\barray-shaped assistant content\b/i.test(text) ||
+    /\bresponse_item\.content arrays?\b/i.test(text);
+  const hasParseJoinFlow =
+    /\b(parse|extract)\b.+\b(response_item\.content|content arrays?)\b.+\b(join|text fragments?|save|saving|conversation messages?)\b/i
+      .test(text) ||
+    /\b(join|joined)\b.+\btext fragments?\b.+\b(before saving|conversation messages?|assistant messages?)\b/i
+      .test(text);
+  return hasImportContentArrayEvidence(text) && (hasStringVsArrayFlow || hasParseJoinFlow);
+}
+
+function hasImportContentArrayFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasContentLoss =
+    /\b(empty turns?|empty imported conversation messages?|empty messages?|missing assistant text|lost assistant text|lost assistant content|missing assistant content|without assistant text)\b/i
+      .test(text);
+  const hasCausalFlow = /\b(so|because|instead of|produced|lost|missing)\b/i.test(text);
+  return hasImportContentArrayEvidence(text) && hasContentLoss && hasCausalFlow;
 }
 
 function hasDurableEngineeringEvidence(value: string) {
@@ -726,6 +767,7 @@ function hasConcreteMechanism(value: string) {
   const hasSchemaDefaultArrayFlow = hasSchemaDefaultArrayMechanism(text);
   const hasJsonParsingFlow = hasJsonParsingMechanism(text);
   const hasProviderBaseUrlFlow = hasProviderBaseUrlMechanism(text);
+  const hasImportContentArrayFlow = hasImportContentArrayMechanism(text);
   const hasDurableEngineeringFlow = hasDurableEngineeringMechanism(text);
   const hasImportDedupeFlow = hasImportDedupeMechanism(text);
   const hasContentSanitizationFlow = hasContentSanitizationMechanism(text);
@@ -748,6 +790,7 @@ function hasConcreteMechanism(value: string) {
     hasSchemaDefaultArrayFlow ||
     hasJsonParsingFlow ||
     hasProviderBaseUrlFlow ||
+    hasImportContentArrayFlow ||
     hasDurableEngineeringFlow ||
     hasImportDedupeFlow ||
     hasContentSanitizationFlow ||
@@ -852,6 +895,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     hasSchemaArrayFailureSignal(value) ||
     hasJsonParsingFailureSignal(value) ||
     hasProviderBaseUrlFailureSignal(value) ||
+    hasImportContentArrayFailureSignal(value) ||
     hasDurableEngineeringFailureSignal(value) ||
     hasImportDedupeFailureSignal(value) ||
     hasContentSanitizationFailureSignal(value) ||
@@ -1409,6 +1453,7 @@ function hasUsefulCodeSnippet(
     hasSchemaArrayEvidence(combined) ||
     hasJsonParsingEvidence(combined) ||
     hasProviderBaseUrlEvidence(combined) ||
+    hasImportContentArrayEvidence(combined) ||
     hasContentSanitizationEvidence(combined) ||
     hasPersistenceSnapshotEvidence(combined) ||
     hasIndexConsistencyEvidence(combined) ||
@@ -1431,7 +1476,12 @@ function isPlaceholderFunctionCallSnippet(code: string) {
   if (!args) return true;
   return args
     .split(',')
-    .every((arg) => /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?$/.test(arg.trim()));
+    .every((arg) => isSimplePlaceholderArgument(arg.trim()));
+}
+
+function isSimplePlaceholderArgument(value: string) {
+  return /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?$/.test(value) ||
+    /^["'`][^"'`]+["'`]$/.test(value);
 }
 
 function hasLowQualityTags(note: MaterializedTaskMemoryNote) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -252,7 +252,7 @@ function hasStrongRootCauseSignal(value: string) {
 function isExistenceOnlyClaim(value: string) {
   const text = value.toLowerCase();
   const hasExistencePhrase =
-    /\b(existed|exists|was present|were present|present during|is available|was available|on disk|is on disk|was on disk|was there|were there|there was|there were|was found|were found|was included|were included|was located|were located|was listed)\b/
+    /\b(existed|exists|was present|were present|present during|is available|was available|on disk|is on disk|was on disk|was there|were there|there was|there were|was found|were found|was included|were included|was located|were located|was listed|was detected|were detected|was observed|were observed|was seen|were seen|was discovered|were discovered|appeared|showed up)\b/
       .test(text);
   return hasExistencePhrase && !hasDefaultDataDirectoryConsequence(text);
 }

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1045,7 +1045,12 @@ function isFirstPersonDiaryClaim(value: string) {
     `(?:^|[:.!?,;]\\s*|\\b(?:and|then|but|so)\\s+)\\b(?:i|we)\\s+(?:${diaryVerbs})\\b`,
     'i',
   )
-    .test(value);
+    .test(value) ||
+    new RegExp(
+      `(?:^|[:.!?,;]\\s*)\\bmy\\s+(?:fix|change|implementation)\\s+(?:${diaryVerbs})\\b`,
+      'i',
+    )
+      .test(value);
 }
 
 function hasChineseFirstPersonDiaryClaim(value: string) {
@@ -1291,13 +1296,18 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
       .test(text) ||
     /\bdaemon\b.+\bexit code\b|\bexit code\b.+\bdaemon\b/i
       .test(text);
+  const hasNamedProxyRoutingObject =
+    /\b(vite dev proxy|vite proxy|dev proxy|proxy path rewrite|proxy rewrite|proxy rewrote|registered fastify route|registered route|fastify)\b/i
+      .test(text) &&
+    /\b(\/api\/[\w/-]+|\/search|proxy|route|fastify|http\s*404)\b/i
+      .test(text);
   const hasNamedMigrationObject =
     /\b(sqlite|chatcrystal\.db|migration|migrations?|not null|default|existing rows?|existing \w+ rows?|notes column|column nullable|backfill|constraint)\b/i
       .test(text) &&
     /\b(migration|migrations?|not null|backfill|chatcrystal\.db|constraint)\b/i
       .test(text);
   const hasEngineeringContext =
-    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?|initialization|initialized|route|mcp|json-rpc|stdio|stdout|stderr|framing|transport|logs?|diagnostics?|tags?|joins?|deletion|cleanup|filter chips?|webui|websocket|listeners?|useeffect|remounts?|unmount|child_process|child process|daemon|pid|spawn|exit code|serve|status|dead server|migration|not null|default|backfill|column|startup)\b/i
+    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?|initialization|initialized|route|mcp|json-rpc|stdio|stdout|stderr|framing|transport|logs?|diagnostics?|tags?|joins?|deletion|cleanup|filter chips?|webui|websocket|listeners?|useeffect|remounts?|unmount|child_process|child process|daemon|pid|spawn|exit code|serve|status|dead server|migration|not null|default|backfill|column|startup|vite|proxy|fastify|rewrite|registered route)\b/i
       .test(text);
   return (
     hasConcreteToken ||
@@ -1308,6 +1318,7 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
     hasNamedLifecycleObject ||
     hasNamedListenerObject ||
     hasNamedProcessLifecycleObject ||
+    hasNamedProxyRoutingObject ||
     hasNamedMigrationObject
   ) && hasEngineeringContext;
 }
@@ -1356,6 +1367,11 @@ function hasStrictStructuralEngineeringAction(value: string) {
       .test(text) ||
     /\b(persist|persisting|write|writing)\b.+\bpid\b.+\b(after|before)\b.+\b(spawn handshake|child|exit event|ready)\b/i
       .test(text);
+  const hasConcreteProxyRoutingAction =
+    /\b(preserve|preserves|preserved|disable|disabled)\b.+\b(proxy path rewrite|proxy rewrite|\/api\/[\w/-]+ path|\/api\/[\w/-]+)\b/i
+      .test(text) ||
+    /\b(disable|disabled)\b.+\bproxy\b.+\brewrite\b.+\b(route|\/api\/[\w/-]+|fastify)\b/i
+      .test(text);
   const hasConcreteMigrationAction =
     /\bbackfill\b.+\b(existing rows?|existing \w+ rows?|rows?)\b/i
       .test(text) ||
@@ -1373,6 +1389,7 @@ function hasStrictStructuralEngineeringAction(value: string) {
       hasConcreteTransportAction ||
       hasConcreteListenerAction ||
       hasConcreteProcessLifecycleAction ||
+      hasConcreteProxyRoutingAction ||
       hasConcreteMigrationAction
     );
 }
@@ -1473,6 +1490,17 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       .test(text) ||
     /\b(?:crystal status|status)\b.+\b(?:connect|connects|connecting)\b.+\bdead server\b/i
       .test(text);
+  const hasProxyPathRewriteFlow =
+    /\b(vite dev proxy|vite proxy|dev proxy|proxy)\b.+\b(rewrote|rewrites?|rewrite|path rewrite|preserv(?:e|es|ed|ing))\b.+(?:\/api\/[\w/-]+|\/search|\b(?:path|registered route|fastify|route)\b)/i
+      .test(text) ||
+    /\bpreserv(?:e|es|ed|ing)\b.+\/api\/[\w/-]+.+\b(vite proxy|dev proxy|proxy)\b.+\b(fastify|registered route|route)\b/i
+      .test(text) ||
+    /\/api\/[\w/-]+.+\bpath\b.+\b(vite proxy|proxy|fastify|registered route)\b/i
+      .test(text) ||
+    /\/api\/[\w/-]+.+\b(rewrote|rewrites?|rewrite)\b.+\/[\w/-]+.+\bfastify\b.+\b(?:returned\s+)?http\s*404\b/i
+      .test(text) ||
+    /\b(disable|disabled|preserv(?:e|es|ed|ing))\b.+\bproxy\b.+\b(path rewrite|rewrite|\/api\/[\w/-]+)\b.+\b(registered fastify route|registered route|fastify|route)\b/i
+      .test(text);
   const hasMigrationConstraintFlow =
     /\bmigration\b.+\badd(?:ed)?\b.+\bnot null\b.+\bwithout a default\b/i
       .test(text) ||
@@ -1485,7 +1513,7 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
     /\badd\b.+\bcolumn\b.+\bnullable\b.+\bbackfill\b.+\benforce\b.+\bnot null\b/i
       .test(text);
   const hasCausalFlow =
-    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gat(?:e|es|ed|ing)|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve|left|no longer existed|deleting notes?|note deletion|cleanup|prune|filter|duplicate|appended twice|remounts?|unmount|spawn handshake|exit event|exit code|dead server|nonzero|non-zero|backfill|not null|default|constraint|violat(?:e|ed|es|ing))\b/i
+    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gat(?:e|es|ed|ing)|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve|left|no longer existed|deleting notes?|note deletion|cleanup|prune|filter|duplicate|appended twice|remounts?|unmount|spawn handshake|exit event|exit code|dead server|nonzero|non-zero|backfill|not null|default|constraint|violat(?:e|ed|es|ing)|rewrote|rewrite|proxy|preserv(?:e|es|ed|ing)|registered route)\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) &&
     hasCausalFlow &&
@@ -1500,6 +1528,7 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       hasTransportFramingFlow ||
       hasListenerCleanupFlow ||
       hasProcessLifecycleFlow ||
+      hasProxyPathRewriteFlow ||
       hasMigrationConstraintFlow
     );
 }
@@ -1803,7 +1832,9 @@ function isExplicitEnglishStatusShell(value: string) {
 
 function hasTechnicalPrefixStatusShell(value: string) {
   const text = value.trim();
-  const technicalPrefix = String.raw`(?:\/api\/[\w/-]+|[a-z0-9]+_[a-z0-9_]+|[a-z][a-z0-9_]*\.[a-z_][a-z0-9_]*|activerequestid|setresults|data_dir|node_env|child_process|jsonl|sqlite|sql\.js|websocket|mcp|json-rpc)`;
+  const descriptorWord = String.raw`(?:api|search|vite|proxy|fastify|react|sqlite|database|mcp|websocket|codex|claude|import|jsonl|electron|daemon|embedding|llm|route)`;
+  const chineseDescriptorWord = String.raw`(?:搜索|接口|代理|路由|导入|数据库|前端|后端)`;
+  const technicalPrefix = String.raw`(?:\/api\/[\w/-]+|[a-z0-9]+_[a-z0-9_]+|[a-z][a-z0-9_]*\.[a-z_][a-z0-9_]*|activerequestid|setresults|data_dir|node_env|child_process|jsonl|sqlite|sql\.js|websocket|mcp|json-rpc|${descriptorWord}(?:\s+${descriptorWord}){0,2}|${chineseDescriptorWord}(?:\s+${chineseDescriptorWord}){0,2})`;
   const englishShell = String.raw`(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task)\s+(?:record|report|note|summary|update|log|entry)|(?:status|record|update|implementation|result|outcome|completion(?:\s+(?:note|record))?|completed|done))`;
   const chineseShell = String.raw`(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|运行结果|执行结果|结果记录|结果报告|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|结果|完成|已完成|完成说明)`;
   return new RegExp(`^\\s*${technicalPrefix}\\s+${englishShell}\\s*(?:[:\\-\\u2013\\u2014])`, 'i')

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1923,14 +1923,18 @@ function hasTechnicalPrefixStatusShell(value: string) {
     .test(text) ||
     new RegExp(`^\\s*${technicalPrefix}\\s+${englishShell}\\s+(?:for|on|about)\\b`, 'i')
       .test(text) ||
+    new RegExp(`^\\s*${technicalPrefix}\\s+${englishShell}\\s+(?=(?:\\/api\\/|http\\s*[45]\\d\\d\\b|returns?\\b|returned\\b|responds?\\b|because\\b))`, 'i')
+      .test(text) ||
     new RegExp(`^\\s*${technicalPrefix}\\s*${chineseShell}\\s*(?:[：:\\-\\u2013\\u2014]|$)`, 'i')
+      .test(text) ||
+    new RegExp(`^\\s*${technicalPrefix}\\s*${chineseShell}\\s+(?=(?:\\/api\\/|http\\s*[45]\\d\\d\\b|返回|因为|因|导致))`, 'i')
       .test(text);
 }
 
 function isCurrentRunImplementationShell(value: string) {
   const text = value.trim();
   const currentRunSubject = '(?:run|execution|fix|task|change)';
-  const currentRunPrefix = `(?:(?:(?:in|during)\\s+(?:this|the\\s+current)\\s+${currentRunSubject})|(?:(?:the\\s+)?current|this)\\s+${currentRunSubject})`;
+  const currentRunPrefix = `(?:(?:(?:in|during|for)\\s+(?:this|the\\s+current|this\\s+current)\\s+${currentRunSubject})|(?:(?:the\\s+)?current|this)\\s+${currentRunSubject})`;
   const implementationVerb = '(?:use|uses|used|did|add|adds|added|set|sets|configured?|register(?:s|ed)?|wait(?:s|ed)?|block(?:s|ed)?|gate(?:s|d)?|ignore(?:s|d)?|cancel(?:s|ed|led)?|move(?:s|d)?|place(?:s|d)?|import(?:s|ed)?|update(?:s|d)?|fix(?:es|ed)?|change(?:s|d)?|validat(?:e|es|ed)|normaliz(?:e|es|ed)|parse(?:s|d)?|strip(?:s|ped)?|debounce(?:s|d)?|route(?:s|d)?|return(?:s|ed)?|prune(?:s|d)?|remove(?:s|d)?|wrap(?:s|ped)?)';
   const hasCurrentRunPrefix =
     new RegExp(`^\\s*${currentRunPrefix}\\b`, 'i').test(text);

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -837,7 +837,10 @@ function isFirstPersonDiaryClaim(value: string) {
     'found',
     'implemented',
     'imported',
+    'caused',
+    'let',
     'loaded',
+    'made',
     'moved',
     'normalized',
     'parsed',
@@ -880,7 +883,9 @@ function hasChineseFirstPersonDiaryClaim(value: string) {
     .join('|');
   const subjectElidedAction =
     `(?:已经|已)(?:${chineseAction}|(?:把|将|在|为).{0,80}(?:${chineseAction}|\\b(?:${englishAction})\\b))`;
-  return new RegExp(`(?:我|我们)(?:已经|已)?${chineseAction}|(?:我|我们)(?:已经|已)?(?:把|将).{0,80}(?:${chineseAction}|\\b(?:${englishAction})\\b)|${subjectElidedAction}`, 'i')
+  const causativeAction =
+    `(?:我|我们)(?:已经|已)?(?:让|使).{0,80}(?:${chineseAction}|\\b(?:${englishAction})\\b)`;
+  return new RegExp(`(?:我|我们)(?:已经|已)?${chineseAction}|(?:我|我们)(?:已经|已)?(?:把|将).{0,80}(?:${chineseAction}|\\b(?:${englishAction})\\b)|${subjectElidedAction}|${causativeAction}`, 'i')
     .test(value);
 }
 
@@ -1273,6 +1278,11 @@ function isVisibleStatusSnapshotText(value: string) {
       .test(value) ||
     /\b(typecheck|lint|ci|build|tests?|testing|verification)\b.+\bcompleted successfully\b/i
       .test(value);
+  const hasHttpSuccessStatus =
+    /\b(?:now\s+)?(?:returns?|responds?)(?:\s+with)?\s+(?:http\s*)?2\d\d\b/i
+      .test(value) ||
+    /\bhttp\s*2\d\d\b.+\b(after|now|success|succeeded|passed|ok|works?|working)\b/i
+      .test(value);
   const hasStatusVerb = /\b(checked|noted|observed|reviewed|resolved|tested|testing passed|verified|verification|current|status)\b/i
     .test(value);
   const hasChineseStatus =
@@ -1286,6 +1296,7 @@ function isVisibleStatusSnapshotText(value: string) {
       .test(value);
   return hasPassStatus ||
     hasSuccessStatus ||
+    hasHttpSuccessStatus ||
     hasChineseStatus ||
     ((hasStatusVerb && hasStatusObject) && !hasStrongReusableMechanism(value));
 }

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -266,13 +266,15 @@ function hasPackageDistRootCauseShape(value: string) {
 function hasPackageDistRootCauseSignal(value: string) {
   const text = value.toLowerCase();
   const packageMechanism = '(?:version parsing|parsing|version normalization|normalization|normalize|normalized|different formats|inconsistent normalization|comparison|comparing)';
-  const packageOutcome = '(?:diverged|divergence|mismatch|stale(?: package metadata| output| dist)?|wrong comparison|comparison failure|differed from package metadata|differed from package version)';
+  const packageOutcome = '(?:diverged|divergence|mismatch|stale(?: package metadata| output| dist)?|wrong comparison|comparison failure|dist comparisons? unreliable|differed from package metadata|differed from package version)';
   const hasPositiveSignal =
     new RegExp(`\\b(package metadata|package version|generated dist output|dist output)\\b.+\\b${packageOutcome}\\b.+\\bbecause\\b.+\\b${packageMechanism}\\b.+\\b(inconsistent|different formats|mismatch|wrong|stale)\\b`, 'i')
       .test(text) ||
     new RegExp(`\\b(generated dist output|dist output)\\b.+\\b${packageOutcome}\\b.+\\b(package metadata|package version)\\b.+\\bbecause\\b.+\\b${packageMechanism}\\b.+\\b(inconsistent|different formats|mismatch|wrong|stale)\\b`, 'i')
       .test(text) ||
-    new RegExp(`\\b(inconsistent|mismatch|wrong comparison|comparison failure|stale|different formats)\\b.+\\b(version parsing|package version parsing|package metadata|package version|version normalization|package normalization)\\b.+\\b(generated dist output|dist output|dist comparisons?|dist)\\b`, 'i')
+    new RegExp(`\\b(inconsistent|different formats)\\b.+\\b(version parsing|package version parsing|version normalization|package normalization)\\b.+\\b(generated dist output|dist output|dist comparisons?|dist)\\b.+\\b${packageOutcome}\\b`, 'i')
+      .test(text) ||
+    /\b(inconsistent|different formats)\b.+\b(version parsing|package version parsing|version normalization|package normalization)\b.+\bdist comparisons?\b.+\bunreliable\b/i
       .test(text);
   if (hasPositiveSignal) return true;
   if (isPackageArtifactObservationClaim(text) || isExistenceOnlyClaim(text)) return false;

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -228,7 +228,7 @@ function hasConcreteTransferableText(value: string) {
 }
 
 function isFirstPersonDiaryClaim(value: string) {
-  return /\b(i|we)\s+(added|checked|verified|fixed|implemented|updated|changed|then)\b/i
+  return /\b(i|we)\s+(added|checked|verified|fixed|implemented|updated|changed|found|diagnosed|switched|then)\b/i
     .test(value);
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -228,7 +228,21 @@ function hasConcreteTransferableText(value: string) {
 }
 
 function isFirstPersonDiaryClaim(value: string) {
-  return /\b(i|we)\s+(added|checked|verified|fixed|implemented|updated|changed|found|diagnosed|discovered|switched|then)\b/i
+  const diaryVerbs = [
+    'added',
+    'changed',
+    'checked',
+    'confirmed',
+    'diagnosed',
+    'discovered',
+    'fixed',
+    'found',
+    'implemented',
+    'switched',
+    'updated',
+    'verified',
+  ].join('|');
+  return new RegExp(`(?:^|:\\s*)\\b(?:i|we)\\s+(?:${diaryVerbs})\\b`, 'i')
     .test(value);
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1035,6 +1035,8 @@ function isFirstPersonDiaryClaim(value: string) {
     'switched',
     'tested',
     'updated',
+    'use',
+    'used',
     'verified',
   ]))
     .map(regexEscape)
@@ -1281,8 +1283,11 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
   const hasNamedLifecycleObject =
     /\b(db initialization|database initialization|sql\.js initialization|sql\.js finished initialization|finished initialization|accepting import requests?|accepting \/api\/[\w/-]+ requests?|route handled requests?)\b/i
       .test(text);
+  const hasNamedListenerObject =
+    /\b(websocket|web socket|message listener|event listener|useeffect cleanup|useeffect|remounts?|unmount|socket\.addeventlistener|socket\.removeeventlistener|addeventlistener|removeeventlistener)\b/i
+      .test(text);
   const hasEngineeringContext =
-    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?|initialization|initialized|route|mcp|json-rpc|stdio|stdout|stderr|framing|transport|logs?|diagnostics?|tags?|joins?|deletion|cleanup|filter chips?|webui)\b/i
+    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?|initialization|initialized|route|mcp|json-rpc|stdio|stdout|stderr|framing|transport|logs?|diagnostics?|tags?|joins?|deletion|cleanup|filter chips?|webui|websocket|listeners?|useeffect|remounts?|unmount)\b/i
       .test(text);
   return (
     hasConcreteToken ||
@@ -1290,7 +1295,8 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
     hasNamedAsyncObject ||
     hasNamedRelationObject ||
     hasNamedTransportObject ||
-    hasNamedLifecycleObject
+    hasNamedLifecycleObject ||
+    hasNamedListenerObject
   ) && hasEngineeringContext;
 }
 
@@ -1324,6 +1330,13 @@ function hasStrictStructuralEngineeringAction(value: string) {
       .test(text) ||
     /\b(reserve)\b.+\b(process\.stdout|stdout)\b.+\b(json-rpc|json rpc|response frames?|stdio)\b/i
       .test(text);
+  const hasConcreteListenerAction =
+    /\b(pair)\b.+\bsocket\.addeventlistener\b.+\bsocket\.removeeventlistener\b/i
+      .test(text) ||
+    /\b(return)\b.+\buseeffect cleanup\b.+\bsocket\.removeeventlistener\b/i
+      .test(text) ||
+    /\b(remove|cleanup|clean up)\b.+\b(message listener|event listener|websocket listener|socket\.removeeventlistener)\b/i
+      .test(text);
   return hasStrictStructuralEngineeringEvidence(text) &&
     (
       hasAction ||
@@ -1331,7 +1344,8 @@ function hasStrictStructuralEngineeringAction(value: string) {
       hasConcreteAsyncAction ||
       hasConcreteRelationAction ||
       hasConcreteLifecycleAction ||
-      hasConcreteTransportAction
+      hasConcreteTransportAction ||
+      hasConcreteListenerAction
     );
 }
 
@@ -1411,8 +1425,19 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       .test(text) ||
     /\b(reserve)\b.+\b(process\.stdout|stdout)\b.+\b(json-rpc|json rpc|response frames?|stdio)\b/i
       .test(text);
+  const hasListenerCleanupFlow =
+    /\bsocket\.addeventlistener\b.+\bsocket\.removeeventlistener\b.+\b(useeffect cleanup|cleanup|remounts?|duplicate websocket messages?|duplicate messages?)\b/i
+      .test(text) ||
+    /\breact remounts?\b.+\bsocket\.addeventlistener\b.+\bwithout removing\b.+\b(message listener|previous message listener)\b/i
+      .test(text) ||
+    /\bwithout removing\b.+\bprevious message listener\b.+\b(websocket message|message)\b.+\b(appended twice|duplicate)\b/i
+      .test(text) ||
+    /\buseeffect cleanup\b.+\bsocket\.removeeventlistener\b.+\b(before unmount|remounts?|one message listener)\b/i
+      .test(text) ||
+    /\blistener cleanup\b.+\bprevents?\b.+\bduplicate messages?\b/i
+      .test(text);
   const hasCausalFlow =
-    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gat(?:e|es|ed|ing)|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve|left|no longer existed|deleting notes?|note deletion|cleanup|prune|filter)\b/i
+    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gat(?:e|es|ed|ing)|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve|left|no longer existed|deleting notes?|note deletion|cleanup|prune|filter|duplicate|appended twice|remounts?|unmount)\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) &&
     hasCausalFlow &&
@@ -1424,17 +1449,18 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       hasStaleAsyncResponseFlow ||
       hasRelationCleanupFlow ||
       hasInitializationOrderFlow ||
-      hasTransportFramingFlow
+      hasTransportFramingFlow ||
+      hasListenerCleanupFlow
     );
 }
 
 function hasStrictStructuralEngineeringFailureSignal(value: string) {
   const text = value.toLowerCase();
   const hasNamedConsequence =
-    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|orphan note_tags rows?|orphan tags?|unused tags?|count 0|joins? whose note_id no longer existed|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream))\b/i
+    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|duplicate messages?|duplicate websocket messages?|appended twice|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|orphan note_tags rows?|orphan tags?|unused tags?|count 0|joins? whose note_id no longer existed|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream))\b/i
       .test(text);
   const hasCausalFlow =
-    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|left|no longer existed|deleting notes?|note deletion|cleanup|filter|prune)\b/i
+    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|left|no longer existed|deleting notes?|note deletion|cleanup|filter|prune|remounts?|unmount|duplicate|appended twice)\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) && hasNamedConsequence && hasCausalFlow;
 }
@@ -1719,7 +1745,7 @@ function isVisibleWorkLogClaim(value: string) {
 }
 
 function isExplicitEnglishStatusShell(value: string) {
-  return /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task)\s+(?:record|report|note|summary|update|log)|(?:implementation|task|fix|execution|run|work|status)\s+results?|run\s+results?|work\s*log|worklog|status|record|update|implementation|result|outcome|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
+  return /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task)\s+(?:record|report|note|summary|update|log|entry)|(?:implementation|task|fix|execution|run|work|status)\s+results?|run\s+results?|work\s*log(?:\s+entry)?|worklog(?:\s+entry)?|status|record|update|implementation|result|outcome|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
     .test(value.trim()) ||
     isCurrentRunImplementationShell(value);
 }
@@ -1727,9 +1753,9 @@ function isExplicitEnglishStatusShell(value: string) {
 function isCurrentRunImplementationShell(value: string) {
   const text = value.trim();
   const hasCurrentRunPrefix =
-    /^\s*(?:this|current)\s+(?:run|execution|fix|task|change)\b/i.test(text);
+    /^\s*(?:the\s+)?(?:this|current)\s+(?:run|execution|fix|task|change)\b/i.test(text);
   const hasImplementationAction =
-    /^\s*(?:this|current)\s+(?:run|execution|fix|task|change)\b.{0,40}\b(?:use|uses|used|did|add|adds|added|set|sets|configured?|register(?:s|ed)?|wait(?:s|ed)?|block(?:s|ed)?|gate(?:s|d)?|ignore(?:s|d)?|cancel(?:s|ed|led)?|move(?:s|d)?|place(?:s|d)?|import(?:s|ed)?|update(?:s|d)?|fix(?:es|ed)?|change(?:s|d)?|validat(?:e|es|ed)|normaliz(?:e|es|ed)|parse(?:s|d)?|strip(?:s|ped)?|debounce(?:s|d)?|route(?:s|d)?|return(?:s|ed)?|prune(?:s|d)?|remove(?:s|d)?|wrap(?:s|ped)?)\b/i
+    /^\s*(?:the\s+)?(?:this|current)\s+(?:run|execution|fix|task|change)\b.{0,40}\b(?:use|uses|used|did|add|adds|added|set|sets|configured?|register(?:s|ed)?|wait(?:s|ed)?|block(?:s|ed)?|gate(?:s|d)?|ignore(?:s|d)?|cancel(?:s|ed|led)?|move(?:s|d)?|place(?:s|d)?|import(?:s|ed)?|update(?:s|d)?|fix(?:es|ed)?|change(?:s|d)?|validat(?:e|es|ed)|normaliz(?:e|es|ed)|parse(?:s|d)?|strip(?:s|ped)?|debounce(?:s|d)?|route(?:s|d)?|return(?:s|ed)?|prune(?:s|d)?|remove(?:s|d)?|wrap(?:s|ped)?)\b/i
       .test(text);
   return hasCurrentRunPrefix && hasImplementationAction && hasSpecificEvidence(text);
 }

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1023,6 +1023,9 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
   const hasNamedAsyncObject =
     /\b(abortcontroller|react search|search view|\/api\/search|search request sequence|stale search requests?|stale responses?|stale results?|previous responses?|current query results?|current results|overlapping requests?|overlapping \/api\/search requests?)\b/i
       .test(text);
+  const hasNamedRelationObject =
+    /\b(note_ids?|note_tags|tag counts?|filter chips?|webui|deletenotewithreview|note deletion|orphan tags?|unused tags?|joins? whose note_id|existing notes?)\b/i
+      .test(text);
   const hasNamedTransportObject =
     /\b(mcp|json-rpc|json rpc|stdio|stdout|stderr|process\.stdout|process\.stderr|response frames?|response transport|stdio stream)\b/i
       .test(text);
@@ -1030,12 +1033,13 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
     /\b(db initialization|database initialization|sql\.js initialization|sql\.js finished initialization|finished initialization|accepting import requests?|accepting \/api\/[\w/-]+ requests?|route handled requests?)\b/i
       .test(text);
   const hasEngineeringContext =
-    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?|initialization|initialized|route|mcp|json-rpc|stdio|stdout|stderr|framing|transport|logs?|diagnostics?)\b/i
+    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?|initialization|initialized|route|mcp|json-rpc|stdio|stdout|stderr|framing|transport|logs?|diagnostics?|tags?|joins?|deletion|cleanup|filter chips?|webui)\b/i
       .test(text);
   return (
     hasConcreteToken ||
     hasNamedDbObject ||
     hasNamedAsyncObject ||
+    hasNamedRelationObject ||
     hasNamedTransportObject ||
     hasNamedLifecycleObject
   ) && hasEngineeringContext;
@@ -1044,7 +1048,7 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
 function hasStrictStructuralEngineeringAction(value: string) {
   const text = value.toLowerCase();
   const hasAction =
-    /\b(add|create|remove|wrap|validate|normalize|configure|set|index|return|reuse|cancel|use|wait|send|reserve)\b/i
+    /\b(add|create|remove|wrap|validate|normalize|configure|set|index|return|reuse|cancel|use|wait|send|reserve|filter|prune|clean up|cleanup)\b/i
       .test(text);
   const hasConcreteDbAction =
     /\b(add|create)\b.+\b(unique\s*\([^)]*\)|unique key|unique constraint|constraint|index|idx_[a-z0-9_]+)\b/i
@@ -1058,6 +1062,11 @@ function hasStrictStructuralEngineeringAction(value: string) {
       .test(text) ||
     /\b(ignore)\b.+\b(responses?)\b.+\b(not from the latest query|older|previous|stale|latest query)\b/i
       .test(text);
+  const hasConcreteRelationAction =
+    /\b(filter|filtered)\b.+\b(tag counts?|tags?)\b.+\b(existing notes?|existing note_ids?|note_ids?)\b/i
+      .test(text) ||
+    /\b(prune|remove|clean up|cleanup)\b.+\b(orphan note_tags rows?|orphan tags?|unused tags?|joins?)\b/i
+      .test(text);
   const hasConcreteLifecycleAction =
     /\b(wait)\b.+\b(db initialization|database initialization|sql\.js initialization|initialized|finished initialization)\b.+\b(before accepting|before handling|requests?)\b/i
       .test(text);
@@ -1067,7 +1076,14 @@ function hasStrictStructuralEngineeringAction(value: string) {
     /\b(reserve)\b.+\b(process\.stdout|stdout)\b.+\b(json-rpc|json rpc|response frames?|stdio)\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) &&
-    (hasAction || hasConcreteDbAction || hasConcreteAsyncAction || hasConcreteLifecycleAction || hasConcreteTransportAction);
+    (
+      hasAction ||
+      hasConcreteDbAction ||
+      hasConcreteAsyncAction ||
+      hasConcreteRelationAction ||
+      hasConcreteLifecycleAction ||
+      hasConcreteTransportAction
+    );
 }
 
 function hasStrictStructuralEngineeringMechanism(value: string) {
@@ -1111,6 +1127,17 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       .test(text) ||
     /\bolder\b.+\b\/api\/search responses?\b.+\b(after a newer query|newer query)\b.+\boverwrite\b.+\bcurrent results\b/i
       .test(text);
+  const hasRelationCleanupFlow =
+    /\b(filter|filtered)\b.+\b(tag counts?|tags?)\b.+\b(existing notes?|existing note_ids?|note_ids?)\b/i
+      .test(text) ||
+    /\b(prune|remove|clean up|cleanup)\b.+\b(orphan note_tags rows?|orphan tags?|unused tags?|joins?)\b/i
+      .test(text) ||
+    /\b(deleting notes?|note deletion|deletenotewithreview)\b.+\b(left|leaves?|orphan|unused|cleanup|joins?)\b/i
+      .test(text) ||
+    /\bcleanup\b.+\bdid not remove\b.+\bjoins?\b.+\bnote_id\b.+\bno longer existed\b/i
+      .test(text) ||
+    /\b(filter chips?)\b.+\b(count 0|orphan|unused)\b/i
+      .test(text);
   const hasInitializationOrderFlow =
     /\b(route|\/api\/[\w/-]+)\b.+\b(handled|handles?|accept(?:ed|ing)?|requests?)\b.+\bbefore\b.+\b(sql\.js|db|database)\b.+\b(finished initialization|initialization|initialized)\b/i
       .test(text) ||
@@ -1130,7 +1157,7 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
     /\b(reserve)\b.+\b(process\.stdout|stdout)\b.+\b(json-rpc|json rpc|response frames?|stdio)\b/i
       .test(text);
   const hasCausalFlow =
-    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gate|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve)\b/i
+    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gate|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve|left|no longer existed|deleting notes?|note deletion|cleanup|prune|filter)\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) &&
     hasCausalFlow &&
@@ -1140,6 +1167,7 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       hasLookupScanFlow ||
       hasUniquenessConstraintFlow ||
       hasStaleAsyncResponseFlow ||
+      hasRelationCleanupFlow ||
       hasInitializationOrderFlow ||
       hasTransportFramingFlow
     );
@@ -1148,10 +1176,10 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
 function hasStrictStructuralEngineeringFailureSignal(value: string) {
   const text = value.toLowerCase();
   const hasNamedConsequence =
-    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream))\b/i
+    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|orphan note_tags rows?|orphan tags?|unused tags?|count 0|joins? whose note_id no longer existed|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream))\b/i
       .test(text);
   const hasCausalFlow =
-    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?)\b/i
+    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|left|no longer existed|deleting notes?|note deletion|cleanup|filter|prune)\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) && hasNamedConsequence && hasCausalFlow;
 }
@@ -1220,7 +1248,9 @@ function isExistenceOnlyClaim(value: string) {
   const hasExistencePhrase =
     /\b(existed|exists|was present|were present|present during|is available|was available|on disk|is on disk|was on disk|was there|were there|there was|there were|was found|were found|was included|were included|was located|were located|was listed|was detected|were detected|was observed|were observed|was seen|were seen|was discovered|were discovered|appeared|showed up)\b/
       .test(text);
-  return hasExistencePhrase && !hasDefaultDataDirectoryConsequence(text);
+  return hasExistencePhrase &&
+    !hasDefaultDataDirectoryConsequence(text) &&
+    !hasStrictStructuralEngineeringFailureSignal(text);
 }
 
 function isPackageArtifactObservationClaim(value: string) {
@@ -1447,6 +1477,13 @@ function hasChineseVisibleMechanism(value: string) {
 
 function isChineseVisibleStatusShell(value: string) {
   if (!/[\u3400-\u9fff]/.test(value)) return false;
+  const hasStatusRecordShell =
+    /(?:^|[\s：:])(?:状态记录|记录状态)(?:[\s：:]|$)|^状态\s*[：:]/i
+      .test(value) ||
+    /(?:已记录|记录了).{0,80}(?:已修复|修复完成|已完成|完成|处理完成|解决完成)/i
+      .test(value);
+  if (hasStatusRecordShell) return true;
+
   const hasCompletionShell =
     /问题处理完|处理完成|处理完毕|修复好了|修好了|已经处理|已处理|回归正常|恢复正常|更稳定|不再返回|已解决|解决完成|已完成|修复完成|修复已完成/i
       .test(value);

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -2221,6 +2221,7 @@ function isExplicitEnglishStatusShell(value: string) {
     isDiagnosticEvidenceStatusShell(value) ||
     isConfirmationResultStatusShell(value) ||
     isPredicateResultStatusShell(value) ||
+    isUndelimitedStatusPrefixShell(value) ||
     isCurrentRunImplementationShell(value) ||
     isCurrentRunStatusObservationClaim(value);
 }
@@ -2254,6 +2255,13 @@ function isPredicateResultStatusShell(value: string) {
   const text = value.trim();
   return hasSpecificEvidence(text) &&
     /^\s*(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,2}\s+)?(?:(?:smoke\s+)?test|result|progress|validation|qa|check|acceptance)\s+(?:shows?|is)\b/i
+      .test(text);
+}
+
+function isUndelimitedStatusPrefixShell(value: string) {
+  const text = value.trim();
+  return hasSpecificEvidence(text) &&
+    /^\s*(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,2}\s+)?(?:status check|progress|verification note|completion check|result check)\s+(?=(?:activeRequestId|setResults|\/api\/|stale\b|http\b|api\b|[a-z0-9_]+\.[a-z_]))/i
       .test(text);
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -2261,7 +2261,7 @@ function isPredicateResultStatusShell(value: string) {
 function isUndelimitedStatusPrefixShell(value: string) {
   const text = value.trim();
   return hasSpecificEvidence(text) &&
-    /^\s*(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,2}\s+)?(?:status check|progress|verification note|completion check|result check)\s+(?=(?:activeRequestId|setResults|\/api\/|stale\b|http\b|api\b|[a-z0-9_]+\.[a-z_]))/i
+    /^\s*(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,2}\s+)?(?:status check|progress|verification note|completion check|result check)\s+(?:[a-z][a-z0-9-]*\s+){0,4}(?=(?:activeRequestId|setResults|\/api\/|stale\b|http\b|api\b|[a-z0-9_]+\.[a-z_]))/i
       .test(text);
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -51,6 +51,7 @@ function hasConcreteTransferableAction(value: string) {
   const text = value.toLowerCase();
   if (hasNegativeTransferableAction(text)) return true;
   if (hasSchemaDefaultArrayAction(text)) return true;
+  if (hasDurableEngineeringPreventionAction(text)) return true;
   if (hasPersistenceSerializationAction(text)) return true;
   const concreteActionWords = [
     'add',
@@ -196,6 +197,7 @@ function hasSpecificEvidence(value: string) {
     /\b(data_dir|node_env|econrefused|typeerror|note_tags|chatcrystal\.db|port|source_run_key|foreign_keys)\b|\/api\/[\w/-]+|\b[a-z0-9]+_[a-z0-9_]+\b|[a-z]:\\|\/[\w.-]+|[\u3400-\u9fff]/i
       .test(text) ||
     hasSchemaArrayEvidence(text) ||
+    hasDurableEngineeringEvidence(text) ||
     hasContentSanitizationEvidence(text) ||
     hasPersistenceSnapshotEvidence(text) ||
     hasIndexConsistencyEvidence(text) ||
@@ -223,6 +225,48 @@ function hasSchemaDefaultArrayMechanism(value: string) {
   const hasIterationOrHandler =
     /\b(iterat(?:e|ed|es|ing|ion)|handler|handler logic)\b/i.test(text);
   return hasSchemaArrayEvidence(text) && hasOptionalOrDefaultArray && hasIterationOrHandler;
+}
+
+function hasDurableEngineeringEvidence(value: string) {
+  const text = value.toLowerCase();
+  return /\b(json|jsonl|fixtures?|fixture corpora|corpus|samples?|calibration samples?|calibration corpus|dataset object|fixture object|experience-gate|provenance|contains_real_user_data|synthetic data|raw local paths?|raw user paths?|private ips?|credentials?|private-key text|secret-like tokens?|secrets?|sanitization rules?)\b/i
+    .test(text);
+}
+
+function hasDurableEngineeringPreventionAction(value: string) {
+  const text = value.toLowerCase();
+  return hasDurableEngineeringEvidence(text) &&
+    /\b(wrap|store|stored|reject|rejects?|test|tests|sanitize|sanitiz(?:e|ed|es|ing|ation)|strip|validate|assert|assertions?)\b/i
+      .test(text);
+}
+
+function hasDurableEngineeringMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasConcreteGovernanceMechanism =
+    /\b(dataset object|fixture object|provenance metadata|synthetic provenance|provenance|privacy assertions?|contains_real_user_data=false|sanitization rules?|tests? that reject|before committing|review context)\b/i
+      .test(text);
+  const hasSensitiveDataEvidence =
+    /\b(raw local paths?|raw user paths?|private ips?|credentials?|private-key text|secret-like tokens?|secrets?)\b/i
+      .test(text);
+  const hasDataArtifact =
+    /\b(json sample arrays?|json|fixtures?|fixture corpora|corpus|samples?|calibration samples?|calibration corpus|dataset object|fixture object|experience-gate)\b/i
+      .test(text);
+  return hasDurableEngineeringEvidence(text) &&
+    (
+      hasConcreteGovernanceMechanism ||
+      (hasDurableEngineeringPreventionAction(text) && hasSensitiveDataEvidence && hasDataArtifact)
+    );
+}
+
+function hasDurableEngineeringFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasConcreteConsequence =
+    /\b(hid whether|could commit|cannot silently include|silently include|leak(?:ed|s|ing)?|raw local paths?|raw user paths?|private ips?|credentials?|private-key text|secret-like tokens?|secrets?|without review context|missing review context|privacy leak|private data|sensitive data)\b/i
+      .test(text);
+  const hasFailureFlow =
+    /\b(because|so|caused|led to|hid whether|could commit|cannot silently include|without review context|leak(?:ed|s|ing)?|returned|overwrote|threw)\b/i
+      .test(text);
+  return hasDurableEngineeringEvidence(text) && hasConcreteConsequence && hasFailureFlow;
 }
 
 function hasContentSanitizationEvidence(value: string) {
@@ -364,6 +408,7 @@ function hasConcreteMechanism(value: string) {
     /\b(rate[- ]limit|http 429|429|retry-after|backoff|delay)\b.+\b(retry|retried|retries|queue|queued|provider requests?)\b/i
       .test(text);
   const hasSchemaDefaultArrayFlow = hasSchemaDefaultArrayMechanism(text);
+  const hasDurableEngineeringFlow = hasDurableEngineeringMechanism(text);
   const hasContentSanitizationFlow = hasContentSanitizationMechanism(text);
   const hasPersistenceSerializationFlow = hasPersistenceSerializationMechanism(text);
   const hasIndexConsistencyFlow = hasIndexConsistencyMechanism(text);
@@ -378,6 +423,7 @@ function hasConcreteMechanism(value: string) {
     hasParserFieldValidation ||
     hasRetryBackoffFlow ||
     hasSchemaDefaultArrayFlow ||
+    hasDurableEngineeringFlow ||
     hasContentSanitizationFlow ||
     hasPersistenceSerializationFlow ||
     hasIndexConsistencyFlow
@@ -445,6 +491,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     /\b(race|raced|orphan|dedupe|deduplicate|stale dist|dist diverge|dist diverged|diverge|diverged|econrefused|typeerror|threw|throws?|readiness issue|startup race|invalid note_tags|foreign_keys|cascade|nulling|source_run_key collision)\b/i
       .test(value) ||
     hasSchemaArrayFailureSignal(value) ||
+    hasDurableEngineeringFailureSignal(value) ||
     hasContentSanitizationFailureSignal(value) ||
     hasPersistenceSnapshotFailureSignal(value) ||
     hasIndexConsistencyFailureSignal(value) ||

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -19,6 +19,15 @@ function hasMeaningfulText(value: string, minLatin = 24, minCjk = 18) {
   return compactLength(text) >= (hasCjk ? minCjk : minLatin);
 }
 
+function isPlaceholderText(value: string) {
+  return /\b(unknown|n\/a|not sure|todo|tbd|appropriate change|fix the issue|task needed investigation)\b/i
+    .test(value);
+}
+
+function hasNonPlaceholderMeaningfulText(value: string, minLatin = 24, minCjk = 18) {
+  return hasMeaningfulText(value, minLatin, minCjk) && !isPlaceholderText(value);
+}
+
 function isGenericTitle(title: string) {
   return /^(task|memory|note|update|summary|investigate|check|fix)$/i.test(title.trim());
 }
@@ -31,48 +40,14 @@ function joined(note: MaterializedTaskMemoryNote) {
   ].join('\n').toLowerCase();
 }
 
-function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
-  if (isMostlyOneOffStatus(note)) return false;
-  const payload = note.raw_payload;
-  const conclusions = note.key_conclusions.join('\n').toLowerCase();
-  const hasMeaningfulRootCause = Boolean(
-    payload.root_cause && hasMeaningfulText(payload.root_cause),
-  );
-  const hasMeaningfulResolution = Boolean(
-    payload.resolution && hasMeaningfulText(payload.resolution),
-  );
-  const hasStructuredSignal =
-    (hasMeaningfulRootCause && hasMeaningfulResolution) ||
-    Boolean(payload.reusable_patterns?.some((item) => hasMeaningfulText(item))) ||
-    Boolean(payload.pitfalls?.some((item) => hasMeaningfulText(item))) ||
-    Boolean(payload.decisions?.some((item) => hasMeaningfulText(item))) ||
-    Boolean(payload.error_signatures?.length && (hasMeaningfulRootCause || hasMeaningfulResolution));
-  const hasVisibleSignal =
-    /root cause:|resolution:|pitfall:|pattern:|decision:|error signature:/i.test(conclusions);
-  return hasStructuredSignal && hasVisibleSignal;
-}
-
-function isMostlyOneOffStatus(note: MaterializedTaskMemoryNote) {
-  const text = joined(note);
-  const statusWords = [
-    'version',
-    'status',
-    'checked',
-    'current',
-    'package',
-    'npm link',
-    'dist',
-    'local',
-    'environment',
-    '配置',
-    '版本',
-    '检查',
-    '状态',
-  ];
+function hasConcreteTransferableAction(value: string) {
+  const text = value.toLowerCase();
   const concreteActionWords = [
     'block',
     'cache',
     'collapse',
+    'compare',
+    'comparing',
     'debounce',
     'deduplicate',
     'defer',
@@ -92,18 +67,63 @@ function isMostlyOneOffStatus(note: MaterializedTaskMemoryNote) {
     'sanitize',
     'truncate',
     'validate',
-    'compare',
-    'comparing',
     'wait',
     'wait for',
     '避免',
     '防止',
     '复用',
   ];
+  return concreteActionWords.some((word) => text.includes(word));
+}
+
+function hasConcreteTransferableText(value: string) {
+  return hasNonPlaceholderMeaningfulText(value) && hasConcreteTransferableAction(value);
+}
+
+function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
+  if (isMostlyOneOffStatus(note)) return false;
+  const payload = note.raw_payload;
+  const conclusions = note.key_conclusions.join('\n').toLowerCase();
+  const hasMeaningfulRootCause = Boolean(
+    payload.root_cause && hasNonPlaceholderMeaningfulText(payload.root_cause),
+  );
+  const hasMeaningfulResolution = Boolean(
+    payload.resolution && hasNonPlaceholderMeaningfulText(payload.resolution),
+  );
+  const hasStructuredSignal =
+    (hasMeaningfulRootCause && hasMeaningfulResolution) ||
+    Boolean(payload.reusable_patterns?.some((item) => hasConcreteTransferableText(item))) ||
+    Boolean(payload.pitfalls?.some((item) => hasConcreteTransferableText(item))) ||
+    Boolean(payload.decisions?.some((item) => hasConcreteTransferableText(item))) ||
+    Boolean(payload.error_signatures?.length && (hasMeaningfulRootCause || hasMeaningfulResolution));
+  const hasVisibleSignal =
+    /root cause:|resolution:|pitfall:|pattern:|decision:|error signature:/i.test(conclusions);
+  return hasStructuredSignal && hasVisibleSignal;
+}
+
+function isMostlyOneOffStatus(note: MaterializedTaskMemoryNote) {
+  const text = joined(note);
+  const statusWords = [
+    'version',
+    'status',
+    'checked',
+    'current',
+    'package',
+    'npm link',
+    'dist',
+    'local',
+    'environment',
+    'env',
+    'node_env',
+    'deployment',
+    'production',
+    '配置',
+    '版本',
+    '检查',
+    '状态',
+  ];
   const statusHits = statusWords.filter((word) => text.includes(word)).length;
-  const hasConcreteTransferableAction = concreteActionWords
-    .some((word) => text.includes(word));
-  return statusHits >= 3 && !hasConcreteTransferableAction;
+  return statusHits >= 3 && !hasConcreteTransferableAction(text);
 }
 
 export function validateMaterializedNoteQuality(

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -167,7 +167,7 @@ function hasSpecificObject(value: string) {
 function hasSpecificEvidence(value: string) {
   const text = value.toLowerCase();
   return (
-    /\b(data_dir|node_env|econrefused|note_tags|chatcrystal\.db|port|source_run_key|foreign_keys)\b|\/api\/[\w/-]+|\b[a-z0-9]+_[a-z0-9_]+\b|[a-z]:\\|\/[\w.-]+|[\u3400-\u9fff]/i
+    /\b(data_dir|node_env|econrefused|typeerror|note_tags|chatcrystal\.db|port|source_run_key|foreign_keys)\b|\/api\/[\w/-]+|\b[a-z0-9]+_[a-z0-9_]+\b|[a-z]:\\|\/[\w.-]+|[\u3400-\u9fff]/i
       .test(text) ||
     hasHttpFailureSignal(text) ||
     /\b(api requests?|fastify readiness|server readiness|request setup|package metadata|package version|dist output|generated dist output|data directory|electron server|server entrypoint|client calls?)\b/i
@@ -203,6 +203,11 @@ function hasConcreteMechanism(value: string) {
       /\b(ran after|after request setup|before issuing|before request setup|registration ran after)\b/i.test(text) ||
       hasTimingOrder
     );
+  const hasParserFieldValidation =
+    /\b(typeerror|parser|parsing|jsonl|response_item\.content|partial events?|partial codex events?|event shape|parser fields)\b.+\b(before|after|without content|validat(?:e|ing)|read(?:ing)?|skip)\b/i
+      .test(text) ||
+    /\b(before|after|without content|validat(?:e|ing)|read(?:ing)?|skip)\b.+\b(typeerror|parser|parsing|jsonl|response_item\.content|partial events?|partial codex events?|event shape|parser fields)\b/i
+      .test(text);
   return (
     hasTimingOrder ||
     hasRaceReadiness ||
@@ -210,7 +215,8 @@ function hasConcreteMechanism(value: string) {
     hasDataDirFallback ||
     hasRelationalCleanup ||
     hasDedupeKey ||
-    hasRequestFailureOrdering
+    hasRequestFailureOrdering ||
+    hasParserFieldValidation
   );
 }
 
@@ -259,7 +265,7 @@ function hasPackageItemSignal(value: string) {
 
 function hasFailureOrConsequenceSignal(value: string) {
   return (
-    /\b(race|raced|orphan|dedupe|deduplicate|stale dist|dist diverge|dist diverged|diverge|diverged|econrefused|readiness issue|startup race|invalid note_tags|foreign_keys|cascade|nulling|source_run_key collision)\b/i
+    /\b(race|raced|orphan|dedupe|deduplicate|stale dist|dist diverge|dist diverged|diverge|diverged|econrefused|typeerror|threw|throws?|readiness issue|startup race|invalid note_tags|foreign_keys|cascade|nulling|source_run_key collision)\b/i
       .test(value) ||
     hasDefaultDataDirectoryConsequence(value) ||
     hasHttpFailureSignal(value)
@@ -505,9 +511,14 @@ function isGenericVisibleBoilerplateClaim(value: string) {
     /\b(?:avoid|prevent|prevents?|prevention)\b.+\bfuture failures?\b/i.test(text) ||
     /\bfuture failures?\b.+\bexpected workflow\b/i.test(text);
   const hasGenericReleaseValidation =
+    /\bvalidate behavior\b/i.test(text) ||
     /\balways validate behavior before release\b/i.test(text) ||
     /\bvalidate behavior\b.+\bbefore release\b/i.test(text);
-  return (
+  const hasGenericResolvedInvestigation =
+    /\bissue resolved after investigation\b/i.test(text) ||
+    /\bresolved after investigation\b/i.test(text) ||
+    /\bissue was resolved after investigation(?: and testing)?\b/i.test(text);
+  return hasGenericResolvedInvestigation || (
     hasGenericReliabilityFix ||
     hasGenericFutureFailure ||
     hasGenericReleaseValidation

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -87,6 +87,7 @@ function hasConcreteTransferableAction(value: string) {
     'retry',
     'sanitize',
     'set',
+    'strip',
     'truncate',
     'validate',
     'wait',
@@ -195,6 +196,7 @@ function hasSpecificEvidence(value: string) {
     /\b(data_dir|node_env|econrefused|typeerror|note_tags|chatcrystal\.db|port|source_run_key|foreign_keys)\b|\/api\/[\w/-]+|\b[a-z0-9]+_[a-z0-9_]+\b|[a-z]:\\|\/[\w.-]+|[\u3400-\u9fff]/i
       .test(text) ||
     hasSchemaArrayEvidence(text) ||
+    hasContentSanitizationEvidence(text) ||
     hasPersistenceSnapshotEvidence(text) ||
     hasIndexConsistencyEvidence(text) ||
     hasHttpFailureSignal(text) ||
@@ -221,6 +223,39 @@ function hasSchemaDefaultArrayMechanism(value: string) {
   const hasIterationOrHandler =
     /\b(iterat(?:e|ed|es|ing|ion)|handler|handler logic)\b/i.test(text);
   return hasSchemaArrayEvidence(text) && hasOptionalOrDefaultArray && hasIterationOrHandler;
+}
+
+function hasContentSanitizationEvidence(value: string) {
+  const text = value.toLowerCase();
+  return /<system-reminder>|<command-name>|\b(jsonl|source adapter|adapter|claude code|sanitizecontent|system xml tags?|xml tags?|system-reminder|command-name|system noise|raw jsonl|message content|human-facing notes?|note content|imported conversation messages?)\b/i
+    .test(text);
+}
+
+function hasContentSanitizationMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasSanitizeAction =
+    /\b(sanitize|sanitized|sanitizecontent|strip|stripped|remove|removed|filter|filtered|clean)\b/i
+      .test(text);
+  const hasImportedContentFlow =
+    /\b(pars(?:e|ed|es|ing)|sav(?:e|ed|es|ing)|import(?:ed|ing)?|raw jsonl|message content|conversation messages?|before saving)\b/i
+      .test(text);
+  const hasNoiseOrTagTarget =
+    /<system-reminder>|<command-name>|\b(system xml tags?|xml tags?|system-reminder|command-name|system noise|raw jsonl|message content)\b/i
+      .test(text);
+  return hasContentSanitizationEvidence(text) &&
+    hasSanitizeAction &&
+    (hasImportedContentFlow || hasNoiseOrTagTarget);
+}
+
+function hasContentSanitizationFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasLeakOrPollution =
+    /\b(leak(?:ed|s|ing)?|pollut(?:e|ed|es|ing|ion)|system noise|raw jsonl|become note content|human-facing notes?|note content)\b/i
+      .test(text);
+  const hasCausalFlow =
+    /\b(because|so|leak(?:ed|s|ing)? into|does not become|before saving|raw jsonl message content)\b/i
+      .test(text);
+  return hasContentSanitizationEvidence(text) && hasLeakOrPollution && hasCausalFlow;
 }
 
 function hasPersistenceSnapshotEvidence(value: string) {
@@ -329,6 +364,7 @@ function hasConcreteMechanism(value: string) {
     /\b(rate[- ]limit|http 429|429|retry-after|backoff|delay)\b.+\b(retry|retried|retries|queue|queued|provider requests?)\b/i
       .test(text);
   const hasSchemaDefaultArrayFlow = hasSchemaDefaultArrayMechanism(text);
+  const hasContentSanitizationFlow = hasContentSanitizationMechanism(text);
   const hasPersistenceSerializationFlow = hasPersistenceSerializationMechanism(text);
   const hasIndexConsistencyFlow = hasIndexConsistencyMechanism(text);
   return (
@@ -342,6 +378,7 @@ function hasConcreteMechanism(value: string) {
     hasParserFieldValidation ||
     hasRetryBackoffFlow ||
     hasSchemaDefaultArrayFlow ||
+    hasContentSanitizationFlow ||
     hasPersistenceSerializationFlow ||
     hasIndexConsistencyFlow
   );
@@ -408,6 +445,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     /\b(race|raced|orphan|dedupe|deduplicate|stale dist|dist diverge|dist diverged|diverge|diverged|econrefused|typeerror|threw|throws?|readiness issue|startup race|invalid note_tags|foreign_keys|cascade|nulling|source_run_key collision)\b/i
       .test(value) ||
     hasSchemaArrayFailureSignal(value) ||
+    hasContentSanitizationFailureSignal(value) ||
     hasPersistenceSnapshotFailureSignal(value) ||
     hasIndexConsistencyFailureSignal(value) ||
     hasDefaultDataDirectoryConsequence(value) ||
@@ -744,6 +782,8 @@ function isVisibleStatusSnapshotText(value: string) {
     .test(value);
   const hasSuccessStatus =
     /\b(ci green|ci completed successfully|tests? succeeded|testing succeeded|verification succeeded|build succeeded|typecheck succeeded|lint succeeded)\b/i
+      .test(value) ||
+    /\b(typecheck|lint|ci|build|tests?|testing|verification)\b.+\bcompleted successfully\b/i
       .test(value);
   const hasStatusVerb = /\b(checked|noted|observed|reviewed|resolved|tested|testing passed|verified|verification|current|status)\b/i
     .test(value);

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -72,6 +72,7 @@ function hasConcreteTransferableAction(value: string) {
     'pin',
     'prune',
     'rebuild',
+    'register',
     'remove',
     'replace',
     'retry',
@@ -237,9 +238,9 @@ function hasStrongRootCauseSignal(value: string) {
       .test(value) ||
     /\b(dist comparison|dist comparisons|generated dist output|dist output)\b.+\b(inconsistent|mismatch|wrong comparison|stale|diverged|diverge)\b.+\b(version parsing|package metadata|package version)\b/i
       .test(value) ||
-    /\b(because|so)\b.+\b(ran before|ran after|returned http [45]\d\d|returned [45]\d\d|http [45]\d\d|imported.+before|used the default data directory|version parsing|generated dist output|default data directory|fell back|fallback|diverged|raced|race|econrefused)\b/i
+    /\b(because|so)\b.+\b(ran before|ran after|returned http [45]\d\d|returned [45]\d\d|http [45]\d\d|imported.+before|used the default data directory|version parsing.+(inconsistent|mismatch|wrong|stale|diverged|diverge)|default data directory|fell back|fallback|diverged|raced|race|econrefused)\b/i
       .test(value) ||
-    /\b(ran before|ran after|returned http [45]\d\d|returned [45]\d\d|http [45]\d\d|imported.+before|used the default data directory|version parsing|generated dist output|default data directory|fell back|fallback|diverged|raced|race|econrefused)\b.+\b(because|so)\b/i
+    /\b(ran before|ran after|returned http [45]\d\d|returned [45]\d\d|http [45]\d\d|imported.+before|used the default data directory|version parsing.+(inconsistent|mismatch|wrong|stale|diverged|diverge)|default data directory|fell back|fallback|diverged|raced|race|econrefused)\b.+\b(because|so)\b/i
       .test(value)
   );
 }

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -49,6 +49,7 @@ const concreteActionWords = [
   'wait',
   'wait for',
   'wrap',
+  '注册',
   '避免',
   '防止',
   '复用',
@@ -99,6 +100,7 @@ function hasWord(text: string, word: string) {
 
 function hasConcreteTransferableAction(value: string) {
   const text = value.toLowerCase();
+  if (hasChineseRouteOrderingSignal(text)) return true;
   if (hasNegativeTransferableAction(text)) return true;
   if (hasSchemaDefaultArrayAction(text)) return true;
   if (hasDurableEngineeringPreventionAction(text)) return true;
@@ -784,6 +786,7 @@ function hasConcreteMechanism(value: string) {
   const hasFrontendCacheFlow = hasFrontendCacheInvalidationMechanism(text);
   const hasSqliteWalSidecarFlow = hasSqliteWalSidecarMechanism(text);
   return (
+    hasChineseRouteOrderingSignal(text) ||
     hasTimingOrder ||
     hasRaceReadiness ||
     hasPackageDistFlow ||
@@ -1282,6 +1285,7 @@ function isWeakRootCauseClaim(value: string) {
 
 function hasConcreteRootCauseMechanism(value: string) {
   const text = value.toLowerCase();
+  if (hasChineseRouteOrderingSignal(text)) return true;
   const hasRegistrationOrdering =
     /(?:\/api\/[\w/-]+|route|registration).+\b(was registered after request setup|registration ran after request setup|registered after request setup|ran after request setup)\b/i
       .test(text);
@@ -1305,6 +1309,19 @@ function hasConcreteRootCauseMechanism(value: string) {
 function hasGenericRootCauseRationale(value: string) {
   return /\bbecause\b.+\b(correctness|reliability|quality|it)\b.+\b(mattered|was important|is important)\b/i
     .test(value);
+}
+
+function hasChineseRouteOrderingSignal(value: string) {
+  return /\/api\/[\w/-]+/i.test(value) &&
+    /路由/.test(value) &&
+    /注册/.test(value) &&
+    /request setup/i.test(value) &&
+    (
+      /(?:在\s*)?request setup.{0,8}(?:前|之前).{0,24}注册/i.test(value) ||
+      /request setup.{0,12}(?:之后|后).{0,12}(?:才)?注册/i.test(value) ||
+      /注册.{0,24}(?:在\s*)?request setup.{0,8}(?:前|之前)/i.test(value)
+    ) &&
+    /(?:导致|避免|防止|返回|http\s*[45]\d\d)/i.test(value);
 }
 
 function hasConcreteHttpRootCauseSignal(value: string) {
@@ -1478,7 +1495,7 @@ function hasChineseVisibleMechanism(value: string) {
 function isChineseVisibleStatusShell(value: string) {
   if (!/[\u3400-\u9fff]/.test(value)) return false;
   const hasStatusRecordShell =
-    /(?:^|[\s：:])(?:状态记录|记录状态)(?:[\s：:]|$)|^状态\s*[：:]/i
+    /(?:^|[\s：:])(?:状态记录|记录状态|工作日志|日志记录|工作记录)(?:[\s：:]|$)|^(?:状态|记录)\s*[：:]/i
       .test(value) ||
     /(?:已记录|记录了).{0,80}(?:已修复|修复完成|已完成|完成|处理完成|解决完成)/i
       .test(value);

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1286,8 +1286,13 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
   const hasNamedListenerObject =
     /\b(websocket|web socket|message listener|event listener|useeffect cleanup|useeffect|remounts?|unmount|socket\.addeventlistener|socket\.removeeventlistener|addeventlistener|removeeventlistener)\b/i
       .test(text);
+  const hasNamedProcessLifecycleObject =
+    /\b(child_process|child process|daemon pid|pid|crystal serve -d|crystal status|spawn handshake|spawn|exit code\s*\d+|nonzero exit codes?|non-zero exit codes?|dead server|running server|false serve success)\b/i
+      .test(text) ||
+    /\bdaemon\b.+\bexit code\b|\bexit code\b.+\bdaemon\b/i
+      .test(text);
   const hasEngineeringContext =
-    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?|initialization|initialized|route|mcp|json-rpc|stdio|stdout|stderr|framing|transport|logs?|diagnostics?|tags?|joins?|deletion|cleanup|filter chips?|webui|websocket|listeners?|useeffect|remounts?|unmount)\b/i
+    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?|initialization|initialized|route|mcp|json-rpc|stdio|stdout|stderr|framing|transport|logs?|diagnostics?|tags?|joins?|deletion|cleanup|filter chips?|webui|websocket|listeners?|useeffect|remounts?|unmount|child_process|child process|daemon|pid|spawn|exit code|serve|status|dead server)\b/i
       .test(text);
   return (
     hasConcreteToken ||
@@ -1296,7 +1301,8 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
     hasNamedRelationObject ||
     hasNamedTransportObject ||
     hasNamedLifecycleObject ||
-    hasNamedListenerObject
+    hasNamedListenerObject ||
+    hasNamedProcessLifecycleObject
   ) && hasEngineeringContext;
 }
 
@@ -1337,6 +1343,13 @@ function hasStrictStructuralEngineeringAction(value: string) {
       .test(text) ||
     /\b(remove|cleanup|clean up)\b.+\b(message listener|event listener|websocket listener|socket\.removeeventlistener)\b/i
       .test(text);
+  const hasConcreteProcessLifecycleAction =
+    /\b(wait)\b.+\b(child_process|child process|spawn handshake|child)\b.+\b(spawn handshake|ready|exit codes?|pid)\b/i
+      .test(text) ||
+    /\b(reject|treat)\b.+\b(nonzero|non-zero|exit code\s*\d+|exit codes?)\b.+\b(serve failure|failure|before persisting|pid)\b/i
+      .test(text) ||
+    /\b(persist|persisting|write|writing)\b.+\bpid\b.+\b(after|before)\b.+\b(spawn handshake|child|exit event|ready)\b/i
+      .test(text);
   return hasStrictStructuralEngineeringEvidence(text) &&
     (
       hasAction ||
@@ -1345,7 +1358,8 @@ function hasStrictStructuralEngineeringAction(value: string) {
       hasConcreteRelationAction ||
       hasConcreteLifecycleAction ||
       hasConcreteTransportAction ||
-      hasConcreteListenerAction
+      hasConcreteListenerAction ||
+      hasConcreteProcessLifecycleAction
     );
 }
 
@@ -1436,8 +1450,17 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       .test(text) ||
     /\blistener cleanup\b.+\bprevents?\b.+\bduplicate messages?\b/i
       .test(text);
+  const hasProcessLifecycleFlow =
+    /\b(?:write|writes|wrote|writing|persist|persists|persisted|persisting)\b.+\b(?:daemon\s+)?pid\b.+\bbefore\b.+\b(?:observ(?:e|ed|ing).+exit event|child_process|child process|child is ready|spawn handshake|ready)\b/i
+      .test(text) ||
+    /\bexit code\s*\d+\b.+\b(?:looked like a running server|running server|dead server|serve failure|false serve success)\b/i
+      .test(text) ||
+    /\b(wait)\b.+\b(child_process|child process|spawn handshake)\b.+\b(reject|nonzero|non-zero|exit codes?)\b.+\bbefore\b.+\b(?:persist(?:ing)?|write|writing)\b.+\bpid\b/i
+      .test(text) ||
+    /\b(?:crystal status|status)\b.+\b(?:connect|connects|connecting)\b.+\bdead server\b/i
+      .test(text);
   const hasCausalFlow =
-    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gat(?:e|es|ed|ing)|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve|left|no longer existed|deleting notes?|note deletion|cleanup|prune|filter|duplicate|appended twice|remounts?|unmount)\b/i
+    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gat(?:e|es|ed|ing)|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve|left|no longer existed|deleting notes?|note deletion|cleanup|prune|filter|duplicate|appended twice|remounts?|unmount|spawn handshake|exit event|exit code|dead server|nonzero|non-zero)\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) &&
     hasCausalFlow &&
@@ -1450,17 +1473,18 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       hasRelationCleanupFlow ||
       hasInitializationOrderFlow ||
       hasTransportFramingFlow ||
-      hasListenerCleanupFlow
+      hasListenerCleanupFlow ||
+      hasProcessLifecycleFlow
     );
 }
 
 function hasStrictStructuralEngineeringFailureSignal(value: string) {
   const text = value.toLowerCase();
   const hasNamedConsequence =
-    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|duplicate messages?|duplicate websocket messages?|appended twice|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|orphan note_tags rows?|orphan tags?|unused tags?|count 0|joins? whose note_id no longer existed|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream))\b/i
+    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|duplicate messages?|duplicate websocket messages?|appended twice|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|orphan note_tags rows?|orphan tags?|unused tags?|count 0|joins? whose note_id no longer existed|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream)|false serve success|dead server|looked like a running server|running server|nonzero exit codes?|non-zero exit codes?|exit code\s*\d+)\b/i
       .test(text);
   const hasCausalFlow =
-    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|left|no longer existed|deleting notes?|note deletion|cleanup|filter|prune|remounts?|unmount|duplicate|appended twice)\b/i
+    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|left|no longer existed|deleting notes?|note deletion|cleanup|filter|prune|remounts?|unmount|duplicate|appended twice|spawn handshake|exit event|exit code|nonzero|non-zero|dead server)\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) && hasNamedConsequence && hasCausalFlow;
 }
@@ -1752,10 +1776,13 @@ function isExplicitEnglishStatusShell(value: string) {
 
 function isCurrentRunImplementationShell(value: string) {
   const text = value.trim();
+  const currentRunSubject = '(?:run|execution|fix|task|change)';
+  const currentRunPrefix = `(?:(?:in\\s+(?:this|the\\s+current)\\s+${currentRunSubject})|(?:(?:the\\s+)?current|this)\\s+${currentRunSubject})`;
+  const implementationVerb = '(?:use|uses|used|did|add|adds|added|set|sets|configured?|register(?:s|ed)?|wait(?:s|ed)?|block(?:s|ed)?|gate(?:s|d)?|ignore(?:s|d)?|cancel(?:s|ed|led)?|move(?:s|d)?|place(?:s|d)?|import(?:s|ed)?|update(?:s|d)?|fix(?:es|ed)?|change(?:s|d)?|validat(?:e|es|ed)|normaliz(?:e|es|ed)|parse(?:s|d)?|strip(?:s|ped)?|debounce(?:s|d)?|route(?:s|d)?|return(?:s|ed)?|prune(?:s|d)?|remove(?:s|d)?|wrap(?:s|ped)?)';
   const hasCurrentRunPrefix =
-    /^\s*(?:the\s+)?(?:this|current)\s+(?:run|execution|fix|task|change)\b/i.test(text);
+    new RegExp(`^\\s*${currentRunPrefix}\\b`, 'i').test(text);
   const hasImplementationAction =
-    /^\s*(?:the\s+)?(?:this|current)\s+(?:run|execution|fix|task|change)\b.{0,40}\b(?:use|uses|used|did|add|adds|added|set|sets|configured?|register(?:s|ed)?|wait(?:s|ed)?|block(?:s|ed)?|gate(?:s|d)?|ignore(?:s|d)?|cancel(?:s|ed|led)?|move(?:s|d)?|place(?:s|d)?|import(?:s|ed)?|update(?:s|d)?|fix(?:es|ed)?|change(?:s|d)?|validat(?:e|es|ed)|normaliz(?:e|es|ed)|parse(?:s|d)?|strip(?:s|ped)?|debounce(?:s|d)?|route(?:s|d)?|return(?:s|ed)?|prune(?:s|d)?|remove(?:s|d)?|wrap(?:s|ped)?)\b/i
+    new RegExp(`^\\s*${currentRunPrefix}\\b.{0,80}\\b${implementationVerb}\\b`, 'i')
       .test(text);
   return hasCurrentRunPrefix && hasImplementationAction && hasSpecificEvidence(text);
 }
@@ -1813,9 +1840,9 @@ function isChineseVisibleStatusShell(value: string) {
 
 function isChineseCurrentRunImplementationShell(value: string) {
   const hasCurrentRunPrefix =
-    /^\s*(?:本次运行|本次执行|本次修复|本次任务|本次改动)\b/i.test(value);
+    /^\s*(?:本次运行|本次执行|本次修复|本次任务|本次改动|本轮运行|本轮执行|本轮修复|本轮任务|本轮改动)/i.test(value);
   const hasImplementationAction =
-    /^\s*(?:本次运行|本次执行|本次修复|本次任务|本次改动).{0,40}(?:使用|用了|添加|设置|配置|注册|等待|阻塞|拦截|修复|改动|修改|更新|解析|清理|规范化|去重|剥离|去掉|取消|移动|放置|验证|校验)/i
+    /^\s*(?:本次运行|本次执行|本次修复|本次任务|本次改动|本轮运行|本轮执行|本轮修复|本轮任务|本轮改动).{0,80}(?:使用|用了|添加|设置|配置|注册|等待|阻塞|拦截|修复|改动|修改|更新|解析|清理|规范化|去重|剥离|去掉|取消|移动|放置|验证|校验|\b(?:use|uses|used|gate(?:s|d)?|add|adds|added|set|sets|configured?|register(?:s|ed)?|wait(?:s|ed)?|block(?:s|ed)?|ignore(?:s|d)?|cancel(?:s|ed|led)?|update(?:s|d)?|fix(?:es|ed)?|parse(?:s|d)?|strip(?:s|ped)?|debounce(?:s|d)?|return(?:s|ed)?|prune(?:s|d)?|remove(?:s|d)?)\b)/i
       .test(value);
   return hasCurrentRunPrefix && hasImplementationAction && hasSpecificEvidence(value);
 }

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -110,6 +110,7 @@ function hasConcreteTransferableAction(value: string) {
   if (hasDbTransactionAtomicityAction(text)) return true;
   if (hasSqlParameterizationAction(text)) return true;
   if (hasStrictStructuralEngineeringAction(text)) return true;
+  if (hasIndexConsistencyAction(text)) return true;
   if (hasElectronResourceAction(text)) return true;
   if (hasCrossPlatformPathAction(text)) return true;
   if (hasFrontendCacheInvalidationAction(text)) return true;
@@ -823,6 +824,15 @@ function hasIndexConsistencyEvidence(value: string) {
     .test(text);
 }
 
+function hasIndexConsistencyAction(value: string) {
+  const text = value.toLowerCase();
+  const hasAction = /\b(assert|verify|verified|check|test|testing|keep|remove|prune|clean(?:up| up))\b/i
+    .test(text);
+  return hasIndexConsistencyEvidence(text) &&
+    hasAction &&
+    (hasSqlVectorCleanupRelation(text) || hasSqlVectorCommitDivergence(text));
+}
+
 function hasIndexConsistencyMechanism(value: string) {
   const text = value.toLowerCase();
   const hasIndexReference =
@@ -842,7 +852,12 @@ function hasIndexConsistencyMechanism(value: string) {
   return hasIndexConsistencyEvidence(text) &&
     hasIndexReference &&
     hasDeletionOrCleanup &&
-    (hasStaleOrDeletedReference || hasRowIndexRelation);
+    (
+      hasStaleOrDeletedReference ||
+      hasRowIndexRelation ||
+      hasSqlVectorCleanupRelation(text) ||
+      hasSqlVectorCommitDivergence(text)
+    );
 }
 
 function hasIndexConsistencyFailureSignal(value: string) {
@@ -853,7 +868,34 @@ function hasIndexConsistencyFailureSignal(value: string) {
   const hasCausalDeletion =
     /\b(because|without|after delet(?:e|ing)|after removing|removed|deletion|delet(?:e|ed|es|ing)|cannot return|leaves?)\b/i
       .test(text);
-  return hasIndexConsistencyEvidence(text) && hasStaleReference && hasCausalDeletion;
+  const hasSameRunCleanupAssertion =
+    hasSqlVectorCleanupRelation(text) &&
+    /\b(same e2e run|one e2e run|same test|together)\b/i.test(text);
+  return hasIndexConsistencyEvidence(text) &&
+    (
+      (hasStaleReference && hasCausalDeletion) ||
+      hasSqlVectorCommitDivergence(text) ||
+      hasSameRunCleanupAssertion
+    );
+}
+
+function hasSqlVectorCleanupRelation(value: string) {
+  const text = value.toLowerCase();
+  const hasSqlStore = /\b(sql|sqlite|sql\.js|database|db|rows?)\b/i.test(text);
+  const hasVectorStore = /\b(vectra|vector|semantic search|search index|index entries?)\b/i.test(text);
+  const hasCleanupOrDeletion = /\b(delet(?:e|ed|es|ing|ion)|remov(?:e|ed|es|ing)|clean(?:up| up)|prun(?:e|ed|es|ing))\b/i
+    .test(text);
+  return hasSqlStore && hasVectorStore && hasCleanupOrDeletion;
+}
+
+function hasSqlVectorCommitDivergence(value: string) {
+  const text = value.toLowerCase();
+  const hasSqlCommit = /\b(sqlite|sql\.js|sql|database|db)\b.+\bcommits?\b/i.test(text);
+  const hasVectorCommit = /\b(vectra|vector)\b.+\bcommits?\b/i.test(text);
+  const hasDivergence = /\bdiverge|diverged|diverges|diverging|out of sync\b/i.test(text);
+  const hasCleanupContext = /\b(clean(?:up| up)|idempotent|delet(?:e|ed|es|ing|ion)|remov(?:e|ed|es|ing))\b/i
+    .test(text);
+  return hasSqlCommit && hasVectorCommit && hasDivergence && hasCleanupContext;
 }
 
 function hasFrontendCacheEvidence(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -85,10 +85,15 @@ function hasConcreteTransferableAction(value: string) {
 
 function isVagueGenericLesson(value: string) {
   const text = value.toLowerCase();
-  return (
-    /\b(the task|this task|the pattern|the implementation|implementation behavior|expected behavior|expected pattern|values?|input|correctness|going forward)\b/.test(text) &&
-    !hasSpecificObject(text)
-  );
+  const hasBoilerplateClaim =
+    /\bvalidation is important for correctness\b/.test(text) ||
+    /\bbecause\b.+\bis important for correctness\b/.test(text) ||
+    /\bthe (pattern|task) should\b/.test(text) ||
+    /\bshould validate\b.+\bbecause\b/.test(text) ||
+    /\bexpected pattern\b/.test(text);
+  const hasGenericTerms =
+    /\b(the task|this task|the pattern|the implementation|implementation behavior|expected behavior|expected pattern|values?|input|correctness|going forward)\b/.test(text);
+  return hasBoilerplateClaim || (hasGenericTerms && !hasSpecificObject(text));
 }
 
 function isGenericStatusAction(value: string) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -278,6 +278,8 @@ function hasPackageDistRootCauseSignal(value: string) {
     /\b(inconsistent|different formats)\b.+\b(version parsing|package version parsing|version normalization|package normalization)\b.+\bdist comparisons?\b.+\bunreliable\b/i
       .test(text) ||
     /\b(generated dist output|dist output)\b.+\bstale package metadata\b.+\bbecause\b.+\bversion bump\b.+\bran after\b.+\bdist generation\b/i
+      .test(text) ||
+    /\b(generated dist output|dist output)\b.+\bstale\b.+\bbecause\b.+\bdist generation\b.+\bran before\b.+\b(package metadata )?version bump\b/i
       .test(text);
   if ((isPackageArtifactObservationClaim(text) || isExistenceOnlyClaim(text)) && !hasExplicitPackageCausality(text)) {
     return false;

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -600,12 +600,16 @@ function isGenericReleaseValidationClaim(value: string) {
 
 function isVisibleStatusSnapshotText(value: string) {
   const hasPassStatus = /\b(build|npm test|tests?|testing)\b.+\bpassed\b/i.test(value);
+  const hasSuccessStatus =
+    /\b(ci green|tests? succeeded|testing succeeded|verification succeeded|build succeeded)\b/i
+      .test(value);
   const hasStatusVerb = /\b(checked|noted|observed|reviewed|resolved|tested|testing passed|verified|verification|current|status)\b/i
     .test(value);
   const hasStatusObject =
     /\b(node_env|env|environment|production|local|testing|server readiness|fastify readiness|api requests?|package version|version|generated dist output|dist output)\b/i
       .test(value);
-  return (hasPassStatus || (hasStatusVerb && hasStatusObject)) && !hasStrongReusableMechanism(value);
+  return (hasPassStatus || hasSuccessStatus || (hasStatusVerb && hasStatusObject)) &&
+    !hasStrongReusableMechanism(value);
 }
 
 function conclusionText(

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1291,8 +1291,13 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
       .test(text) ||
     /\bdaemon\b.+\bexit code\b|\bexit code\b.+\bdaemon\b/i
       .test(text);
+  const hasNamedMigrationObject =
+    /\b(sqlite|chatcrystal\.db|migration|migrations?|not null|default|existing rows?|existing \w+ rows?|notes column|column nullable|backfill|constraint)\b/i
+      .test(text) &&
+    /\b(migration|migrations?|not null|backfill|chatcrystal\.db|constraint)\b/i
+      .test(text);
   const hasEngineeringContext =
-    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?|initialization|initialized|route|mcp|json-rpc|stdio|stdout|stderr|framing|transport|logs?|diagnostics?|tags?|joins?|deletion|cleanup|filter chips?|webui|websocket|listeners?|useeffect|remounts?|unmount|child_process|child process|daemon|pid|spawn|exit code|serve|status|dead server)\b/i
+    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?|initialization|initialized|route|mcp|json-rpc|stdio|stdout|stderr|framing|transport|logs?|diagnostics?|tags?|joins?|deletion|cleanup|filter chips?|webui|websocket|listeners?|useeffect|remounts?|unmount|child_process|child process|daemon|pid|spawn|exit code|serve|status|dead server|migration|not null|default|backfill|column|startup)\b/i
       .test(text);
   return (
     hasConcreteToken ||
@@ -1302,7 +1307,8 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
     hasNamedTransportObject ||
     hasNamedLifecycleObject ||
     hasNamedListenerObject ||
-    hasNamedProcessLifecycleObject
+    hasNamedProcessLifecycleObject ||
+    hasNamedMigrationObject
   ) && hasEngineeringContext;
 }
 
@@ -1350,6 +1356,13 @@ function hasStrictStructuralEngineeringAction(value: string) {
       .test(text) ||
     /\b(persist|persisting|write|writing)\b.+\bpid\b.+\b(after|before)\b.+\b(spawn handshake|child|exit event|ready)\b/i
       .test(text);
+  const hasConcreteMigrationAction =
+    /\bbackfill\b.+\b(existing rows?|existing \w+ rows?|rows?)\b/i
+      .test(text) ||
+    /\badd\b.+\bcolumn\b.+\bnullable\b.+\bbackfill\b.+\benforce\b.+\bnot null\b/i
+      .test(text) ||
+    /\benforce\b.+\bnot null\b.+\b(after|then|once)\b.+\b(data|rows?|constraint)\b/i
+      .test(text);
   return hasStrictStructuralEngineeringEvidence(text) &&
     (
       hasAction ||
@@ -1359,7 +1372,8 @@ function hasStrictStructuralEngineeringAction(value: string) {
       hasConcreteLifecycleAction ||
       hasConcreteTransportAction ||
       hasConcreteListenerAction ||
-      hasConcreteProcessLifecycleAction
+      hasConcreteProcessLifecycleAction ||
+      hasConcreteMigrationAction
     );
 }
 
@@ -1459,8 +1473,19 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       .test(text) ||
     /\b(?:crystal status|status)\b.+\b(?:connect|connects|connecting)\b.+\bdead server\b/i
       .test(text);
+  const hasMigrationConstraintFlow =
+    /\bmigration\b.+\badd(?:ed)?\b.+\bnot null\b.+\bwithout a default\b/i
+      .test(text) ||
+    /\bnot null\b.+\bwithout a default\b.+\b(existing rows?|existing \w+ rows?|chatcrystal\.db rows?|constraint)\b/i
+      .test(text) ||
+    /\b(existing rows?|existing \w+ rows?|chatcrystal\.db rows?)\b.+\bviolat(?:e|ed|es|ing)\b.+\bconstraint\b/i
+      .test(text) ||
+    /\bbackfill\b.+\b(existing rows?|existing \w+ rows?|rows?)\b.+\b(enforce|not null|constraint)\b/i
+      .test(text) ||
+    /\badd\b.+\bcolumn\b.+\bnullable\b.+\bbackfill\b.+\benforce\b.+\bnot null\b/i
+      .test(text);
   const hasCausalFlow =
-    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gat(?:e|es|ed|ing)|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve|left|no longer existed|deleting notes?|note deletion|cleanup|prune|filter|duplicate|appended twice|remounts?|unmount|spawn handshake|exit event|exit code|dead server|nonzero|non-zero)\b/i
+    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gat(?:e|es|ed|ing)|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve|left|no longer existed|deleting notes?|note deletion|cleanup|prune|filter|duplicate|appended twice|remounts?|unmount|spawn handshake|exit event|exit code|dead server|nonzero|non-zero|backfill|not null|default|constraint|violat(?:e|ed|es|ing))\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) &&
     hasCausalFlow &&
@@ -1474,17 +1499,18 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       hasInitializationOrderFlow ||
       hasTransportFramingFlow ||
       hasListenerCleanupFlow ||
-      hasProcessLifecycleFlow
+      hasProcessLifecycleFlow ||
+      hasMigrationConstraintFlow
     );
 }
 
 function hasStrictStructuralEngineeringFailureSignal(value: string) {
   const text = value.toLowerCase();
   const hasNamedConsequence =
-    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|duplicate messages?|duplicate websocket messages?|appended twice|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|orphan note_tags rows?|orphan tags?|unused tags?|count 0|joins? whose note_id no longer existed|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream)|false serve success|dead server|looked like a running server|running server|nonzero exit codes?|non-zero exit codes?|exit code\s*\d+)\b/i
+    /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|duplicate messages?|duplicate websocket messages?|appended twice|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|orphan note_tags rows?|orphan tags?|unused tags?|count 0|joins? whose note_id no longer existed|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream)|false serve success|dead server|looked like a running server|running server|nonzero exit codes?|non-zero exit codes?|exit code\s*\d+|migration (?:does not )?fail(?:s|ed)?|migration failures?|existing row failures?|constraint violation|violated the constraint)\b/i
       .test(text);
   const hasCausalFlow =
-    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|left|no longer existed|deleting notes?|note deletion|cleanup|filter|prune|remounts?|unmount|duplicate|appended twice|spawn handshake|exit event|exit code|nonzero|non-zero|dead server)\b/i
+    /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|left|no longer existed|deleting notes?|note deletion|cleanup|filter|prune|remounts?|unmount|duplicate|appended twice|spawn handshake|exit event|exit code|nonzero|non-zero|dead server|backfill|not null|default|constraint|violat(?:e|ed|es|ing)|migration)\b/i
       .test(text);
   return hasStrictStructuralEngineeringEvidence(text) && hasNamedConsequence && hasCausalFlow;
 }
@@ -1769,9 +1795,21 @@ function isVisibleWorkLogClaim(value: string) {
 }
 
 function isExplicitEnglishStatusShell(value: string) {
-  return /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task)\s+(?:record|report|note|summary|update|log|entry)|(?:implementation|task|fix|execution|run|work|status)\s+results?|run\s+results?|work\s*log(?:\s+entry)?|worklog(?:\s+entry)?|status|record|update|implementation|result|outcome|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
+  return hasTechnicalPrefixStatusShell(value) ||
+    /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task)\s+(?:record|report|note|summary|update|log|entry)|(?:implementation|task|fix|execution|run|work|status)\s+results?|run\s+results?|work\s*log(?:\s+entry)?|worklog(?:\s+entry)?|status|record|update|implementation|result|outcome|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
     .test(value.trim()) ||
     isCurrentRunImplementationShell(value);
+}
+
+function hasTechnicalPrefixStatusShell(value: string) {
+  const text = value.trim();
+  const technicalPrefix = String.raw`(?:\/api\/[\w/-]+|[a-z0-9]+_[a-z0-9_]+|[a-z][a-z0-9_]*\.[a-z_][a-z0-9_]*|activerequestid|setresults|data_dir|node_env|child_process|jsonl|sqlite|sql\.js|websocket|mcp|json-rpc)`;
+  const englishShell = String.raw`(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task)\s+(?:record|report|note|summary|update|log|entry)|(?:status|record|update|implementation|result|outcome|completion(?:\s+(?:note|record))?|completed|done))`;
+  const chineseShell = String.raw`(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|运行结果|执行结果|结果记录|结果报告|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|结果|完成|已完成|完成说明)`;
+  return new RegExp(`^\\s*${technicalPrefix}\\s+${englishShell}\\s*(?:[:\\-\\u2013\\u2014])`, 'i')
+    .test(text) ||
+    new RegExp(`^\\s*${technicalPrefix}\\s*${chineseShell}\\s*(?:[：:\\-\\u2013\\u2014]|$)`, 'i')
+      .test(text);
 }
 
 function isCurrentRunImplementationShell(value: string) {
@@ -1820,6 +1858,7 @@ function hasChineseVisibleMechanism(value: string) {
 function isChineseVisibleStatusShell(value: string) {
   if (!/[\u3400-\u9fff]/.test(value)) return false;
   const hasStatusRecordShell =
+    hasTechnicalPrefixStatusShell(value) ||
     /^\s*(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|运行结果|执行结果|结果记录|结果报告|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|结果|完成|已完成|完成说明)\s*(?:[：:\-\u2013\u2014]|$)/i
       .test(value) ||
     /(?:^|[\s：:])(?:状态记录|记录状态|工作日志|日志记录|工作记录)(?:[\s：:]|$)|^(?:状态|记录)\s*[：:]/i

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -221,9 +221,15 @@ function hasConcreteTransferableText(value: string) {
     hasConcreteMechanism(value) &&
     hasFailureOrConsequenceSignal(value) &&
     !isExistenceOnlyClaim(value) &&
+    !isFirstPersonDiaryClaim(value) &&
     !isGenericStatusAction(value) &&
     !isVagueGenericLesson(value)
   );
+}
+
+function isFirstPersonDiaryClaim(value: string) {
+  return /\b(i|we)\s+(added|checked|verified|fixed|implemented|updated|changed|then)\b/i
+    .test(value);
 }
 
 function hasPackageItemSignal(value: string) {
@@ -431,6 +437,8 @@ function isMostlyOneOffStatus(note: MaterializedTaskMemoryNote) {
     'version',
     'status',
     'checked',
+    'verified',
+    'verification',
     'current',
     'package',
     'npm link',
@@ -462,7 +470,7 @@ function isStatusShapedSelfContainedItem(note: MaterializedTaskMemoryNote) {
 
   const text = joined(note);
   const hasStatusShape =
-    /\b(current|checked|checks?|status|local|package version|version|dist output|generated dist output)\b/i
+    /\b(current|checked|verified|verification|checks?|status|local|node_env|env|environment|production|package version|version|dist output|generated dist output)\b/i
       .test(text);
   return hasStatusShape && !hasStrongReusableMechanism(text);
 }

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -95,6 +95,8 @@ function isVagueGenericLesson(value: string) {
     /\bvalidation is important for correctness\b/.test(text) ||
     /\bcorrectness matters\b/.test(text) ||
     /\bcorrect pattern\b/.test(text) ||
+    /\bright value for reliability\b/.test(text) ||
+    /\b(for|so|because)\b.+\b(reliable|reliability|correctness)\b/.test(text) ||
     /\bbecause\b.+\bis important for correctness\b/.test(text) ||
     /\bshould\b.+\bbecause correctness\b/.test(text) ||
     /\bshould\b.+\bcorrect pattern\b/.test(text) ||
@@ -108,6 +110,8 @@ function isVagueGenericLesson(value: string) {
     /\bso the server works\b/.test(text) ||
     /\badd api config\b/.test(text) ||
     /\bcache server config\b/.test(text) ||
+    /\bbetter approach\b/.test(text) ||
+    /\bhandle\b.+\bproperly\b/.test(text) ||
     /\bexpected pattern\b/.test(text);
   const hasGenericTerms =
     /\b(the task|this task|the pattern|the implementation|implementation behavior|expected behavior|expected pattern|values?|input|correctness|going forward)\b/.test(text);
@@ -134,14 +138,42 @@ function hasSpecificEvidence(value: string) {
   return (
     /\b(data_dir|node_env|econrefused|note_tags|chatcrystal\.db|port|source_run_key|foreign_keys)\b|\/api\/[\w/-]+|\b[a-z0-9]+_[a-z0-9_]+\b|[a-z]:\\|\/[\w.-]+|[\u3400-\u9fff]/i
       .test(text) ||
-    /\b(request setup|package version|dist output|generated dist output|data directory|electron server|server entrypoint|client calls?)\b/i
+    /\b(api requests?|fastify readiness|server readiness|request setup|package metadata|package version|dist output|generated dist output|data directory|electron server|server entrypoint|client calls?)\b/i
       .test(text)
   );
 }
 
 function hasConcreteMechanism(value: string) {
-  return /\b(before importing|raced server startup|raced startup|resets foreign_keys|orphan rows|commits can diverge|used the default data directory|stale dist|dedupe by source_run_key|client calls raced|request setup timing|package version parsing|dist comparisons?|release checks?|startup used the default data directory|imported the server before|until readiness resolves|default data directory)\b/i
-    .test(value.toLowerCase());
+  const text = value.toLowerCase();
+  const hasTimingOrder =
+    /\b(before|after|until|when)\b.+\b(import|importing|issue|issuing|request|requests|setup|ready|readiness|server|startup|data_dir|entrypoint|metadata|dist|compare|comparing)\b/i
+      .test(text) ||
+    /\b(import|importing|issue|issuing|request|requests|setup|ready|readiness|server|startup|data_dir|entrypoint|metadata|dist|compare|comparing)\b.+\b(before|after|until|when)\b/i
+      .test(text);
+  const hasRaceReadiness =
+    /\b(race|raced|readiness|startup|econrefused)\b.+\b(request|requests|ready|server|client calls?|fastify)\b/i
+      .test(text) ||
+    /\b(request|requests|ready|server|client calls?|fastify)\b.+\b(race|raced|readiness|startup|econrefused)\b/i
+      .test(text);
+  const hasPackageDistFlow =
+    /\b(parse|parsing|normalize|normalizing|compare|comparing)\b.+\b(package metadata|package version|generated dist|dist output)\b/i
+      .test(text) ||
+    /\b(package metadata|package version|generated dist|dist output)\b.+\b(diverged|diverge|parse|parsing|normalize|normalizing|compare|comparing)\b/i
+      .test(text);
+  const hasDataDirFallback =
+    /\b(default data directory|data directory fallback|fell back|fallback)\b/i.test(text);
+  const hasRelationalCleanup =
+    /\b(foreign_keys|orphan rows|cascade|nulling|resets foreign_keys)\b/i.test(text);
+  const hasDedupeKey =
+    /\b(dedupe|deduplicate)\b.+\b(source_run_key|key)\b/i.test(text);
+  return (
+    hasTimingOrder ||
+    hasRaceReadiness ||
+    hasPackageDistFlow ||
+    hasDataDirFallback ||
+    hasRelationalCleanup ||
+    hasDedupeKey
+  );
 }
 
 function hasConcreteTransferableText(value: string) {
@@ -155,23 +187,37 @@ function hasConcreteTransferableText(value: string) {
   );
 }
 
+function hasActionableResolution(value: string) {
+  return (
+    hasNonPlaceholderMeaningfulText(value) &&
+    hasConcreteTransferableAction(value) &&
+    !isGenericStatusAction(value) &&
+    !isVagueGenericLesson(value)
+  );
+}
+
+function hasDurableFixSignal(note: MaterializedTaskMemoryNote) {
+  const rootCause = note.raw_payload.root_cause;
+  const resolution = note.raw_payload.resolution;
+  if (!rootCause || !resolution) return false;
+
+  const combined = `${rootCause}\n${resolution}`;
+  return (
+    hasNonPlaceholderMeaningfulText(rootCause) &&
+    hasActionableResolution(resolution) &&
+    hasSpecificEvidence(combined) &&
+    hasConcreteMechanism(combined) &&
+    !isGenericStatusAction(rootCause) &&
+    !isVagueGenericLesson(rootCause)
+  );
+}
+
 function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
   if (isMostlyOneOffStatus(note)) return false;
   const payload = note.raw_payload;
   const conclusions = note.key_conclusions.join('\n').toLowerCase();
-  const hasMeaningfulRootCause = Boolean(
-    payload.root_cause &&
-    hasNonPlaceholderMeaningfulText(payload.root_cause) &&
-    hasSpecificObject(payload.root_cause) &&
-    !isGenericStatusAction(payload.root_cause) &&
-    !isVagueGenericLesson(payload.root_cause),
-  );
-  const hasMeaningfulResolution = Boolean(
-    payload.resolution &&
-    hasConcreteTransferableText(payload.resolution),
-  );
   const hasStructuredSignal =
-    (hasMeaningfulRootCause && hasMeaningfulResolution) ||
+    hasDurableFixSignal(note) ||
     Boolean(payload.reusable_patterns?.some((item) => hasConcreteTransferableText(item))) ||
     Boolean(payload.pitfalls?.some((item) => hasConcreteTransferableText(item))) ||
     Boolean(payload.decisions?.some((item) => hasConcreteTransferableText(item)));

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -878,7 +878,9 @@ function hasChineseFirstPersonDiaryClaim(value: string) {
   ]))
     .map(regexEscape)
     .join('|');
-  return new RegExp(`(?:我|我们)(?:已经|已)?${chineseAction}|(?:我|我们)(?:已经|已)?(?:把|将).{0,80}(?:${chineseAction}|\\b(?:${englishAction})\\b)|(?:已经|已)(?:把|将).{0,80}(?:${chineseAction}|\\b(?:${englishAction})\\b)`, 'i')
+  const subjectElidedAction =
+    `(?:已经|已)(?:${chineseAction}|(?:把|将|在|为).{0,80}(?:${chineseAction}|\\b(?:${englishAction})\\b))`;
+  return new RegExp(`(?:我|我们)(?:已经|已)?${chineseAction}|(?:我|我们)(?:已经|已)?(?:把|将).{0,80}(?:${chineseAction}|\\b(?:${englishAction})\\b)|${subjectElidedAction}`, 'i')
     .test(value);
 }
 
@@ -1466,7 +1468,7 @@ function hasUsefulCodeSnippet(
 }
 
 function isPlaceholderFunctionCallSnippet(code: string) {
-  const normalized = code.trim().replace(/;$/, '').trim();
+  const normalized = normalizeSnippetForPlaceholderCall(code);
   const match = /^([A-Za-z_$][\w$]*)\s*\(([^()]*)\)$/.exec(normalized);
   if (!match) return false;
 
@@ -1479,6 +1481,20 @@ function isPlaceholderFunctionCallSnippet(code: string) {
   return args
     .split(',')
     .every((arg) => isSimplePlaceholderArgument(arg.trim()));
+}
+
+function normalizeSnippetForPlaceholderCall(code: string) {
+  let normalized = code.trim().replace(/;$/, '').trim();
+  for (let i = 0; i < 4; i += 1) {
+    const next = normalized
+      .replace(/^return\s+/i, '')
+      .replace(/^await\s+/i, '')
+      .replace(/^(?:const|let|var)\s+[A-Za-z_$][\w$]*\s*=\s*/i, '')
+      .trim();
+    if (next === normalized) break;
+    normalized = next.replace(/;$/, '').trim();
+  }
+  return normalized;
 }
 
 function isSimplePlaceholderArgument(value: string) {
@@ -1495,8 +1511,8 @@ function normalizeTagForQuality(tag: string) {
   for (let i = 0; i < 3; i += 1) {
     normalized = normalized
       .replace(/^#+\s*/, '')
-      .replace(/^[\[\]()（）【】]+/, '')
-      .replace(/[\[\]()（）【】]+$/, '')
+      .replace(/^[`"'“”‘’「」『』《》\[\]()（）【】]+/, '')
+      .replace(/[`"'“”‘’「」『』《》\[\]()（）【】]+$/, '')
       .replace(/[.。!！,，;；:：]+$/, '')
       .trim();
   }

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -256,7 +256,10 @@ function isFirstPersonDiaryClaim(value: string) {
     'updated',
     'verified',
   ].join('|');
-  return new RegExp(`(?:^|[:.!?]\\s*)\\b(?:i|we)\\s+(?:${diaryVerbs})\\b`, 'i')
+  return new RegExp(
+    `(?:^|[:.!?,;]\\s*|\\b(?:and|then|but|so)\\s+)\\b(?:i|we)\\s+(?:${diaryVerbs})\\b`,
+    'i',
+  )
     .test(value);
 }
 
@@ -590,7 +593,7 @@ function hasVisibleConclusionBoilerplate(note: MaterializedTaskMemoryNote) {
 }
 
 function isLowQualityVisibleConclusion(value: string) {
-  const labelMatch = /^\s*(root cause|resolution|pattern|decision|pitfall|takeaway|error signature):\s*/i
+  const labelMatch = /^\s*(root cause|resolution|pattern|decision|pitfall|takeaway|observation|build|test|error signature):\s*/i
     .exec(value);
   const label = labelMatch?.[1]?.toLowerCase();
   const body = value.slice(labelMatch?.[0]?.length ?? 0);
@@ -606,8 +609,17 @@ function isLowQualityVisibleConclusion(value: string) {
     isMetaReusableClaim(body) ||
     (shouldApplyGenericLessonGate && isVagueGenericLesson(body)) ||
     (shouldApplyGenericLessonGate && isVagueGenericFixClaim(body)) ||
+    (shouldApplyGenericLessonGate && !hasConcreteConclusionValue(body)) ||
     isGenericVisibleBoilerplateClaim(value) ||
     isGenericVisibleBoilerplateClaim(body)
+  );
+}
+
+function hasConcreteConclusionValue(value: string) {
+  return (
+    hasVisibleConcreteContent(value) ||
+    hasConcreteTransferableText(value) ||
+    hasFailureOrConsequenceSignal(value)
   );
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -50,9 +50,11 @@ function hasWord(text: string, word: string) {
 function hasConcreteTransferableAction(value: string) {
   const text = value.toLowerCase();
   const concreteActionWords = [
+    'add',
     'block',
     'cache',
     'collapse',
+    'configure',
     'compare',
     'comparing',
     'debounce',
@@ -67,14 +69,19 @@ function hasConcreteTransferableAction(value: string) {
     'migrate',
     'normalize',
     'parse',
+    'pin',
     'prune',
     'rebuild',
+    'remove',
+    'replace',
     'retry',
     'sanitize',
+    'set',
     'truncate',
     'validate',
     'wait',
     'wait for',
+    'wrap',
     '避免',
     '防止',
     '复用',
@@ -86,7 +93,11 @@ function isVagueGenericLesson(value: string) {
   const text = value.toLowerCase();
   const hasBoilerplateClaim =
     /\bvalidation is important for correctness\b/.test(text) ||
+    /\bcorrectness matters\b/.test(text) ||
+    /\bcorrect pattern\b/.test(text) ||
     /\bbecause\b.+\bis important for correctness\b/.test(text) ||
+    /\bshould\b.+\bbecause correctness\b/.test(text) ||
+    /\bshould\b.+\bcorrect pattern\b/.test(text) ||
     /\bthe (pattern|task) should\b/.test(text) ||
     /\bshould validate\b.+\bbecause\b/.test(text) ||
     /\bexpected pattern\b/.test(text);
@@ -107,7 +118,7 @@ function isGenericStatusAction(value: string) {
 }
 
 function hasSpecificObject(value: string) {
-  return /\b(server|readiness|client calls?|request setup|package version|dist output|release checks?|node_env|npm link|sqlite|database|tags?|note_tags|embedding|jsonl|cursor|codex|claude|mcp|api|url|port|path|config|environment|schema|queue|watcher|electron|window state)\b|\b[a-z0-9]+_[a-z0-9_]+\b|[a-z]:\\|\/[\w.-]+|[\u3400-\u9fff]/i
+  return /\b(server|readiness|client calls?|request setup|package version|dist output|release checks?|node_env|data_dir|data directory|entrypoint|startup|npm link|sqlite|database|tags?|note_tags|embedding|jsonl|cursor|codex|claude|mcp|api|url|port|path|config|environment|schema|queue|watcher|electron|window state)\b|\b[a-z0-9]+_[a-z0-9_]+\b|[a-z]:\\|\/[\w.-]+|[\u3400-\u9fff]/i
     .test(value.toLowerCase());
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -452,6 +452,7 @@ function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
   const hasFixSignal = hasDurableFixSignal(note);
   if (!hasVisibleTitleSummarySignal) return false;
   if (hasVisibleConclusionBoilerplate(note)) return false;
+  if (payload.outcome_type === 'fix') return hasFixSignal && hasVisibleFixSignal;
   if (hasFixSignal) return hasVisibleFixSignal;
   if (isMostlyOneOffStatus(note)) return false;
 
@@ -508,7 +509,10 @@ function isGenericVisibleBoilerplateClaim(value: string) {
   const text = value.toLowerCase();
   const hasGenericReliabilityFix =
     /\b(?:backend|api|server)?\s*reliability\s+fix\b/i.test(text) ||
-    /\bfix\b.+\breliability\b/i.test(text);
+    /\bfix\b.+\breliability\b/i.test(text) ||
+    /\breliability improvement\b/i.test(text) ||
+    /\bimprove\b.+\b(reliability|correctness)\b/i.test(text) ||
+    /\b(reliability|correctness)\b.+\bfuture requests?\b/i.test(text);
   const hasGenericFutureFailure =
     /\bfuture failure prevention\b/i.test(text) ||
     /\b(?:avoid|prevent|prevents?|prevention)\b.+\bfuture failures?\b/i.test(text) ||
@@ -529,12 +533,13 @@ function isGenericVisibleBoilerplateClaim(value: string) {
 }
 
 function isVisibleStatusSnapshotText(value: string) {
+  const hasPassStatus = /\b(build|npm test|tests?|testing)\b.+\bpassed\b/i.test(value);
   const hasStatusVerb = /\b(checked|noted|observed|reviewed|resolved|tested|testing passed|verified|verification|current|status)\b/i
     .test(value);
   const hasStatusObject =
     /\b(node_env|env|environment|production|local|testing|server readiness|fastify readiness|api requests?|package version|version|generated dist output|dist output)\b/i
       .test(value);
-  return hasStatusVerb && hasStatusObject && !hasStrongReusableMechanism(value);
+  return (hasPassStatus || (hasStatusVerb && hasStatusObject)) && !hasStrongReusableMechanism(value);
 }
 
 function conclusionText(

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -108,6 +108,7 @@ function hasConcreteTransferableAction(value: string) {
   if (hasCrossPlatformPathAction(text)) return true;
   if (hasFrontendCacheInvalidationAction(text)) return true;
   if (hasSqliteWalSidecarAction(text)) return true;
+  if (hasProviderBaseUrlAction(text)) return true;
   return concreteActionWords.some((word) => hasWord(text, word));
 }
 
@@ -209,6 +210,7 @@ function hasSpecificEvidence(value: string) {
     hasChineseTechnicalEvidence(text) ||
     hasSchemaArrayEvidence(text) ||
     hasJsonParsingEvidence(text) ||
+    hasProviderBaseUrlEvidence(text) ||
     hasDurableEngineeringEvidence(text) ||
     hasImportDedupeEvidence(text) ||
     hasContentSanitizationEvidence(text) ||
@@ -278,6 +280,55 @@ function hasJsonParsingFailureSignal(value: string) {
   const hasCausalFlow =
     /\b(because|so|returned|passed|before|can return|persist)\b/i.test(text);
   return hasJsonParsingEvidence(text) && hasParsingFailure && hasCausalFlow;
+}
+
+function hasProviderBaseUrlEvidence(value: string) {
+  const text = value.toLowerCase();
+  return /\/v1\/chat\/completions|\/chat\/completions|\/v1\b|\b(custom provider|openai-compatible client|custom_base_url|base url|provider base url|provider url|llm)\b/i
+    .test(text);
+}
+
+function hasProviderBaseUrlAction(value: string) {
+  const text = value.toLowerCase();
+  const hasAction = /\b(configure|configured|set|include|add)\b/i.test(text);
+  const hasTarget =
+    /\/v1\b|\b(custom_base_url|base url|provider base url|provider url|prefix|openai-compatible client)\b/i
+      .test(text);
+  return hasProviderBaseUrlEvidence(text) && hasAction && hasTarget;
+}
+
+function hasProviderBaseUrlMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasRelativeEndpointFlow =
+    /\b(openai-compatible client|client)\b.+\b(calls?|called|appends?|relative to)\b.+\b(\/chat\/completions|base url|base)\b/i
+      .test(text) ||
+    /\/chat\/completions.+\b(relative to|instead of|wrong endpoint)\b|\/chat\/completions.+\/v1\/chat\/completions/i
+      .test(text) ||
+    /\b(custom_base_url|base url|provider base url|provider url)\b.+\b(omitted|missing|without)\b.+\/v1\b/i
+      .test(text);
+  const hasConfiguredPrefixFlow =
+    /\b(configure|configured|set|include|add)\b.+\b(custom_base_url|base url|provider base url|provider url)\b.+(?:\/v1\b|\bprefix\b)/i
+      .test(text) ||
+    /(?:\/v1\b|\bprefix\b).+\b(before creating|creating)\b.+\b(openai-compatible client|client)\b/i
+      .test(text);
+  return hasProviderBaseUrlEvidence(text) &&
+    (hasRelativeEndpointFlow || hasConfiguredPrefixFlow);
+}
+
+function hasProviderBaseUrlFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasHttpNotFound =
+    /\b(http\s*)?404\b|\bnot found\b/i.test(text);
+  const hasWrongEndpointFlow =
+    /\b(omitted|missing|without)\b.+\/v1\b/i.test(text) ||
+    /\b(called|calls?)\b.+\/chat\/completions.+\b(instead of|rather than)\b.+\/v1\/chat\/completions/i
+      .test(text) ||
+    /\b(wrong endpoint|relative endpoint|relative to that base)\b/i.test(text);
+  const hasCausalFlow = /\b(because|so|otherwise|instead of)\b/i.test(text);
+  return hasProviderBaseUrlEvidence(text) &&
+    hasHttpNotFound &&
+    hasWrongEndpointFlow &&
+    hasCausalFlow;
 }
 
 function hasDurableEngineeringEvidence(value: string) {
@@ -674,6 +725,7 @@ function hasConcreteMechanism(value: string) {
       .test(text);
   const hasSchemaDefaultArrayFlow = hasSchemaDefaultArrayMechanism(text);
   const hasJsonParsingFlow = hasJsonParsingMechanism(text);
+  const hasProviderBaseUrlFlow = hasProviderBaseUrlMechanism(text);
   const hasDurableEngineeringFlow = hasDurableEngineeringMechanism(text);
   const hasImportDedupeFlow = hasImportDedupeMechanism(text);
   const hasContentSanitizationFlow = hasContentSanitizationMechanism(text);
@@ -695,6 +747,7 @@ function hasConcreteMechanism(value: string) {
     hasRetryBackoffFlow ||
     hasSchemaDefaultArrayFlow ||
     hasJsonParsingFlow ||
+    hasProviderBaseUrlFlow ||
     hasDurableEngineeringFlow ||
     hasImportDedupeFlow ||
     hasContentSanitizationFlow ||
@@ -798,6 +851,7 @@ function hasFailureOrConsequenceSignal(value: string) {
       .test(value) ||
     hasSchemaArrayFailureSignal(value) ||
     hasJsonParsingFailureSignal(value) ||
+    hasProviderBaseUrlFailureSignal(value) ||
     hasDurableEngineeringFailureSignal(value) ||
     hasImportDedupeFailureSignal(value) ||
     hasContentSanitizationFailureSignal(value) ||
@@ -952,7 +1006,9 @@ function hasGenericRootCauseRationale(value: string) {
 }
 
 function hasConcreteHttpRootCauseSignal(value: string) {
-  return hasConcreteRootCauseMechanism(value) || hasRateLimitRetryRootCauseSignal(value);
+  return hasConcreteRootCauseMechanism(value) ||
+    hasRateLimitRetryRootCauseSignal(value) ||
+    hasProviderBaseUrlFailureSignal(value);
 }
 
 function hasRateLimitRetryRootCauseSignal(value: string) {
@@ -1335,6 +1391,7 @@ function hasUsefulCodeSnippet(
   const code = snippet.code.trim();
   const description = snippet.description?.trim() ?? '';
   if (!hasMeaningfulText(code, 4, 4) || isPlaceholderText(code)) return false;
+  if (isPlaceholderFunctionCallSnippet(code)) return false;
   if (!hasNonPlaceholderMeaningfulText(description, 12, 8)) return false;
 
   const combined = `${language}\n${code}\n${description}`;
@@ -1351,6 +1408,7 @@ function hasUsefulCodeSnippet(
       .test(combined) ||
     hasSchemaArrayEvidence(combined) ||
     hasJsonParsingEvidence(combined) ||
+    hasProviderBaseUrlEvidence(combined) ||
     hasContentSanitizationEvidence(combined) ||
     hasPersistenceSnapshotEvidence(combined) ||
     hasIndexConsistencyEvidence(combined) ||
@@ -1358,6 +1416,22 @@ function hasUsefulCodeSnippet(
     hasDurableEngineeringEvidence(combined) ||
     hasSpecificEvidence(combined);
   return hasConcreteEvidence && hasConcreteCodeShape;
+}
+
+function isPlaceholderFunctionCallSnippet(code: string) {
+  const normalized = code.trim().replace(/;$/, '').trim();
+  const match = /^([A-Za-z_$][\w$]*)\s*\(([^()]*)\)$/.exec(normalized);
+  if (!match) return false;
+
+  const functionName = match[1].toLowerCase();
+  const placeholderNames = /^(fix|handle|dothing|do_thing|process|update|set)$/i;
+  if (!placeholderNames.test(functionName)) return false;
+
+  const args = match[2].trim();
+  if (!args) return true;
+  return args
+    .split(',')
+    .every((arg) => /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?$/.test(arg.trim()));
 }
 
 function hasLowQualityTags(note: MaterializedTaskMemoryNote) {

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -714,15 +714,21 @@ function hasIndexConsistencyFailureSignal(value: string) {
 
 function hasFrontendCacheEvidence(value: string) {
   const text = value.toLowerCase();
-  return /\b(react query|query keys?|deletenote|delete mutation|note delete mutation|tags cache|notes cache|sidebar|tag counts?|filter chips?|stale tag filters?|derived tag counts?)\b/i
+  return /\b(react query|querykey|query keys?|cache keys?|deletenote|delete mutation|note delete mutation|tags cache|notes cache|cache entry|active tag filter|tag filters?|request url|filtered rows?|sidebar|tag counts?|filter chips?|stale tag filters?|derived tag counts?)\b/i
     .test(text);
 }
 
 function hasFrontendCacheInvalidationAction(value: string) {
   const text = value.toLowerCase();
   const hasCacheAction = /\b(invalidate|invalidated|refetch|reload|refresh|update)\b/i.test(text);
-  const hasCacheTarget = /\b(cache|query keys?|react query|tags?|notes?|tag counts?)\b/i.test(text);
-  return hasFrontendCacheEvidence(text) && hasCacheAction && hasCacheTarget;
+  const hasCacheTarget = /\b(cache|querykey|query keys?|cache keys?|react query|tags?|notes?|tag counts?)\b/i.test(text);
+  const hasCacheKeyAction =
+    /\b(include|add)\b.+\b(active tag filter|tag filter|filter)\b.+\b(querykey|query key|cache key)\b/i
+      .test(text) ||
+    /\b(querykey|query key|cache key)\b.+\b(include|add|active tag filter|tag filter|filter|separate)\b/i
+      .test(text);
+  return hasFrontendCacheEvidence(text) &&
+    ((hasCacheAction && hasCacheTarget) || hasCacheKeyAction);
 }
 
 function hasFrontendCacheInvalidationMechanism(value: string) {
@@ -735,19 +741,31 @@ function hasFrontendCacheInvalidationMechanism(value: string) {
   const hasMutationOrDeleteContext =
     /\b(after|when|once|succeeds?|delete|deleted|deletenote|delete mutation|mutation|removed sql row|sql row)\b/i
       .test(text);
-  return hasFrontendCacheEvidence(text) && hasInvalidationFlow && hasMutationOrDeleteContext;
+  const hasCacheKeyFlow =
+    /\b(querykey|query key|cache key)\b.+\b(omit(?:s|ted)?|missing|without)\b.+\b(active tag filter|tag filter|filter)\b/i
+      .test(text) ||
+    /\b(active tag filter|tag filter|filter)\b.+\b(omit(?:ted)?|missing)\b.+\b(querykey|query key|cache key)\b/i
+      .test(text) ||
+    /\b(querykey|query key|cache key)\b.+\b(omitted|missing|without|include|included|active tag filter|tag filter|filter)\b.+\b(stale filtered rows?|request url|separate notes cache entry|cache entry)\b/i
+      .test(text) ||
+    /\b(notes cache|react query cache|cache)\b.+\b(reused|reuse)\b.+\bstale filtered rows?\b/i
+      .test(text) ||
+    /\b(active tag filter|tag filter|filter)\b.+\b(querykey|query key|cache key)\b.+\b(separate notes cache entry|stale filtered rows?|request url)\b/i
+      .test(text);
+  return hasFrontendCacheEvidence(text) &&
+    ((hasInvalidationFlow && hasMutationOrDeleteContext) || hasCacheKeyFlow);
 }
 
 function hasFrontendCacheFailureSignal(value: string) {
   const text = value.toLowerCase();
   const hasStaleUi =
-    /\b(stale|kept stale|does not show stale|cannot show stale|stale tag filters?|stale filter chips?|stale tag counts?|stale note tags?)\b/i
+    /\b(stale|kept stale|does not show stale|cannot show stale|stale filtered rows?|stale tag filters?|stale filter chips?|stale tag counts?|stale note tags?)\b/i
       .test(text);
   const hasUiTarget =
-    /\b(sidebar|filter chips?|tag filters?|tag counts?|derived tag counts?|ui|react query|tags cache|notes cache)\b/i
+    /\b(sidebar|filter chips?|tag filters?|active tag filter|tag counts?|derived tag counts?|ui|react query|querykey|query key|cache key|request url|filtered rows?|tags cache|notes cache|cache entry)\b/i
       .test(text);
   const hasCausalFlow =
-    /\b(so|because|after|but|did not invalidate|removed|delete|deletion|leaves?)\b/i
+    /\b(so|because|after|but|did not invalidate|removed|delete|deletion|leaves?|omitted|missing|reused|reuse|changed|separate)\b/i
       .test(text);
   return hasFrontendCacheEvidence(text) && hasStaleUi && hasUiTarget && hasCausalFlow;
 }
@@ -2224,7 +2242,7 @@ function isGenericReleaseValidationClaim(value: string) {
 }
 
 function isVisibleStatusSnapshotText(value: string) {
-  const hasPassStatus = /\b(build|npm test|tests?|testing|typecheck|lint|ci|verification)\b.+\bpassed\b/i
+  const hasPassStatus = /\b(build|npm test|tests?|testing|typecheck|lint|ci|verification|checks?)\b.+\bpassed\b/i
     .test(value);
   const hasSuccessStatus =
     /\b(ci green|ci completed successfully|tests? succeeded|testing succeeded|verification succeeded|build succeeded|typecheck succeeded|lint succeeded)\b/i
@@ -2241,7 +2259,7 @@ function isVisibleStatusSnapshotText(value: string) {
   const hasStatusVerb = /\b(checked|noted|observed|reviewed|resolved|tested|testing passed|verified|verification|current|status)\b/i
     .test(value);
   const hasChineseStatus =
-    /已验证|验证通过|测试通过|构建通过|编译通过|类型检查通过|检查通过|已修复|修复已验证|ci\s*通过|持续集成通过/i
+    /已验证|验证通过|测试通过|构建通过|编译通过|类型检查通过|检查通过|检查已通过|已修复|修复已验证|ci\s*通过|持续集成通过/i
       .test(value) ||
     isChineseVisibleStatusShell(value) ||
     /(?:提高|提升).{0,12}(?:可靠性|正确性)|(?:可靠性|正确性).{0,12}(?:提高|提升)/

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -115,6 +115,7 @@ function hasConcreteTransferableAction(value: string) {
   if (hasSqliteWalSidecarAction(text)) return true;
   if (hasProviderBaseUrlAction(text)) return true;
   if (hasEmbeddingModelConfigAction(text)) return true;
+  if (hasEsmImportExtensionAction(text)) return true;
   if (hasImportContentArrayAction(text)) return true;
   return concreteActionWords.some((word) => hasWord(text, word));
 }
@@ -220,6 +221,7 @@ function hasSpecificEvidence(value: string) {
     hasJsonParsingEvidence(text) ||
     hasProviderBaseUrlEvidence(text) ||
     hasEmbeddingModelConfigEvidence(text) ||
+    hasEsmImportExtensionEvidence(text) ||
     hasImportContentArrayEvidence(text) ||
     hasDurableEngineeringEvidence(text) ||
     hasImportDedupeEvidence(text) ||
@@ -434,6 +436,56 @@ function hasEmbeddingModelConfigFailureSignal(value: string) {
     /\b(because|so|which|caused|returned|reused|missing|did not expose|does not expose|without)\b/i
       .test(text);
   return hasEmbeddingModelConfigEvidence(text) && hasNamedFailure && hasCausalFlow;
+}
+
+function hasEsmImportExtensionEvidence(value: string) {
+  const text = value.toLowerCase();
+  const hasModuleToken =
+    /\b(typescript|tsx|node|esm|compiled esm|compiled dist|dist files?|dist|server typescript)\b/i
+      .test(text);
+  const hasSpecifierToken =
+    /\.js specifiers?|\.ts specifiers?|\.ts\b|\.js\b|import extension|typescript imports?|source imports?|esm modules?|compiled output/i
+      .test(text);
+  return hasModuleToken && hasSpecifierToken;
+}
+
+function hasEsmImportExtensionAction(value: string) {
+  const text = value.toLowerCase();
+  const hasAction = /\b(use|change|replace|import)\b/i.test(text);
+  const hasTarget =
+    /\.js specifiers?|typescript source imports?|server typescript imports?|source imports?/i
+      .test(text);
+  return hasEsmImportExtensionEvidence(text) && hasAction && hasTarget;
+}
+
+function hasEsmImportExtensionMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasEmitSpecifierFlow =
+    /\btypescript\b.+\b(imported|imports?)\b.+\.ts\b.+\b(compiled esm|emitted|emit)\b.+\.ts specifier/i
+      .test(text) ||
+    /\.ts specifier\b.+\b(node|dist|compiled)\b.+\b(resolve|resolves?|could not resolve)\b/i
+      .test(text) ||
+    /\bcompiled esm\b.+\b(emitted|emit)\b.+\.ts specifier/i
+      .test(text);
+  const hasJsSpecifierMappingFlow =
+    /\.js specifiers?\b.+\b(typescript|tsx|node|compiled dist|dist files?|esm modules?)\b/i
+      .test(text) ||
+    /\btsx\b.+\b(maps?|resolves?)\b.+\b(development|\.js specifiers?)\b/i
+      .test(text) ||
+    /\bnode\b.+\b(resolves?|runs?)\b.+\b(compiled dist|dist files?|compiled output|esm modules?)\b/i
+      .test(text);
+  return hasEsmImportExtensionEvidence(text) && (hasEmitSpecifierFlow || hasJsSpecifierMappingFlow);
+}
+
+function hasEsmImportExtensionFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasNamedFailure =
+    /\b(could not resolve|cannot resolve|module not found|breaks? tsx tests?|tests? fail(?:ed)?|build fail(?:ed)?|dist fail(?:ed)?)\b/i
+      .test(text);
+  const hasCausalFlow =
+    /\b(because|so|emitted|emit|compiled|directly|resolve|resolves?|mapped?|maps?|breaks?)\b/i
+      .test(text);
+  return hasEsmImportExtensionEvidence(text) && hasNamedFailure && hasCausalFlow;
 }
 
 function hasImportContentArrayEvidence(value: string) {
@@ -882,6 +934,7 @@ function hasConcreteMechanism(value: string) {
   const hasJsonParsingFlow = hasJsonParsingMechanism(text);
   const hasProviderBaseUrlFlow = hasProviderBaseUrlMechanism(text);
   const hasEmbeddingModelConfigFlow = hasEmbeddingModelConfigMechanism(text);
+  const hasEsmImportExtensionFlow = hasEsmImportExtensionMechanism(text);
   const hasImportContentArrayFlow = hasImportContentArrayMechanism(text);
   const hasDurableEngineeringFlow = hasDurableEngineeringMechanism(text);
   const hasImportDedupeFlow = hasImportDedupeMechanism(text);
@@ -910,6 +963,7 @@ function hasConcreteMechanism(value: string) {
     hasJsonParsingFlow ||
     hasProviderBaseUrlFlow ||
     hasEmbeddingModelConfigFlow ||
+    hasEsmImportExtensionFlow ||
     hasImportContentArrayFlow ||
     hasDurableEngineeringFlow ||
     hasImportDedupeFlow ||
@@ -1029,6 +1083,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     hasJsonParsingFailureSignal(value) ||
     hasProviderBaseUrlFailureSignal(value) ||
     hasEmbeddingModelConfigFailureSignal(value) ||
+    hasEsmImportExtensionFailureSignal(value) ||
     hasImportContentArrayFailureSignal(value) ||
     hasDurableEngineeringFailureSignal(value) ||
     hasImportDedupeFailureSignal(value) ||
@@ -1591,7 +1646,7 @@ function isVisibleWorkLogClaim(value: string) {
 }
 
 function isExplicitEnglishStatusShell(value: string) {
-  return /^\s*(?:work\s*log|worklog|status\s+record|status\s+update|status|record|execution\s+record|completion(?:\s+(?:note|record))?|completed|done|fix\s+record|this\s+fix|this\s+run|run\s+log)\s*(?:[:\-\u2013\u2014])/i
+  return /^\s*(?:(?:status|work|implementation|execution|completion|fix|run)\s+(?:record|report|note|summary|update|log)|work\s*log|worklog|status|record|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
     .test(value.trim());
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -57,6 +57,7 @@ function hasConcreteTransferableAction(value: string) {
   if (hasElectronResourceAction(text)) return true;
   if (hasCrossPlatformPathAction(text)) return true;
   if (hasFrontendCacheInvalidationAction(text)) return true;
+  if (hasSqliteWalSidecarAction(text)) return true;
   const concreteActionWords = [
     'add',
     'block',
@@ -211,6 +212,7 @@ function hasSpecificEvidence(value: string) {
     hasElectronResourceEvidence(text) ||
     hasCrossPlatformPathEvidence(text) ||
     hasFrontendCacheEvidence(text) ||
+    hasSqliteWalSidecarEvidence(text) ||
     hasHttpFailureSignal(text) ||
     /\b(api requests?|fastify readiness|server readiness|request setup|package metadata|package version|dist output|generated dist output|data directory|electron server|server entrypoint|client calls?)\b/i
       .test(text)
@@ -486,6 +488,62 @@ function hasFrontendCacheFailureSignal(value: string) {
   return hasFrontendCacheEvidence(text) && hasStaleUi && hasUiTarget && hasCausalFlow;
 }
 
+function hasSqliteWalSidecarEvidence(value: string) {
+  const text = value.toLowerCase();
+  return /\b(state\.vscdb(?:-(?:wal|shm))?|workspacestorage|cursor|trae|sql\.js|wal|shm|sidecars?|composer metadata|database rows?|chat rows?|committed wal pages?)\b/i
+    .test(text);
+}
+
+function hasSqliteWalSidecarAction(value: string) {
+  const text = value.toLowerCase();
+  const hasWalAction = /\b(copy|copied|include|open|opening|read|reading)\b/i.test(text);
+  const hasWalTarget =
+    /\b(state\.vscdb|state\.vscdb-wal|state\.vscdb-shm|wal|shm|sidecars?|sql\.js|database)\b/i
+      .test(text);
+  return hasSqliteWalSidecarEvidence(text) && hasWalAction && hasWalTarget;
+}
+
+function hasSqliteWalSidecarMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasCopySidecarFlow =
+    /\bcopy\b.+\bstate\.vscdb\b.+\b(?:state\.vscdb-wal|wal|-wal)\b.+\b(?:state\.vscdb-shm|shm|-shm)\b/i
+      .test(text) ||
+    /\b(?:wal|shm|sidecars?)\b.+\bcopy|copied\b/i.test(text);
+  const hasOpenWithSqlJsFlow =
+    /\b(before|when|so)\b.+\b(open|opening|sql\.js|committed wal pages?)\b/i.test(text) ||
+    /\b(open|opening|sql\.js|committed wal pages?)\b.+\b(before|when|so|sees?)\b/i.test(text);
+  const hasReadOnlyDbFlow =
+    /\b(reading only|read only)\b.+\bstate\.vscdb\b.+\bsql\.js\b/i.test(text) ||
+    /\bstate\.vscdb-wal\b.+\b(recent|composer metadata|committed wal pages?)\b/i.test(text);
+  return hasSqliteWalSidecarEvidence(text) &&
+    (
+      (hasCopySidecarFlow && hasOpenWithSqlJsFlow) ||
+      hasReadOnlyDbFlow
+    );
+}
+
+function hasSqliteWalSidecarFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasMissingOrStaleRows =
+    /\b(stale|missing|not missing|hides?|returned stale|returned missing|missing chat rows?|missing composer metadata|missing rows?)\b/i
+      .test(text);
+  const hasRowTarget =
+    /\b(composer metadata|composer rows?|chat rows?|database rows?|rows?|committed wal pages?|state\.vscdb-wal|wal)\b/i
+      .test(text);
+  const hasCausalFlow =
+    /\b(because|so|reading only|only state\.vscdb|before opening|kept recent|returned)\b/i
+      .test(text);
+  const hasDirectWalConsequence =
+    /\b(wal|state\.vscdb-wal|sidecars?)\b.+\b(hides?|stale|missing)\b.+\b(composer metadata|composer rows?|chat rows?|rows?)\b/i
+      .test(text) ||
+    /\b(hides?|stale|missing)\b.+\b(composer metadata|composer rows?|chat rows?|rows?)\b.+\b(wal|state\.vscdb-wal|sidecars?)\b/i
+      .test(text);
+  return hasSqliteWalSidecarEvidence(text) &&
+    hasMissingOrStaleRows &&
+    hasRowTarget &&
+    (hasCausalFlow || hasDirectWalConsequence);
+}
+
 function hasElectronResourceEvidence(value: string) {
   const text = value.toLowerCase();
   return /\b(packaged electron|packaged builds?|electron-builder|extraresources|process\.resourcespath|resourcespath|resource path|bundled server code|wasm|sql-wasm\.wasm|sql\.js|enoent|chatcrystal\.db)\b/i
@@ -619,6 +677,7 @@ function hasConcreteMechanism(value: string) {
   const hasElectronResourceFlow = hasElectronResourceMechanism(text);
   const hasCrossPlatformPathFlow = hasCrossPlatformPathMechanism(text);
   const hasFrontendCacheFlow = hasFrontendCacheInvalidationMechanism(text);
+  const hasSqliteWalSidecarFlow = hasSqliteWalSidecarMechanism(text);
   return (
     hasTimingOrder ||
     hasRaceReadiness ||
@@ -638,7 +697,8 @@ function hasConcreteMechanism(value: string) {
     hasIndexConsistencyFlow ||
     hasElectronResourceFlow ||
     hasCrossPlatformPathFlow ||
-    hasFrontendCacheFlow
+    hasFrontendCacheFlow ||
+    hasSqliteWalSidecarFlow
   );
 }
 
@@ -720,6 +780,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     hasElectronResourceFailureSignal(value) ||
     hasCrossPlatformPathFailureSignal(value) ||
     hasFrontendCacheFailureSignal(value) ||
+    hasSqliteWalSidecarFailureSignal(value) ||
     hasDefaultDataDirectoryConsequence(value) ||
     hasHttpFailureSignal(value)
   );

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -764,18 +764,24 @@ function hasIndexConsistencyFailureSignal(value: string) {
 
 function hasFrontendCacheEvidence(value: string) {
   const text = value.toLowerCase();
-  return /\b(react query|querykey|query keys?|cache keys?|deletenote|delete mutation|note delete mutation|tags cache|notes cache|cache entry|active tag filter|tag filters?|request url|filtered rows?|sidebar|tag counts?|filter chips?|stale tag filters?|derived tag counts?)\b/i
+  return /\b(react query|querykey|query keys?|cache key|cache keys?|redis|i18n|tenant_id|locale|phrase_id|translations?|translation rows?|cached english|zh-cn|deletenote|delete mutation|note delete mutation|tags cache|notes cache|cache entry|active tag filter|tag filters?|request url|filtered rows?|sidebar|tag counts?|filter chips?|stale tag filters?|derived tag counts?)\b/i
     .test(text);
 }
 
 function hasFrontendCacheInvalidationAction(value: string) {
   const text = value.toLowerCase();
   const hasCacheAction = /\b(invalidate|invalidated|refetch|reload|refresh|update)\b/i.test(text);
-  const hasCacheTarget = /\b(cache|querykey|query keys?|cache keys?|react query|tags?|notes?|tag counts?)\b/i.test(text);
+  const hasCacheTarget = /\b(cache|querykey|query keys?|cache keys?|react query|redis|i18n|translations?|translation rows?|tags?|notes?|tag counts?)\b/i.test(text);
   const hasCacheKeyAction =
     /\b(include|add)\b.+\b(active tag filter|tag filter|filter)\b.+\b(querykey|query key|cache key)\b/i
       .test(text) ||
     /\b(querykey|query key|cache key)\b.+\b(include|add|active tag filter|tag filter|filter|separate)\b/i
+      .test(text) ||
+    /\b(include|add|build|compose|derive|set)\b.+\b(tenant_id|locale|phrase_id)\b.+\b(cache key|cache keys?)\b/i
+      .test(text) ||
+    /\b(build|compose|derive|set)\b.+\b(cache key|cache keys?)\b.+\b(tenant_id|locale|phrase_id)\b/i
+      .test(text) ||
+    /\b(cache key|cache keys?)\b.+\b(tenant_id|locale|phrase_id)\b/i
       .test(text);
   return hasFrontendCacheEvidence(text) &&
     ((hasCacheAction && hasCacheTarget) || hasCacheKeyAction);
@@ -796,9 +802,15 @@ function hasFrontendCacheInvalidationMechanism(value: string) {
       .test(text) ||
     /\b(active tag filter|tag filter|filter)\b.+\b(omit(?:ted)?|missing)\b.+\b(querykey|query key|cache key)\b/i
       .test(text) ||
-    /\b(querykey|query key|cache key)\b.+\b(omitted|missing|without|include|included|active tag filter|tag filter|filter)\b.+\b(stale filtered rows?|request url|separate notes cache entry|cache entry)\b/i
+    /\b(querykey|query key|cache key)\b.+\b(omitted|missing|without|include|included|active tag filter|tag filter|filter|tenant_id|locale|phrase_id)\b.+\b(stale filtered rows?|stale translations?|wrong translations?|cached english|english strings?|zh-cn|request url|separate notes cache entry|cache entry)\b/i
       .test(text) ||
     /\b(notes cache|react query cache|cache)\b.+\b(reused|reuse)\b.+\bstale filtered rows?\b/i
+      .test(text) ||
+    /\b(redis|i18n|cache|cache key|cache keys?)\b.+\b(reused|reuse)\b.+\b(cached english|english strings?|stale translations?|wrong translations?|zh-cn)\b/i
+      .test(text) ||
+    /\bcach(?:e|ing)\b.+\btranslations?\b.+\bonly by\b.+\bphrase_id\b.+\b(reused|reuse)\b.+\b(english strings?|cached english|zh-cn)\b/i
+      .test(text) ||
+    /\b(cache key|cache keys?)\b.+\b(used|uses|omit(?:s|ted)?|without)\b.+\bphrase_id\b.+\b(without|no|omit(?:s|ted)?)\b.+\blocale\b/i
       .test(text) ||
     /\b(active tag filter|tag filter|filter)\b.+\b(querykey|query key|cache key)\b.+\b(separate notes cache entry|stale filtered rows?|request url)\b/i
       .test(text);
@@ -809,13 +821,13 @@ function hasFrontendCacheInvalidationMechanism(value: string) {
 function hasFrontendCacheFailureSignal(value: string) {
   const text = value.toLowerCase();
   const hasStaleUi =
-    /\b(stale|kept stale|does not show stale|cannot show stale|stale filtered rows?|stale tag filters?|stale filter chips?|stale tag counts?|stale note tags?)\b/i
+    /\b(stale|kept stale|does not show stale|cannot show stale|stale filtered rows?|stale tag filters?|stale filter chips?|stale tag counts?|stale note tags?|stale translations?|wrong translations?|cached english|english strings?)\b/i
       .test(text);
   const hasUiTarget =
-    /\b(sidebar|filter chips?|tag filters?|active tag filter|tag counts?|derived tag counts?|ui|react query|querykey|query key|cache key|request url|filtered rows?|tags cache|notes cache|cache entry)\b/i
+    /\b(sidebar|filter chips?|tag filters?|active tag filter|tag counts?|derived tag counts?|ui|react query|redis|i18n|tenant_id|locale|phrase_id|querykey|query key|cache key|request url|filtered rows?|translations?|translation rows?|tags cache|notes cache|cache entry|zh-cn)\b/i
       .test(text);
   const hasCausalFlow =
-    /\b(so|because|after|but|did not invalidate|removed|delete|deletion|leaves?|omitted|missing|reused|reuse|changed|separate)\b/i
+    /\b(so|because|after|but|did not invalidate|removed|delete|deletion|leaves?|omitted|missing|without|reused|reuse|used|only by|changed|separate)\b/i
       .test(text);
   return hasFrontendCacheEvidence(text) && hasStaleUi && hasUiTarget && hasCausalFlow;
 }
@@ -2106,6 +2118,7 @@ function isExplicitEnglishStatusShell(value: string) {
     /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task|progress|verification|validation|regression|qa|diagnostics?|(?:smoke\s+)?test)\s+(?:record|report|note|summary|update|log|entry|check|result|results?|confirmed)|(?:implementation|task|fix|execution|run|work|status)\s+results?|run\s+results?|work\s*log(?:\s+entry)?|worklog(?:\s+entry)?|status|record|update|implementation|result|outcome|progress|verification|validation|regression|qa|check|diagnostics?|(?:smoke\s+)?test|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
       .test(value.trim()) ||
     isValidationResultStatusShell(value) ||
+    isDiagnosticEvidenceStatusShell(value) ||
     isConfirmationResultStatusShell(value) ||
     isPredicateResultStatusShell(value) ||
     isCurrentRunImplementationShell(value) ||
@@ -2114,6 +2127,11 @@ function isExplicitEnglishStatusShell(value: string) {
 
 function isValidationResultStatusShell(value: string) {
   return /^\s*(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,2}\s+)?(?:validation|regression|qa)\s+(?:confirmed|passed|succeeded|completed)\b/i
+    .test(value.trim());
+}
+
+function isDiagnosticEvidenceStatusShell(value: string) {
+  return /^\s*(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,2}\s+)?diagnostic evidence\s+(?:found|shows?|confirmed|indicates?)\b/i
     .test(value.trim());
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -119,6 +119,7 @@ function hasConcreteTransferableAction(value: string) {
   if (hasEsmImportExtensionAction(text)) return true;
   if (hasImportContentArrayAction(text)) return true;
   if (hasSignatureRawBodyAction(text)) return true;
+  if (hasAdvisoryLockTransactionAction(text)) return true;
   return concreteActionWords.some((word) => hasWord(text, word));
 }
 
@@ -226,6 +227,7 @@ function hasSpecificEvidence(value: string) {
     hasEsmImportExtensionEvidence(text) ||
     hasImportContentArrayEvidence(text) ||
     hasSignatureRawBodyEvidence(text) ||
+    hasAdvisoryLockTransactionEvidence(text) ||
     hasDurableEngineeringEvidence(text) ||
     hasImportDedupeEvidence(text) ||
     hasContentSanitizationEvidence(text) ||
@@ -577,6 +579,50 @@ function hasSignatureRawBodyFailureSignal(value: string) {
     /\b(because|so|before|after|can|could|changed|normalize|normalized|reconstructed|fail|rejected)\b/i
       .test(text);
   return hasSignatureRawBodyEvidence(text) && hasSignatureFailure && hasCausalFlow;
+}
+
+function hasAdvisoryLockTransactionEvidence(value: string) {
+  const text = value.toLowerCase();
+  return /\b(pg_advisory(?:_xact)?_lock|advisory locks?|session locks?|transaction-scoped|stale locks?|queue workers?|failed job rollbacks?|job transaction)\b/i
+    .test(text) &&
+    /\b(lock|locks?|pg_advisory|rollback|queue workers?|job transaction)\b/i
+      .test(text);
+}
+
+function hasAdvisoryLockTransactionAction(value: string) {
+  const text = value.toLowerCase();
+  const hasScopedLockAction =
+    /\b(use|switch to|acquire)\b.+\b(pg_advisory_xact_lock|transaction-scoped|xact lock|job transaction)\b/i
+      .test(text) ||
+    /\bpg_advisory_xact_lock\b.+\b(transaction|rollback|releases? the lock|next retry)\b/i
+      .test(text);
+  return hasAdvisoryLockTransactionEvidence(text) && hasScopedLockAction;
+}
+
+function hasAdvisoryLockTransactionMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasSessionLockRollbackFlow =
+    /\b(session-scoped|session locks?|pg_advisory_lock)\b.+\b(surviv(?:e|ed|es)|failed jobs?|rollback|rollbacks?|stale locks?|block(?:ed)? queue workers?)\b/i
+      .test(text) ||
+    /\bstale locks?\b.+\b(block(?:ed)?|queue workers?|retries)\b/i
+      .test(text);
+  const hasXactLockReleaseFlow =
+    /\b(pg_advisory_xact_lock|transaction-scoped)\b.+\b(rollback|releases? the lock|job transaction|next retry)\b/i
+      .test(text) ||
+    /\brollback\b.+\breleases? the lock\b.+\b(next retry|queue workers?|failed jobs?)\b/i
+      .test(text);
+  return hasAdvisoryLockTransactionEvidence(text) && (hasSessionLockRollbackFlow || hasXactLockReleaseFlow);
+}
+
+function hasAdvisoryLockTransactionFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasLockFailure =
+    /\b(stale locks?|block(?:ed)? queue workers?|surviv(?:e|ed|es) failed job rollbacks?|failed job rollbacks?|session locks? can survive|rollback releases the lock)\b/i
+      .test(text);
+  const hasCausalFlow =
+    /\b(because|so|after|before|rollback|rollbacks?|failed jobs?|surviv(?:e|ed|es)|block(?:ed)?|retries|releases?)\b/i
+      .test(text);
+  return hasAdvisoryLockTransactionEvidence(text) && hasLockFailure && hasCausalFlow;
 }
 
 function hasDurableEngineeringEvidence(value: string) {
@@ -1019,6 +1065,7 @@ function hasConcreteMechanism(value: string) {
   const hasEsmImportExtensionFlow = hasEsmImportExtensionMechanism(text);
   const hasImportContentArrayFlow = hasImportContentArrayMechanism(text);
   const hasSignatureRawBodyFlow = hasSignatureRawBodyMechanism(text);
+  const hasAdvisoryLockTransactionFlow = hasAdvisoryLockTransactionMechanism(text);
   const hasDurableEngineeringFlow = hasDurableEngineeringMechanism(text);
   const hasImportDedupeFlow = hasImportDedupeMechanism(text);
   const hasContentSanitizationFlow = hasContentSanitizationMechanism(text);
@@ -1050,6 +1097,7 @@ function hasConcreteMechanism(value: string) {
     hasEsmImportExtensionFlow ||
     hasImportContentArrayFlow ||
     hasSignatureRawBodyFlow ||
+    hasAdvisoryLockTransactionFlow ||
     hasDurableEngineeringFlow ||
     hasImportDedupeFlow ||
     hasContentSanitizationFlow ||
@@ -1187,6 +1235,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     hasEsmImportExtensionFailureSignal(value) ||
     hasImportContentArrayFailureSignal(value) ||
     hasSignatureRawBodyFailureSignal(value) ||
+    hasAdvisoryLockTransactionFailureSignal(value) ||
     hasDurableEngineeringFailureSignal(value) ||
     hasImportDedupeFailureSignal(value) ||
     hasContentSanitizationFailureSignal(value) ||
@@ -2153,7 +2202,7 @@ function isConfirmationResultStatusShell(value: string) {
 function isPredicateResultStatusShell(value: string) {
   const text = value.trim();
   return hasSpecificEvidence(text) &&
-    /^\s*(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,2}\s+)?(?:(?:smoke\s+)?test|result|progress|validation|qa)\s+(?:shows?|is)\b/i
+    /^\s*(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,2}\s+)?(?:(?:smoke\s+)?test|result|progress|validation|qa|check|acceptance)\s+(?:shows?|is)\b/i
       .test(text);
 }
 

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1904,9 +1904,11 @@ function hasTechnicalPrefixStatusShell(value: string) {
   const chineseDescriptorPrefix = String.raw`(?:[\u3400-\u9fff]{2,16})`;
   const technicalPrefix = String.raw`(?:\/api\/[\w/-]+|[a-z0-9]+_[a-z0-9_]+|[a-z][a-z0-9_]*\.[a-z_][a-z0-9_]*|activerequestid|setresults|data_dir|node_env|child_process|jsonl|sqlite|sql\.js|websocket|mcp|json-rpc|${descriptorWord}(?:\s+${descriptorWord}){0,2}|${chineseDescriptorWord}(?:\s+${chineseDescriptorWord}){0,2}|${englishDescriptorPrefix}|${chineseDescriptorPrefix})`;
   const englishShell = String.raw`(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task)\s+(?:record|report|note|summary|update|log|entry)|(?:status|record|update|implementation|result|outcome|completion(?:\s+(?:note|record))?|completed|done))`;
-  const chineseShell = String.raw`(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|运行结果|执行结果|结果记录|结果报告|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|结果|完成|已完成|完成说明)`;
+  const chineseShell = String.raw`(?:状态记录|记录状态|工作日志|日志记录|工作记录|执行记录|完成记录|状态更新|运行结果|执行结果|结果记录|结果报告|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|状态|结果|完成|已完成|完成说明)`;
   return new RegExp(`^\\s*${technicalPrefix}\\s+${englishShell}\\s*(?:[:\\-\\u2013\\u2014])`, 'i')
     .test(text) ||
+    new RegExp(`^\\s*${technicalPrefix}\\s+${englishShell}\\s+(?:for|on|about)\\b`, 'i')
+      .test(text) ||
     new RegExp(`^\\s*${technicalPrefix}\\s*${chineseShell}\\s*(?:[：:\\-\\u2013\\u2014]|$)`, 'i')
       .test(text);
 }

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -199,6 +199,7 @@ function hasSpecificEvidence(value: string) {
       .test(text) ||
     hasChineseTechnicalEvidence(text) ||
     hasSchemaArrayEvidence(text) ||
+    hasJsonParsingEvidence(text) ||
     hasDurableEngineeringEvidence(text) ||
     hasImportDedupeEvidence(text) ||
     hasContentSanitizationEvidence(text) ||
@@ -233,6 +234,37 @@ function hasSchemaDefaultArrayMechanism(value: string) {
   const hasIterationOrHandler =
     /\b(iterat(?:e|ed|es|ing|ion)|handler|handler logic)\b/i.test(text);
   return hasSchemaArrayEvidence(text) && hasOptionalOrDefaultArray && hasIterationOrHandler;
+}
+
+function hasJsonParsingEvidence(value: string) {
+  const text = value.toLowerCase();
+  return /```json|\b(generatetext|extractjson|json\.parse|syntaxerror|llm summaries?|llm summary|fenced output|fenced objects?|markdown fences?|json fences?|fence text|note fields?|parsed title|parsed summary|parsed conclusions)\b/i
+    .test(text);
+}
+
+function hasJsonParsingMechanism(value: string) {
+  const text = value.toLowerCase();
+  const hasFenceOrParser =
+    /```json|\b(extractjson|json\.parse|fences?|fenced|markdown fences?|parse|parsing|parsed)\b/i
+      .test(text);
+  const hasStripBeforeParse =
+    /\b(strip|stripped|remove|removed|trim)\b.+\b(fences?|fenced|markdown|json\.parse|parse|parsing)\b/i
+      .test(text) ||
+    /\b(fences?|fenced|markdown)\b.+\b(strip|stripped|remove|removed|trim)\b/i
+      .test(text) ||
+    /\bbefore\b.+\b(json\.parse|parse|parsing|calling json\.parse)\b/i
+      .test(text);
+  return hasJsonParsingEvidence(text) && hasFenceOrParser && hasStripBeforeParse;
+}
+
+function hasJsonParsingFailureSignal(value: string) {
+  const text = value.toLowerCase();
+  const hasParsingFailure =
+    /\b(syntaxerror|throw|threw|throws?|parsing threw|not persisted|before note fields were persisted|fenced output|fenced objects?)\b/i
+      .test(text);
+  const hasCausalFlow =
+    /\b(because|so|returned|passed|before|can return|persist)\b/i.test(text);
+  return hasJsonParsingEvidence(text) && hasParsingFailure && hasCausalFlow;
 }
 
 function hasDurableEngineeringEvidence(value: string) {
@@ -451,6 +483,7 @@ function hasConcreteMechanism(value: string) {
     /\b(rate[- ]limit|http 429|429|retry-after|backoff|delay)\b.+\b(retry|retried|retries|queue|queued|provider requests?)\b/i
       .test(text);
   const hasSchemaDefaultArrayFlow = hasSchemaDefaultArrayMechanism(text);
+  const hasJsonParsingFlow = hasJsonParsingMechanism(text);
   const hasDurableEngineeringFlow = hasDurableEngineeringMechanism(text);
   const hasImportDedupeFlow = hasImportDedupeMechanism(text);
   const hasContentSanitizationFlow = hasContentSanitizationMechanism(text);
@@ -467,6 +500,7 @@ function hasConcreteMechanism(value: string) {
     hasParserFieldValidation ||
     hasRetryBackoffFlow ||
     hasSchemaDefaultArrayFlow ||
+    hasJsonParsingFlow ||
     hasDurableEngineeringFlow ||
     hasImportDedupeFlow ||
     hasContentSanitizationFlow ||
@@ -536,6 +570,7 @@ function hasFailureOrConsequenceSignal(value: string) {
     /\b(race|raced|orphan|dedupe|deduplicate|stale dist|dist diverge|dist diverged|diverge|diverged|econrefused|typeerror|threw|throws?|readiness issue|startup race|invalid note_tags|foreign_keys|cascade|nulling|source_run_key collision)\b/i
       .test(value) ||
     hasSchemaArrayFailureSignal(value) ||
+    hasJsonParsingFailureSignal(value) ||
     hasDurableEngineeringFailureSignal(value) ||
     hasImportDedupeFailureSignal(value) ||
     hasContentSanitizationFailureSignal(value) ||
@@ -1030,6 +1065,51 @@ function hasStrongReusableMechanism(value: string) {
     .test(value);
 }
 
+function hasLowQualityCodeSnippets(note: MaterializedTaskMemoryNote) {
+  return Boolean(note.raw_payload.code_snippets?.some((snippet) => !hasUsefulCodeSnippet(snippet)));
+}
+
+function hasUsefulCodeSnippet(
+  snippet: NonNullable<MaterializedTaskMemoryNote['raw_payload']['code_snippets']>[number],
+) {
+  const language = snippet.language.trim().toLowerCase();
+  const code = snippet.code.trim();
+  const description = snippet.description?.trim() ?? '';
+  if (!hasMeaningfulText(code, 4, 4) || isPlaceholderText(code)) return false;
+  if (!hasNonPlaceholderMeaningfulText(description, 12, 8)) return false;
+
+  const combined = `${language}\n${code}\n${description}`;
+  const hasConcreteCodeShape =
+    /[{}();=<>]/.test(code) ||
+    /\b(pragma|select|insert|update|delete|create table|json\.parse|z\.object|z\.array|const|let|function|return|import|export|class)\b/i
+      .test(code) ||
+    /\/api\/[\w/-]+|\b[a-z0-9]+_[a-z0-9_]+\b/i.test(code);
+  const hasConcreteEvidence =
+    /\b(pragma\s+foreign_keys|foreign_keys|json\.parse|z\.object|z\.array|response_item\.content|data_dir|node_env|source_run_key|note_tags)\b/i
+      .test(combined) ||
+    hasSchemaArrayEvidence(combined) ||
+    hasJsonParsingEvidence(combined) ||
+    hasContentSanitizationEvidence(combined) ||
+    hasPersistenceSnapshotEvidence(combined) ||
+    hasIndexConsistencyEvidence(combined) ||
+    hasImportDedupeEvidence(combined) ||
+    hasDurableEngineeringEvidence(combined) ||
+    hasSpecificEvidence(combined);
+  const isPlainText = /^(text|txt|plain|plaintext)$/.test(language);
+  return hasConcreteEvidence && (!isPlainText || hasConcreteCodeShape);
+}
+
+function hasLowQualityTags(note: MaterializedTaskMemoryNote) {
+  return note.tags.some((tag) => isLowQualityTag(tag));
+}
+
+function isLowQualityTag(tag: string) {
+  const normalized = tag.trim().toLowerCase();
+  if (!normalized || isPlaceholderText(normalized)) return true;
+  return /^(success|fixed|reliable|done|verified|test[-_\s]?passed|passed|ok|okay|resolved|working|complete|completed|all[-_\s]?good)$/i
+    .test(normalized);
+}
+
 export function validateMaterializedNoteQuality(
   note: MaterializedTaskMemoryNote,
   options: { mode: ValidationMode },
@@ -1048,6 +1128,12 @@ export function validateMaterializedNoteQuality(
   }
   if (!note.key_conclusions.some((item) => hasMeaningfulText(item, 16, 10))) {
     warnings.push('key_conclusions');
+  }
+  if (hasLowQualityCodeSnippets(note)) {
+    warnings.push('code_snippets');
+  }
+  if (hasLowQualityTags(note)) {
+    warnings.push('tags');
   }
   if (!hasDurableReusableSignal(note)) {
     warnings.push('durable_reusable_lesson');

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -20,7 +20,7 @@ function hasMeaningfulText(value: string, minLatin = 24, minCjk = 18) {
 }
 
 function isPlaceholderText(value: string) {
-  return /\b(unknown|n\/a|not sure|todo|tbd|appropriate change|fix the issue|task needed investigation)\b/i
+  return /\b(unknown|n\/a|not sure|todo|tbd|appropriate change|fix the issue|task needed investigation|expected behavior|task works correctly|expected pattern)\b/i
     .test(value);
 }
 
@@ -76,8 +76,26 @@ function hasConcreteTransferableAction(value: string) {
   return concreteActionWords.some((word) => text.includes(word));
 }
 
+function isVagueGenericLesson(value: string) {
+  const text = value.toLowerCase();
+  return (
+    /\b(the task|this task|the pattern|the implementation|implementation behavior|expected behavior|expected pattern|values?|input|correctness|going forward)\b/.test(text) &&
+    !hasSpecificObject(text)
+  );
+}
+
+function hasSpecificObject(value: string) {
+  return /\b(server|readiness|client calls?|request setup|package version|dist output|release checks?|node_env|npm link|sqlite|database|tags?|note_tags|embedding|jsonl|cursor|codex|claude|mcp|api|url|port|path|config|environment|schema|queue|watcher|electron|window state)\b|\b[a-z0-9]+_[a-z0-9_]+\b|[a-z]:\\|\/[\w.-]+|[\u3400-\u9fff]/i
+    .test(value.toLowerCase());
+}
+
 function hasConcreteTransferableText(value: string) {
-  return hasNonPlaceholderMeaningfulText(value) && hasConcreteTransferableAction(value);
+  return (
+    hasNonPlaceholderMeaningfulText(value) &&
+    hasConcreteTransferableAction(value) &&
+    hasSpecificObject(value) &&
+    !isVagueGenericLesson(value)
+  );
 }
 
 function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
@@ -85,10 +103,14 @@ function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
   const payload = note.raw_payload;
   const conclusions = note.key_conclusions.join('\n').toLowerCase();
   const hasMeaningfulRootCause = Boolean(
-    payload.root_cause && hasNonPlaceholderMeaningfulText(payload.root_cause),
+    payload.root_cause &&
+    hasNonPlaceholderMeaningfulText(payload.root_cause) &&
+    !isVagueGenericLesson(payload.root_cause),
   );
   const hasMeaningfulResolution = Boolean(
-    payload.resolution && hasNonPlaceholderMeaningfulText(payload.resolution),
+    payload.resolution &&
+    hasNonPlaceholderMeaningfulText(payload.resolution) &&
+    !isVagueGenericLesson(payload.resolution),
   );
   const hasStructuredSignal =
     (hasMeaningfulRootCause && hasMeaningfulResolution) ||

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -1353,8 +1353,9 @@ function hasStrictStructuralEngineeringEvidence(value: string) {
     /\b(migration|migrations?|not null|backfill|chatcrystal\.db|constraint)\b/i
       .test(text);
   const hasEngineeringContext =
-    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?|initialization|initialized|route|mcp|json-rpc|stdio|stdout|stderr|framing|transport|logs?|diagnostics?|tags?|joins?|deletion|cleanup|filter chips?|webui|websocket|listeners?|useeffect|remounts?|unmount|child_process|child process|daemon|pid|spawn|exit code|serve|status|dead server|migration|not null|default|backfill|column|startup|vite|proxy|fastify|rewrite|registered route|spa fallback|fallback handler|index\.html|conversation_id|queue jobs?|enqueue|enqueueing|summarize)\b/i
-      .test(text);
+    /\b(sqlite|sql\.js|table|rows?|index|indexed lookup|lookup|lookups?|query|queries|filtered|filtering|request timeouts?|timed out|large imports?|messages?|note detail|cache|schema|parser|jsonl|constraint|unique|duplicate|receipt|receipts|writeback|search|frontend|react|requests?|responses?|initialization|initialized|route|mcp|json-rpc|stdio|stdout|stderr|framing|transport|logs?|diagnostics?|tags?|joins?|deletion|cleanup|filter chips?|webui|websocket|listeners?|useeffect|remounts?|unmount|child_process|child process|daemon|pid|spawn|exit code|serve|status|dead server|migration|not null|default|backfill|column|startup|vite|proxy|fastify|rewrite|registered route|spa fallback|fallback handler|index\.html|conversation_id|queue jobs?|enqueue|enqueueing|summarize|activerequestid|setresults)\b/i
+      .test(text) ||
+    /(?:语义搜索|响应|查询结果|旧响应|旧的.*响应|覆盖.*结果)/i.test(text);
   return (
     hasConcreteToken ||
     hasNamedDbObject ||
@@ -1506,6 +1507,12 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
     /\b(ignore)\b.+\bresponses?\b.+\b(not from the latest query|older|previous|stale|latest query)\b/i
       .test(text) ||
     /\bolder\b.+\b\/api\/search responses?\b.+\b(after a newer query|newer query)\b.+\boverwrite\b.+\bcurrent results\b/i
+      .test(text) ||
+    /(?:旧(?:的)?\s*)?(?:\/api\/search\s*)?响应.{0,20}覆盖.{0,12}(?:当前查询结果|新结果)/i
+      .test(text) ||
+    /(?:在\s*)?setresults.{0,8}前.{0,12}校验.{0,16}activerequestid.{0,30}(?:避免|防止).{0,24}(?:旧(?:的)?\s*)?(?:\/api\/search\s*)?响应.{0,20}覆盖/i
+      .test(text) ||
+    /setresults.{0,8}前.{0,12}(?:没有|未).{0,8}校验.{0,16}activerequestid/i
       .test(text);
   const hasQueueDedupeFlow =
     /\bsummarize\b.+\bretries\b.+\benqueue\b.+\bduplicate conversation jobs?\b/i
@@ -1606,7 +1613,8 @@ function hasStrictStructuralEngineeringMechanism(value: string) {
       .test(text);
   const hasCausalFlow =
     /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|timed out|overwrote|overwrite|reused|reuse|retried|retries|cancel|gat(?:e|es|ed|ing)|ignore|latest query|request id|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|wait|reserve|left|no longer existed|deleting notes?|note deletion|cleanup|prune|filter|duplicate|deduplicate|dedupe|enqueued|enqueue|pending job|appended twice|remounts?|unmount|spawn handshake|exit event|exit code|dead server|nonzero|non-zero|backfill|not null|default|constraint|violat(?:e|ed|es|ing)|rewrote|rewrite|proxy|preserv(?:e|es|ed|ing)|registered route|fell through|spa fallback|fallback handler|index\.html)\b/i
-      .test(text);
+      .test(text) ||
+    /(?:因为|所以|导致|避免|防止|覆盖|校验|没有|未)/i.test(text);
   return hasStrictStructuralEngineeringEvidence(text) &&
     hasCausalFlow &&
     (
@@ -1631,10 +1639,13 @@ function hasStrictStructuralEngineeringFailureSignal(value: string) {
   const text = value.toLowerCase();
   const hasNamedConsequence =
     /\b(request timeouts?|timed out|timeouts?|full table scans?|scanned the full \w+ table|scanning every \w+ row|duplicate receipt rows?|duplicate rows?|duplicate notes?|duplicate conversation jobs?|duplicate messages?|duplicate websocket messages?|appended twice|stale responses?|stale results?|overwrote the current query results?|overwrote current results?|overwrite the current query results?|overwrite current results?|replace current results?|orphan note_tags rows?|orphan tags?|unused tags?|count 0|joins? whose note_id no longer existed|http\s*[45]\d\d|returned\s+[45]\d\d|could not parse|cannot parse|corrupt(?:s|ed|ing)?(?: mcp)?(?: json-rpc)? framing|corrupt(?:s|ed|ing)?(?: mcp)? json-rpc|interleav(?:e|ed|es|ing).+(?:json-rpc|responses?|frames?|stdio stream)|false serve success|dead server|looked like a running server|running server|nonzero exit codes?|non-zero exit codes?|exit code\s*\d+|migration (?:does not )?fail(?:s|ed)?|migration failures?|existing row failures?|constraint violation|violated the constraint|fell through to the spa fallback|clients? received index\.html instead of json|return json instead of index\.html|returns? html for api json)\b/i
+      .test(text) ||
+    /(?:旧(?:的)?\s*)?(?:\/api\/search\s*)?响应.{0,20}覆盖.{0,12}(?:当前查询结果|新结果)/i
       .test(text);
   const hasCausalFlow =
     /\b(because|so|but|without|instead of|before|after|until|avoid|avoids|prevent|prevents|overwrote|overwrite|reused|reuse|retried|retries|cancel|return existing|interleav(?:e|ed|es|ing)|corrupt(?:s|ed|ing)?|left|no longer existed|deleting notes?|note deletion|cleanup|filter|prune|remounts?|unmount|duplicate|deduplicate|dedupe|enqueued|enqueue|pending job|appended twice|spawn handshake|exit event|exit code|nonzero|non-zero|dead server|backfill|not null|default|constraint|violat(?:e|ed|es|ing)|migration|fell through|spa fallback|fallback handler|index\.html)\b/i
-      .test(text);
+      .test(text) ||
+    /(?:因为|所以|导致|避免|防止|覆盖|校验|没有|未)/i.test(text);
   return hasStrictStructuralEngineeringEvidence(text) && hasNamedConsequence && hasCausalFlow;
 }
 
@@ -1919,7 +1930,7 @@ function isVisibleWorkLogClaim(value: string) {
 
 function isExplicitEnglishStatusShell(value: string) {
   return hasTechnicalPrefixStatusShell(value) ||
-    /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task|progress|verification)\s+(?:record|report|note|summary|update|log|entry|check)|(?:implementation|task|fix|execution|run|work|status)\s+results?|run\s+results?|work\s*log(?:\s+entry)?|worklog(?:\s+entry)?|status|record|update|implementation|result|outcome|progress|verification|check|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
+    /^\s*(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task|progress|verification|diagnostics?|(?:smoke\s+)?test)\s+(?:record|report|note|summary|update|log|entry|check)|(?:implementation|task|fix|execution|run|work|status)\s+results?|run\s+results?|work\s*log(?:\s+entry)?|worklog(?:\s+entry)?|status|record|update|implementation|result|outcome|progress|verification|check|diagnostics?|(?:smoke\s+)?test|completion(?:\s+(?:note|record))?|completed|done|this\s+fix|this\s+run)\s*(?:[:\-\u2013\u2014])/i
       .test(value.trim()) ||
     isCurrentRunImplementationShell(value) ||
     isCurrentRunStatusObservationClaim(value);
@@ -1932,8 +1943,8 @@ function hasTechnicalPrefixStatusShell(value: string) {
   const englishDescriptorPrefix = String.raw`(?:[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*){0,3})`;
   const chineseDescriptorPrefix = String.raw`(?:[\u3400-\u9fff]{2,16})`;
   const technicalPrefix = String.raw`(?:\/api\/[\w/-]+|[a-z0-9]+_[a-z0-9_]+|[a-z][a-z0-9_]*\.[a-z_][a-z0-9_]*|activerequestid|setresults|data_dir|node_env|child_process|jsonl|sqlite|sql\.js|websocket|mcp|json-rpc|${descriptorWord}(?:\s+${descriptorWord}){0,2}|${chineseDescriptorWord}(?:\s+${chineseDescriptorWord}){0,2}|${englishDescriptorPrefix}|${chineseDescriptorPrefix})`;
-  const englishShell = String.raw`(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task|progress|verification)\s+(?:record|report|note|summary|update|log|entry|check)|(?:status|record|update|implementation|result|outcome|progress|verification|check|completion(?:\s+(?:note|record))?|completed|done))`;
-  const chineseShell = String.raw`(?:状态记录|记录状态|状态检查|工作日志|日志记录|工作记录|执行记录|完成记录|完成检查|状态更新|运行结果|执行结果|结果记录|结果报告|结果检查|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|状态|结果|进度|验证|完成|已完成|完成说明)`;
+  const englishShell = String.raw`(?:(?:status|work|implementation|execution|completion|fix|result|change|run|task|progress|verification|diagnostics?|(?:smoke\s+)?test)\s+(?:record|report|note|summary|update|log|entry|check)|(?:status|record|update|implementation|result|outcome|progress|verification|check|diagnostics?|(?:smoke\s+)?test|completion(?:\s+(?:note|record))?|completed|done))`;
+  const chineseShell = String.raw`(?:状态记录|记录状态|状态检查|工作日志|日志记录|工作记录|执行记录|完成记录|完成检查|状态更新|运行结果|执行结果|结果记录|结果报告|结果检查|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|测试记录|状态|结果|进度|验证|测试|诊断|完成|已完成|完成说明)`;
   return new RegExp(`^\\s*${technicalPrefix}\\s+${englishShell}\\s*(?:[:\\-\\u2013\\u2014])`, 'i')
     .test(text) ||
     new RegExp(`^\\s*${technicalPrefix}\\s+${englishShell}\\s+(?:for|on|about)\\b`, 'i')
@@ -2003,7 +2014,7 @@ function isChineseVisibleStatusShell(value: string) {
   if (!/[\u3400-\u9fff]/.test(value)) return false;
   const hasStatusRecordShell =
     hasTechnicalPrefixStatusShell(value) ||
-    /^\s*(?:状态记录|记录状态|状态检查|工作日志|日志记录|工作记录|执行记录|完成记录|完成检查|状态更新|运行结果|执行结果|结果记录|结果报告|结果检查|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|结果|进度|验证|完成|已完成|完成说明)\s*(?:[：:\-\u2013\u2014]|$)/i
+    /^\s*(?:状态记录|记录状态|状态检查|工作日志|日志记录|工作记录|执行记录|完成记录|完成检查|状态更新|运行结果|执行结果|结果记录|结果报告|结果检查|任务结果|实现结果|修复结果|工作结果|状态结果|运行记录|任务记录|实现记录|实现说明|更新记录|变更记录|变更摘要|本次修复|本次执行|本次任务|本次改动|本轮执行|本轮修复|本轮任务|本轮改动|修复记录|测试记录|结果|进度|验证|测试|诊断|完成|已完成|完成说明)\s*(?:[：:\-\u2013\u2014]|$)/i
       .test(value) ||
     /(?:^|[\s：:])(?:状态记录|记录状态|工作日志|日志记录|工作记录)(?:[\s：:]|$)|^(?:状态|记录)\s*[：:]/i
       .test(value) ||

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -415,8 +415,9 @@ function hasDurableFixSignal(note: MaterializedTaskMemoryNote) {
 function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
   const payload = note.raw_payload;
   const hasVisibleSignal = hasVisibleQualitySignal(note);
+  const hasVisibleFixSignal = hasVisibleConcreteFixSignal(note);
   const hasFixSignal = hasDurableFixSignal(note);
-  if (hasFixSignal) return hasVisibleSignal;
+  if (hasFixSignal) return hasVisibleFixSignal;
   if (isMostlyOneOffStatus(note)) return false;
 
   const hasStructuredSignal =
@@ -424,6 +425,26 @@ function hasDurableReusableSignal(note: MaterializedTaskMemoryNote) {
     Boolean(payload.pitfalls?.some((item) => hasConcreteTransferableText(item))) ||
     Boolean(payload.decisions?.some((item) => hasConcreteTransferableText(item)));
   return hasStructuredSignal && hasVisibleSignal;
+}
+
+function conclusionText(note: MaterializedTaskMemoryNote, label: 'root cause' | 'resolution') {
+  const pattern = new RegExp(`^\\s*${label}:\\s*(.+)$`, 'i');
+  return note.key_conclusions
+    .map((item) => pattern.exec(item)?.[1]?.trim())
+    .filter((item): item is string => Boolean(item));
+}
+
+function hasVisibleConcreteFixSignal(note: MaterializedTaskMemoryNote) {
+  const rootCauses = conclusionText(note, 'root cause');
+  const resolutions = conclusionText(note, 'resolution');
+  return (
+    rootCauses.some((item) =>
+      hasNonPlaceholderMeaningfulText(item) &&
+      hasStrongRootCauseSignal(item) &&
+      !isVagueGenericFixClaim(item),
+    ) &&
+    resolutions.some((item) => hasActionableResolution(item))
+  );
 }
 
 function hasVisibleQualitySignal(note: MaterializedTaskMemoryNote) {
@@ -485,7 +506,7 @@ export function validateMaterializedNoteQuality(
   options: { mode: ValidationMode },
 ): NoteQualityDecision {
   const warnings: string[] = [];
-  const acceptedDurableFix = hasDurableFixSignal(note) && hasVisibleQualitySignal(note);
+  const acceptedDurableFix = hasDurableFixSignal(note) && hasVisibleConcreteFixSignal(note);
 
   if (!hasMeaningfulText(note.title, 10, 6) || isGenericTitle(note.title)) {
     warnings.push('title');

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -63,24 +63,29 @@ function isMostlyOneOffStatus(note: MaterializedTaskMemoryNote) {
     '检查',
     '状态',
   ];
-  const durableWords = [
-    'root cause',
-    'resolution',
-    'pitfall',
+  const reusableLessonWords = [
     'avoid',
-    'decision',
+    'because',
+    'cause',
+    'causes',
+    'must',
+    'should',
+    'pattern',
+    'prevent',
+    'prevents',
     'rationale',
     'reuse',
     'transferable',
-    '原因',
-    '解决',
     '避免',
     '模式',
-    '决策',
+    '必须',
+    '应该',
+    '防止',
+    '复用',
   ];
   const statusHits = statusWords.filter((word) => text.includes(word)).length;
-  const durableHits = durableWords.filter((word) => text.includes(word)).length;
-  return statusHits >= 3 && durableHits === 0;
+  const reusableLessonHits = reusableLessonWords.filter((word) => text.includes(word)).length;
+  return statusHits >= 3 && reusableLessonHits === 0;
 }
 
 export function validateMaterializedNoteQuality(

--- a/server/src/services/memory/quality.ts
+++ b/server/src/services/memory/quality.ts
@@ -121,7 +121,7 @@ function isVagueGenericLesson(value: string) {
     /\bhandle\b.+\bproperly\b/.test(text) ||
     /\bexpected pattern\b/.test(text);
   const hasGenericTerms =
-    /\b(the task|this task|the pattern|the implementation|implementation behavior|expected behavior|expected pattern|values?|input|correctness|going forward)\b/.test(text);
+    /\b(the task|this task|the pattern|the implementation|implementation behavior|expected behavior|expected pattern|values?|input|correctness|reliability|maintenance|going forward)\b/.test(text);
   return hasBoilerplateClaim || (hasGenericTerms && !hasSpecificObject(text));
 }
 
@@ -204,9 +204,9 @@ function hasConcreteMechanism(value: string) {
       hasTimingOrder
     );
   const hasParserFieldValidation =
-    /\b(typeerror|parser|parsing|jsonl|response_item\.content|partial events?|partial codex events?|event shape|parser fields)\b.+\b(before|after|without content|validat(?:e|ing)|read(?:ing)?|skip)\b/i
+    /\b(typeerror|parser|parsing|jsonl|response_item\.content|partial events?|partial codex events?|event shape|parser fields)\b.+\b(before|after|without content|validat(?:e|ing)|read(?:ing)?|skips?)\b/i
       .test(text) ||
-    /\b(before|after|without content|validat(?:e|ing)|read(?:ing)?|skip)\b.+\b(typeerror|parser|parsing|jsonl|response_item\.content|partial events?|partial codex events?|event shape|parser fields)\b/i
+    /\b(before|after|without content|validat(?:e|ing)|read(?:ing)?|skips?)\b.+\b(typeerror|parser|parsing|jsonl|response_item\.content|partial events?|partial codex events?|event shape|parser fields)\b/i
       .test(text);
   return (
     hasTimingOrder ||
@@ -470,6 +470,7 @@ function hasVisibleTitleSummaryQuality(note: MaterializedTaskMemoryNote) {
 function hasVisibleTitleQuality(title: string) {
   return (
     hasNonPlaceholderMeaningfulText(title, 10, 6) &&
+    hasVisibleConcreteContent(title) &&
     !isGenericTitle(title) &&
     !isFirstPersonDiaryClaim(title) &&
     !isVisibleWorkLogClaim(title) &&
@@ -483,6 +484,7 @@ function hasVisibleTitleQuality(title: string) {
 function hasVisibleSummaryQuality(summary: string) {
   return (
     hasNonPlaceholderMeaningfulText(summary) &&
+    hasVisibleConcreteContent(summary) &&
     !isFirstPersonDiaryClaim(summary) &&
     !isVisibleWorkLogClaim(summary) &&
     !isVagueGenericFixClaim(summary) &&
@@ -490,6 +492,15 @@ function hasVisibleSummaryQuality(summary: string) {
     !isGenericVisibleBoilerplateClaim(summary) &&
     !isVisibleStatusSnapshotText(summary)
   );
+}
+
+function hasVisibleConcreteContent(value: string) {
+  const text = value.toLowerCase();
+  if (hasSpecificEvidence(text) && hasConcreteMechanism(text)) return true;
+  if (hasSpecificEvidence(text) && hasFailureOrConsequenceSignal(text)) return true;
+  if (hasPackageDistRootCauseSignal(text)) return true;
+  if (/\bdata_dir\b.+\b(electron|import ordering|server entrypoint)\b/i.test(text)) return true;
+  return /\bdata_dir\b.+\b(prevents?|avoids?)\b.+\bfallback\b/i.test(text);
 }
 
 function isVisibleWorkLogClaim(value: string) {
@@ -579,10 +590,11 @@ function hasVisibleConclusionBoilerplate(note: MaterializedTaskMemoryNote) {
 }
 
 function isLowQualityVisibleConclusion(value: string) {
-  const body = value.replace(
-    /^\s*(root cause|resolution|pattern|decision|pitfall|takeaway|error signature):\s*/i,
-    '',
-  );
+  const labelMatch = /^\s*(root cause|resolution|pattern|decision|pitfall|takeaway|error signature):\s*/i
+    .exec(value);
+  const label = labelMatch?.[1]?.toLowerCase();
+  const body = value.slice(labelMatch?.[0]?.length ?? 0);
+  const shouldApplyGenericLessonGate = label !== 'root cause' && label !== 'resolution';
   return (
     isPlaceholderText(value) ||
     isPlaceholderText(body) ||
@@ -592,6 +604,8 @@ function isLowQualityVisibleConclusion(value: string) {
     isVisibleStatusSnapshotText(body) ||
     isMetaReusableClaim(value) ||
     isMetaReusableClaim(body) ||
+    (shouldApplyGenericLessonGate && isVagueGenericLesson(body)) ||
+    (shouldApplyGenericLessonGate && isVagueGenericFixClaim(body)) ||
     isGenericVisibleBoilerplateClaim(value) ||
     isGenericVisibleBoilerplateClaim(body)
   );

--- a/server/src/services/memory/schemas.test.ts
+++ b/server/src/services/memory/schemas.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   parseRecallForTaskRequest,
+  parseValidateTaskMemoryRequest,
   parseWriteTaskMemoryRequest,
 } from './schemas.js';
 
@@ -94,4 +95,25 @@ test('schemas accept trae as a valid source_agent', () => {
   });
 
   assert.equal(parsed.task.source_agent, 'trae');
+});
+
+test('parseValidateTaskMemoryRequest uses the writeback contract', () => {
+  const parsed = parseValidateTaskMemoryRequest({
+    mode: 'auto',
+    source_run_key: 'run-validate',
+    task: {
+      goal: 'Capture readiness fix',
+      task_kind: 'debug',
+      source_agent: 'codex',
+    },
+    memory: {
+      summary: 'Await readiness before issuing requests.',
+      outcome_type: 'fix',
+      root_cause: 'Requests raced server startup.',
+      resolution: 'Wait for readiness before requests.',
+    },
+  });
+
+  assert.equal(parsed.mode, 'auto');
+  assert.equal(parsed.task.source_agent, 'codex');
 });

--- a/server/src/services/memory/schemas.ts
+++ b/server/src/services/memory/schemas.ts
@@ -104,8 +104,15 @@ export const WriteTaskMemoryRequestSchema = z
     }
   });
 
+export const ValidateTaskMemoryRequestShape = WriteTaskMemoryRequestShape;
+export const ValidateTaskMemoryRequestSchema = WriteTaskMemoryRequestSchema;
+
 export function parseWriteTaskMemoryRequest(input: unknown) {
   return WriteTaskMemoryRequestSchema.parse(input);
+}
+
+export function parseValidateTaskMemoryRequest(input: unknown) {
+  return ValidateTaskMemoryRequestSchema.parse(input);
 }
 
 export function parseRecallForTaskRequest(input: unknown) {

--- a/server/src/services/memory/writeback.test.ts
+++ b/server/src/services/memory/writeback.test.ts
@@ -42,6 +42,24 @@ function insertImportedConversation(db: Pick<Database, 'run'>, id: string) {
   );
 }
 
+const READINESS_TITLE = 'Server readiness race returns ECONNREFUSED';
+const READINESS_SUMMARY =
+  'Wait for Fastify readiness before issuing API requests to avoid startup race failures.';
+const READINESS_ROOT_CAUSE =
+  'Client calls hit ECONNREFUSED because they ran before the local server was ready.';
+const READINESS_RESOLUTION =
+  'Wait for the Fastify server readiness promise before issuing API requests.';
+const READINESS_ECONNREFUSED = 'ECONNREFUSED before Fastify readiness';
+const READINESS_ETIMEDOUT = 'ETIMEDOUT before Fastify readiness';
+const READINESS_EXISTING_PITFALL =
+  'Starting API requests before Fastify readiness lets client calls hit ECONNREFUSED during tests.';
+const READINESS_INCOMING_PITFALL =
+  'Do not issue HTTP requests before awaiting Fastify readiness because startup races return ECONNREFUSED.';
+const READINESS_INCOMING_PATTERN =
+  'Gate API request helpers on Fastify readiness before issuing HTTP calls.';
+const READINESS_DECISION =
+  'Wait for Fastify readiness before request setup because client calls return ECONNREFUSED when they race server startup.';
+
 function seedExistingNote(
   db: Database,
   {
@@ -100,12 +118,12 @@ test('writeTaskMemory replays the same persisted decision for the same auto rece
       branch: 'main',
     },
     memory: {
-      summary:
-        'Await server readiness before requests so client calls do not race startup and fail with connection errors.',
+      title: READINESS_TITLE,
+      summary: READINESS_SUMMARY,
       outcome_type: 'fix',
-      root_cause: 'Requests raced the server startup',
-      resolution: 'Await readiness in the helper',
-      error_signatures: ['ECONNREFUSED'],
+      root_cause: READINESS_ROOT_CAUSE,
+      resolution: READINESS_RESOLUTION,
+      error_signatures: [READINESS_ECONNREFUSED],
     },
   } as const;
 
@@ -215,6 +233,122 @@ test('writeTaskMemory persists tags for created memories', async () => {
   );
 });
 
+test('writeTaskMemory skips weak auto status records before semantic search', async () => {
+  const db = await createSqlDatabase();
+  let searchCalls = 0;
+  let embedCalls = 0;
+  let saveCalls = 0;
+
+  const result = await writeTaskMemory(
+    {
+      mode: 'auto',
+      source_run_key: 'run-status-snapshot',
+      task: {
+        goal: 'Record local package version status',
+        task_kind: 'investigate',
+        source_agent: 'codex',
+        project_key: 'git:repo',
+      },
+      memory: {
+        title: 'Persist local package version status',
+        summary:
+          'Persist checked current local package version status and generated dist output.',
+        outcome_type: 'decision',
+        decisions: [
+          'Persist checked current local package version status and generated dist output.',
+        ],
+      },
+    },
+    {
+      db: db as never,
+      save: () => {
+        saveCalls++;
+      },
+      generateEmbeddings: async () => {
+        embedCalls++;
+        return 1;
+      },
+      semanticSearch: async () => {
+        searchCalls++;
+        return [];
+      },
+    },
+  );
+
+  const noteCount = Number(db.exec('SELECT COUNT(*) FROM notes')[0].values[0][0]);
+  const receiptRows = db.exec(
+    'SELECT decision, reason, index_status FROM writeback_receipts WHERE source_run_key = ?',
+    ['run-status-snapshot'],
+  );
+
+  assert.equal(result.decision, 'skipped');
+  assert.equal(result.reason, 'low-note-quality');
+  assert.ok(result.warnings.includes('one_off_status') || result.warnings.includes('durable_reusable_lesson'));
+  assert.equal(searchCalls, 0);
+  assert.equal(embedCalls, 0);
+  assert.equal(saveCalls, 1);
+  assert.equal(noteCount, 0);
+  assert.deepEqual(receiptRows[0].values[0], [
+    'skipped',
+    'low-note-quality',
+    'completed',
+  ]);
+});
+
+test('writeTaskMemory persists materialized fields for created notes', async () => {
+  const db = await createSqlDatabase();
+
+  const result = await writeTaskMemory(
+    {
+      mode: 'auto',
+      source_run_key: 'run-materialized-create',
+      task: {
+        goal: 'Fix server readiness race',
+        task_kind: 'debug',
+        source_agent: 'codex',
+        project_key: 'git:repo',
+        project_dir: 'C:/repo',
+        cwd: 'C:/repo',
+      },
+      memory: {
+        title: '  Server readiness race returns ECONNREFUSED  ',
+        summary:
+          'Wait for Fastify readiness\n before issuing API requests to avoid startup race failures.',
+        outcome_type: 'fix',
+        root_cause: READINESS_ROOT_CAUSE,
+        resolution: READINESS_RESOLUTION,
+      },
+    },
+    {
+      db: db as never,
+      generateEmbeddings: async () => 1,
+      semanticSearch: async () => [],
+    },
+  );
+
+  const noteRows = db.exec(
+    'SELECT title, summary, key_conclusions, raw_llm_response FROM notes WHERE id = ?',
+    [result.note_id],
+  );
+  const rawPayload = JSON.parse(String(noteRows[0].values[0][3])) as {
+    key_conclusions?: string[];
+    title?: string;
+  };
+
+  assert.equal(result.decision, 'created');
+  assert.equal(noteRows[0].values[0][0], 'Server readiness race returns ECONNREFUSED');
+  assert.equal(
+    noteRows[0].values[0][1],
+    'Wait for Fastify readiness before issuing API requests to avoid startup race failures.',
+  );
+  assert.deepEqual(JSON.parse(String(noteRows[0].values[0][2])), [
+    `Root cause: ${READINESS_ROOT_CAUSE}`,
+    `Resolution: ${READINESS_RESOLUTION}`,
+  ]);
+  assert.equal(rawPayload.title, '  Server readiness race returns ECONNREFUSED  ');
+  assert.equal(rawPayload.key_conclusions, undefined);
+});
+
 test('writeTaskMemory re-embeds the merge target after appending evidence', async () => {
   const db = await createSqlDatabase();
   insertImportedConversation(db, 'conv-existing');
@@ -224,18 +358,18 @@ test('writeTaskMemory re-embeds the merge target after appending evidence', asyn
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       'conv-existing',
-      'Timeout fix',
-      'Existing timeout fix summary.',
+      READINESS_TITLE,
+      READINESS_SUMMARY,
       JSON.stringify({
-        root_cause: 'Requests raced the server startup',
-        resolution: 'Await readiness in the helper',
+        root_cause: READINESS_ROOT_CAUSE,
+        resolution: READINESS_RESOLUTION,
       }),
       'git:repo',
       'project',
       'imported-conversation',
       'codex',
       'debug',
-      JSON.stringify(['ECONNREFUSED']),
+      JSON.stringify([READINESS_ECONNREFUSED]),
       JSON.stringify([]),
       'fix',
     ],
@@ -261,12 +395,12 @@ test('writeTaskMemory re-embeds the merge target after appending evidence', asyn
         branch: 'main',
       },
       memory: {
-        summary:
-          'Await server readiness before requests so client calls do not race startup and fail with connection errors.',
+        title: READINESS_TITLE,
+        summary: READINESS_SUMMARY,
         outcome_type: 'fix',
-        root_cause: 'Requests raced the server startup',
-        resolution: 'Await readiness in the helper',
-        error_signatures: ['ECONNREFUSED'],
+        root_cause: READINESS_ROOT_CAUSE,
+        resolution: READINESS_RESOLUTION,
+        error_signatures: [READINESS_ECONNREFUSED],
       },
     },
     {
@@ -305,8 +439,8 @@ test('writeTaskMemory merge preserves existing structured payload fields while a
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       'conv-merge-payload',
-      'Timeout fix',
-      'Existing timeout fix summary.',
+      READINESS_TITLE,
+      READINESS_SUMMARY,
       JSON.stringify(['Existing conclusion']),
       JSON.stringify([
         {
@@ -316,17 +450,19 @@ test('writeTaskMemory merge preserves existing structured payload fields while a
         },
       ]),
       JSON.stringify({
-        root_cause: 'Requests raced the server startup',
-        resolution: 'Await readiness in the helper',
-        reusable_patterns: ['Existing helper'],
-        pitfalls: ['Old pitfall'],
+        root_cause: READINESS_ROOT_CAUSE,
+        resolution: READINESS_RESOLUTION,
+        reusable_patterns: [
+          'Wait for Fastify readiness before request setup so client calls cannot race server startup.',
+        ],
+        pitfalls: [READINESS_EXISTING_PITFALL],
       }),
       'git:repo',
       'project',
       'imported-conversation',
       'codex',
       'debug',
-      JSON.stringify(['ECONNREFUSED']),
+      JSON.stringify([READINESS_ECONNREFUSED]),
       JSON.stringify(['tests/server.ts']),
       'fix',
     ],
@@ -349,22 +485,26 @@ test('writeTaskMemory merge preserves existing structured payload fields while a
         cwd: 'C:/repo',
       },
       memory: {
-        summary:
-          'Await server readiness before requests so client calls do not race startup and fail with connection errors.',
+        title: READINESS_TITLE,
+        summary: READINESS_SUMMARY,
         outcome_type: 'fix',
-        root_cause: 'Requests raced the server startup',
-        resolution: 'Await readiness in the helper',
-        error_signatures: ['ECONNREFUSED', 'ETIMEDOUT'],
+        root_cause: READINESS_ROOT_CAUSE,
+        resolution: READINESS_RESOLUTION,
+        error_signatures: [READINESS_ECONNREFUSED, READINESS_ETIMEDOUT],
         files_touched: ['tests/helper.ts'],
-        key_conclusions: ['New conclusion'],
+        reusable_patterns: [
+          READINESS_INCOMING_PATTERN,
+        ],
+        decisions: [READINESS_DECISION],
         code_snippets: [
           {
             language: 'ts',
-            code: 'await helper.ready()',
-            description: 'New snippet',
+            code: "await fastify.ready();\nawait client.get('/api/status');",
+            description:
+              'Request helper waits for Fastify readiness before issuing API calls that otherwise hit ECONNREFUSED.',
           },
         ],
-        pitfalls: ['New pitfall'],
+        pitfalls: [READINESS_INCOMING_PITFALL],
       },
     },
     {
@@ -392,11 +532,19 @@ test('writeTaskMemory merge preserves existing structured payload fields while a
     reusable_patterns?: string[];
     pitfalls?: string[];
     resolution?: string;
+    decisions?: string[];
   };
 
   assert.deepEqual(JSON.parse(String(rows[0].values[0][0])), [
-    'Existing conclusion',
-    'New conclusion',
+    `Root cause: ${READINESS_ROOT_CAUSE}`,
+    `Resolution: ${READINESS_RESOLUTION}`,
+    `Pitfall: ${READINESS_EXISTING_PITFALL}`,
+    `Pitfall: ${READINESS_INCOMING_PITFALL}`,
+    'Pattern: Wait for Fastify readiness before request setup so client calls cannot race server startup.',
+    `Pattern: ${READINESS_INCOMING_PATTERN}`,
+    `Decision: ${READINESS_DECISION}`,
+    `Error signature: ${READINESS_ECONNREFUSED}`,
+    `Error signature: ${READINESS_ETIMEDOUT}`,
   ]);
   assert.deepEqual(JSON.parse(String(rows[0].values[0][1])), [
     {
@@ -406,21 +554,29 @@ test('writeTaskMemory merge preserves existing structured payload fields while a
     },
     {
       language: 'ts',
-      code: 'await helper.ready()',
-      description: 'New snippet',
+      code: "await fastify.ready();\nawait client.get('/api/status');",
+      description:
+        'Request helper waits for Fastify readiness before issuing API calls that otherwise hit ECONNREFUSED.',
     },
   ]);
   assert.deepEqual(JSON.parse(String(rows[0].values[0][2])), [
-    'ECONNREFUSED',
-    'ETIMEDOUT',
+    READINESS_ECONNREFUSED,
+    READINESS_ETIMEDOUT,
   ]);
   assert.deepEqual(JSON.parse(String(rows[0].values[0][3])), [
     'tests/server.ts',
     'tests/helper.ts',
   ]);
-  assert.deepEqual(mergedPayload.reusable_patterns, ['Existing helper']);
-  assert.deepEqual(mergedPayload.pitfalls, ['Old pitfall', 'New pitfall']);
-  assert.equal(mergedPayload.resolution, 'Await readiness in the helper');
+  assert.deepEqual(mergedPayload.reusable_patterns, [
+    'Wait for Fastify readiness before request setup so client calls cannot race server startup.',
+    READINESS_INCOMING_PATTERN,
+  ]);
+  assert.deepEqual(mergedPayload.decisions, [READINESS_DECISION]);
+  assert.deepEqual(mergedPayload.pitfalls, [
+    READINESS_EXISTING_PITFALL,
+    READINESS_INCOMING_PITFALL,
+  ]);
+  assert.equal(mergedPayload.resolution, READINESS_RESOLUTION);
 });
 
 test('writeTaskMemory replay completes pending indexing before returning the stored auto decision', async () => {
@@ -480,17 +636,18 @@ test('writeTaskMemory replay completes pending indexing before returning the sto
   assert.equal(saveCalls, 1);
 });
 
-test('writeTaskMemory merges root-cause-only fixes with matching existing memories', async () => {
+test('writeTaskMemory merges fixes with matching existing memories after preflight', async () => {
   const db = await createSqlDatabase();
   seedExistingNote(db, {
     noteId: 77,
     projectKey: 'git:repo',
     outcomeType: 'fix',
     raw: {
-      root_cause: 'Requests raced server startup',
-      error_signatures: ['ECONNREFUSED'],
+      root_cause: READINESS_ROOT_CAUSE,
+      resolution: READINESS_RESOLUTION,
+      error_signatures: [READINESS_ECONNREFUSED],
     },
-    errorSignatures: ['ECONNREFUSED'],
+    errorSignatures: [READINESS_ECONNREFUSED],
   });
 
   const result = await writeTaskMemory(
@@ -504,11 +661,12 @@ test('writeTaskMemory merges root-cause-only fixes with matching existing memori
         project_key: 'git:repo',
       },
       memory: {
-        summary:
-          'Requests can race server startup and cause ECONNREFUSED during tests.',
+        title: READINESS_TITLE,
+        summary: READINESS_SUMMARY,
         outcome_type: 'fix',
-        root_cause: 'Requests raced server startup',
-        error_signatures: ['ECONNREFUSED'],
+        root_cause: READINESS_ROOT_CAUSE,
+        resolution: READINESS_RESOLUTION,
+        error_signatures: [READINESS_ECONNREFUSED],
       },
     },
     {
@@ -596,10 +754,11 @@ test('writeTaskMemory accepts concise fixes when structured fields carry the exp
         cwd: 'C:/repo',
       },
       memory: {
-        summary: 'Await readiness before requests.',
+        title: READINESS_TITLE,
+        summary: READINESS_SUMMARY,
         outcome_type: 'fix',
-        root_cause: 'Requests raced server startup.',
-        resolution: 'Wait for server readiness before issuing requests.',
+        root_cause: READINESS_ROOT_CAUSE,
+        resolution: READINESS_RESOLUTION,
       },
     },
     {
@@ -621,7 +780,7 @@ test('writeTaskMemory accepts valid pattern candidates and creates notes', async
       mode: 'auto',
       source_run_key: 'run-pattern',
       task: {
-        goal: 'Add experience quality gate',
+        goal: 'Normalize package metadata before dist comparison',
         task_kind: 'implement',
         source_agent: 'codex',
         project_key: 'git:repo',
@@ -629,11 +788,12 @@ test('writeTaskMemory accepts valid pattern candidates and creates notes', async
         cwd: 'C:/repo',
       },
       memory: {
+        title: 'Normalize package metadata before dist comparison',
         summary:
-          'Core quality gates should validate agent writeback payloads before semantic merge so weak candidates cannot enter the experience library.',
+          'Normalize package metadata before comparing generated dist output when version formats make dist comparisons unreliable.',
         outcome_type: 'pattern',
         reusable_patterns: [
-          'Put quality gates at trusted persistence boundaries before duplicate detection.',
+          'Normalize package metadata before comparing generated dist output because inconsistent version formats made dist comparisons unreliable.',
         ],
       },
     },

--- a/server/src/services/memory/writeback.test.ts
+++ b/server/src/services/memory/writeback.test.ts
@@ -525,7 +525,7 @@ test('writeTaskMemory merge preserves existing structured payload fields while a
   );
 
   const rows = db.exec(
-    'SELECT key_conclusions, code_snippets, error_signatures, files_touched, raw_llm_response FROM notes WHERE id = ?',
+    'SELECT key_conclusions, code_snippets, error_signatures, files_touched, raw_llm_response, source_type FROM notes WHERE id = ?',
     [existingId],
   );
   const mergedPayload = JSON.parse(String(rows[0].values[0][4])) as {
@@ -535,6 +535,7 @@ test('writeTaskMemory merge preserves existing structured payload fields while a
     decisions?: string[];
   };
 
+  assert.equal(rows[0].values[0][5], 'agent-writeback');
   assert.deepEqual(JSON.parse(String(rows[0].values[0][0])), [
     `Root cause: ${READINESS_ROOT_CAUSE}`,
     `Resolution: ${READINESS_RESOLUTION}`,

--- a/server/src/services/memory/writeback.test.ts
+++ b/server/src/services/memory/writeback.test.ts
@@ -537,6 +537,7 @@ test('writeTaskMemory merge preserves existing structured payload fields while a
 
   assert.equal(rows[0].values[0][5], 'agent-writeback');
   assert.deepEqual(JSON.parse(String(rows[0].values[0][0])), [
+    'Existing conclusion',
     `Root cause: ${READINESS_ROOT_CAUSE}`,
     `Resolution: ${READINESS_RESOLUTION}`,
     `Pitfall: ${READINESS_EXISTING_PITFALL}`,

--- a/server/src/services/memory/writeback.ts
+++ b/server/src/services/memory/writeback.ts
@@ -1,9 +1,14 @@
-import type { WriteTaskMemoryResponse } from '@chatcrystal/shared';
+import type {
+  WriteTaskMemoryPayload,
+  WriteTaskMemoryResponse,
+} from '@chatcrystal/shared';
 import { getDatabase, saveDatabase } from '../../db/index.js';
 import { withTransaction } from '../../db/transaction.js';
 import { generateEmbeddings, semanticSearch } from '../embedding.js';
 import { decideWritebackAction } from './decision.js';
+import { materializeTaskMemory } from './materialize.js';
 import { ensureSyntheticOriginConversation } from './origin.js';
+import { validateTaskMemory } from './preflight.js';
 import { deriveProjectKey, resolveCanonicalProjectKey, resolveProjectIdentity } from './projectKey.js';
 import { parseWriteTaskMemoryRequest } from './schemas.js';
 import { validateStructuredMemoryCandidate } from '../experience/gate.js';
@@ -244,19 +249,19 @@ export async function writeTaskMemory(
     }
   }
 
-  const validateMemory =
-    deps.validateStructuredMemoryCandidate ??
-    validateStructuredMemoryCandidate;
-  const qualityDecision = validateMemory(request.memory);
-  if (qualityDecision) {
-    const reason = qualityDecision.reasons[0] ?? 'low-signal';
+  const preflight = validateTaskMemory(request, {
+    validateStructuredMemoryCandidate:
+      deps.validateStructuredMemoryCandidate ?? validateStructuredMemoryCandidate,
+  });
+  const materialized = preflight.materialized_note;
+  if (!preflight.accepted) {
     if (request.mode === 'auto') {
       withTransaction(db, () => {
         db.run(
           `INSERT INTO writeback_receipts (
              source_agent, source_run_key, decision, note_id, merged_into_note_id, reason, index_status
            ) VALUES (?, ?, 'skipped', NULL, NULL, ?, 'completed')`,
-          [normalizedAgent, request.source_run_key ?? null, reason],
+          [normalizedAgent, request.source_run_key ?? null, preflight.reason],
         );
       });
       save();
@@ -267,8 +272,8 @@ export async function writeTaskMemory(
       decision: 'skipped',
       note_id: null,
       merged_into_note_id: null,
-      reason,
-      warnings: qualityDecision.missing_signals,
+      reason: preflight.reason,
+      warnings: preflight.warnings,
     };
   }
 
@@ -354,39 +359,35 @@ export async function writeTaskMemory(
 
     if (decision.decision === 'merged' && decision.target_note_id) {
       const existingPayloadRows = db.exec(
-        `SELECT key_conclusions, code_snippets, raw_llm_response, error_signatures, files_touched
+        `SELECT code_snippets, raw_llm_response, error_signatures, files_touched
            FROM notes
           WHERE id = ?`,
         [decision.target_note_id],
       );
-      const existingKeyConclusions = safeParseStringArray(
+      const existingCodeSnippets = safeParseArray<Record<string, unknown>>(
         existingPayloadRows[0]?.values[0]?.[0],
       );
-      const existingCodeSnippets = safeParseArray<Record<string, unknown>>(
-        existingPayloadRows[0]?.values[0]?.[1],
-      );
       const mergedPayload = mergeMemoryPayload(
-        safeParseObject(existingPayloadRows[0]?.values[0]?.[2]),
+        safeParseObject(existingPayloadRows[0]?.values[0]?.[1]),
         request.memory as Record<string, unknown>,
       );
-      const mergedKeyConclusions = [
-        ...new Set([
-          ...existingKeyConclusions,
-          ...(request.memory.key_conclusions ?? []),
-        ]),
-      ];
+      const mergedMaterialized = materializeTaskMemory(
+        request,
+        mergedPayload as unknown as WriteTaskMemoryPayload,
+      );
+      const mergedKeyConclusions = mergedMaterialized.key_conclusions;
       const mergedCodeSnippets =
         mergeCodeSnippets(existingCodeSnippets, request.memory.code_snippets) ??
         [];
       const mergedErrorSignatures = [
         ...new Set([
-          ...safeParseStringArray(existingPayloadRows[0]?.values[0]?.[3]),
+          ...safeParseStringArray(existingPayloadRows[0]?.values[0]?.[2]),
           ...(request.memory.error_signatures ?? []),
         ]),
       ];
       const mergedFilesTouched = [
         ...new Set([
-          ...safeParseStringArray(existingPayloadRows[0]?.values[0]?.[4]),
+          ...safeParseStringArray(existingPayloadRows[0]?.values[0]?.[3]),
           ...(request.memory.files_touched ?? []),
         ]),
       ];
@@ -431,7 +432,7 @@ export async function writeTaskMemory(
         note_id: null,
         merged_into_note_id: decision.target_note_id,
         related_note_ids: [] as number[],
-        tags: normalizeTags(mergedPayload.tags as string[] | undefined),
+        tags: mergedMaterialized.tags,
       };
     }
 
@@ -452,9 +453,9 @@ export async function writeTaskMemory(
       ) VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         originConversationId,
-        request.memory.title ?? request.task.goal,
-        request.memory.summary,
-        JSON.stringify(request.memory.key_conclusions ?? []),
+        materialized.title,
+        materialized.summary,
+        JSON.stringify(materialized.key_conclusions),
         JSON.stringify(request.memory.code_snippets ?? []),
         JSON.stringify(request.memory),
         resolvedProjectKey ?? null,
@@ -492,7 +493,7 @@ export async function writeTaskMemory(
       decision: 'created' as const,
       note_id: createdNoteId,
       merged_into_note_id: null,
-      tags: normalizeTags(request.memory.tags),
+      tags: materialized.tags,
       related_note_ids: candidates
         .filter((hit) => hit.score >= 0.75)
         .map((hit) => hit.noteId)

--- a/server/src/services/memory/writeback.ts
+++ b/server/src/services/memory/writeback.ts
@@ -400,6 +400,10 @@ export async function writeTaskMemory(
                 raw_llm_response = ?,
                 error_signatures = ?,
                 files_touched = ?,
+                source_type = CASE
+                  WHEN source_type = 'imported-conversation' THEN 'agent-writeback'
+                  ELSE source_type
+                END,
                 updated_at = datetime('now')
           WHERE id = ?`,
         [

--- a/server/src/services/memory/writeback.ts
+++ b/server/src/services/memory/writeback.ts
@@ -359,35 +359,41 @@ export async function writeTaskMemory(
 
     if (decision.decision === 'merged' && decision.target_note_id) {
       const existingPayloadRows = db.exec(
-        `SELECT code_snippets, raw_llm_response, error_signatures, files_touched
+        `SELECT key_conclusions, code_snippets, raw_llm_response, error_signatures, files_touched
            FROM notes
           WHERE id = ?`,
         [decision.target_note_id],
       );
-      const existingCodeSnippets = safeParseArray<Record<string, unknown>>(
+      const existingKeyConclusions = safeParseStringArray(
         existingPayloadRows[0]?.values[0]?.[0],
       );
+      const existingCodeSnippets = safeParseArray<Record<string, unknown>>(
+        existingPayloadRows[0]?.values[0]?.[1],
+      );
       const mergedPayload = mergeMemoryPayload(
-        safeParseObject(existingPayloadRows[0]?.values[0]?.[1]),
+        safeParseObject(existingPayloadRows[0]?.values[0]?.[2]),
         request.memory as Record<string, unknown>,
       );
       const mergedMaterialized = materializeTaskMemory(
         request,
         mergedPayload as unknown as WriteTaskMemoryPayload,
       );
-      const mergedKeyConclusions = mergedMaterialized.key_conclusions;
+      const mergedKeyConclusions = mergeStringArrays(
+        existingKeyConclusions,
+        mergedMaterialized.key_conclusions,
+      );
       const mergedCodeSnippets =
         mergeCodeSnippets(existingCodeSnippets, request.memory.code_snippets) ??
         [];
       const mergedErrorSignatures = [
         ...new Set([
-          ...safeParseStringArray(existingPayloadRows[0]?.values[0]?.[2]),
+          ...safeParseStringArray(existingPayloadRows[0]?.values[0]?.[3]),
           ...(request.memory.error_signatures ?? []),
         ]),
       ];
       const mergedFilesTouched = [
         ...new Set([
-          ...safeParseStringArray(existingPayloadRows[0]?.values[0]?.[3]),
+          ...safeParseStringArray(existingPayloadRows[0]?.values[0]?.[4]),
           ...(request.memory.files_touched ?? []),
         ]),
       ];

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -225,6 +225,26 @@ export interface WriteTaskMemoryResponse {
   warnings: string[];
 }
 
+export interface MaterializedTaskMemoryNote {
+  title: string;
+  summary: string;
+  key_conclusions: string[];
+  embedding_text: string;
+  tags: string[];
+  raw_payload: WriteTaskMemoryPayload;
+}
+
+export type ValidateTaskMemoryRequest = WriteTaskMemoryRequest;
+
+export interface ValidateTaskMemoryResponse {
+  mode: 'auto' | 'manual';
+  accepted: boolean;
+  decision: 'accepted' | 'skipped';
+  reason: string;
+  warnings: string[];
+  materialized_note: MaterializedTaskMemoryNote;
+}
+
 // --- Tags ---
 
 export interface Tag {


### PR DESCRIPTION
## Summary

- Adds a structured task-memory validation contract and REST/MCP preflight so AI writebacks are checked before persistence.
- Enforces a unified note quality gate for auto writebacks, rejecting one-off status/worklog records while accepting durable, reusable memories.
- Materializes accepted structured payloads into visible note fields, persists raw memory payloads, embeds structured/code/file/error signals, and keeps writeback receipts idempotent.
- Hardens merge behavior so imported targets are promoted before re-embedding and existing visible conclusions are preserved.

## Validation

- `npm exec -w server -- tsx --test src/services/memory/*.test.ts src/services/embedding.test.ts`: 264 pass
- `npm run test -w server`: 350 pass
- `npm run build -w server`: pass
- `npm run lint`: pass
- Real E2E on isolated `DATA_DIR` covered weak auto skip, strong memory creation/search, replay idempotency, merge preservation, SQLite `foreign_key_check`, and Vectra item consistency.

## Reviewer Status

- Task-level spec/code-quality reviews passed.
- Final whole-branch reviewer approved with no merge-blocking findings.
